### PR TITLE
bug in _DoesProfileFitToCurrentProfile and superfluous assignment in …

### DIFF
--- a/intf.ZUGFeRDProfileAwareXmlTextWriter.pas
+++ b/intf.ZUGFeRDProfileAwareXmlTextWriter.pas
@@ -285,9 +285,9 @@ var
   maskedProfile: Integer;
   i : TZUGFeRDProfile;
 begin
-  Result := false;
+  if profile = TZUGFERDPROFILES_DEFAULT then
+    Exit(true);
 
-  if profile <> TZUGFERDPROFILES_DEFAULT then
   for i := Low(TZUGFeRDProfile) to High(TZUGFeRDProfile) do
   begin
     if i = TZUGFeRDProfile.Unknown then

--- a/intf.ZUGFeRDProfileAwareXmlTextWriter.pas
+++ b/intf.ZUGFeRDProfileAwareXmlTextWriter.pas
@@ -302,7 +302,7 @@ begin
     end;
   end;
 
-  Result := true;
+  Result := false; // profile does not fit
 end;
 
 function TZUGFeRDProfileAwareXmlTextWriter._IsNodeVisible: Boolean;

--- a/intf.ZUGFeRDTradeLineItem.pas
+++ b/intf.ZUGFeRDTradeLineItem.pas
@@ -265,7 +265,7 @@ constructor TZUGFeRDTradeLineItem.Create;
 begin
   inherited;
   FGlobalID := TZUGFeRDGlobalID.Create;
-  UnitQuantity := TZUGFeRDNullable<Double>.Create;
+  // UnitQuantity := TZUGFeRDNullable<Double>.Create; // should be unneccesary
   FUnitQuantity:= TZUGFeRDNullable<Double>.Create;
   FLineTotalAmount:= TZUGFeRDNullable<Double>.Create;
   FBillingPeriodStart:= TZUGFeRDNullable<TDateTime>.Create;


### PR DESCRIPTION
…TZUGFeRDTradeLineItem.Create

_DoesProfileFitToCurrentProfile hat bei XREchnung Profilen dazu geführt, dass Zeilen doppelt generiert werden. Die Funktion _DoesProfileFitToCurrentProfile liefert niemals false zurück.