### PR TITLE
Nullable feature

### DIFF
--- a/intf.ZUGFeRDHelper.pas
+++ b/intf.ZUGFeRDHelper.pas
@@ -24,6 +24,7 @@ uses
   ,System.SysUtils,System.Classes,System.Types,System.DateUtils,System.Rtti
   ,System.Variants,System.IOUtils,System.Win.COMObj
   ,System.NetEncoding
+  ,Generics.Defaults
   ;
 
 type
@@ -83,6 +84,28 @@ type
   end;
 
   function GetZUGFeRDPdfHelper : IZUGFeRDPdfHelper;
+
+type
+  Nullable<T> = record
+  private
+    FValue: T;
+    FHasValue: IInterface;
+    function GetValue: T;
+    function GetHasValue: Boolean;
+  public
+    constructor Create(AValue: T);
+    function GetValueOrDefault: T; overload;
+    function GetValueOrDefault(Default: T): T; overload;
+    property HasValue: Boolean read GetHasValue;
+    property Value: T read GetValue;
+
+    class operator NotEqual(ALeft, ARight: Nullable<T>): Boolean;
+    class operator Equal(ALeft, ARight: Nullable<T>): Boolean;
+
+    class operator Implicit(Value: Nullable<T>): T;
+    class operator Implicit(Value: T): Nullable<T>;
+    class operator Explicit(Value: Nullable<T>): T;
+  end;
 
 implementation
 
@@ -551,6 +574,114 @@ begin
     str.Free;
   end;
 end;
+
+
+function NopAddref(inst: Pointer): Integer; stdcall;
+begin
+  Result := -1;
+end;
+
+function NopRelease(inst: Pointer): Integer; stdcall;
+begin
+  Result := -1;
+end;
+
+function NopQueryInterface(inst: Pointer; const IID: TGUID; out Obj): HResult; stdcall;
+begin
+  Result := E_NOINTERFACE;
+end;
+
+const
+  FlagInterfaceVTable: array[0..2] of Pointer =
+  (
+    @NopQueryInterface,
+    @NopAddref,
+    @NopRelease
+  );
+
+  FlagInterfaceInstance: Pointer = @FlagInterfaceVTable;
+
+procedure SetFlatInterface(var Intf: IInterface);
+begin
+  Intf := IInterface(@FlagInterfaceInstance);
+end;
+
+{ Nullable<T> }
+
+constructor Nullable<T>.Create(AValue: T);
+begin
+  FValue := AValue;
+  FHasValue:= TInterfacedObject.Create; // IInterface(@FlagInterfaceInstance);
+  // SetFlagInterface(FHasValue);
+end;
+
+class operator Nullable<T>.Equal(ALeft, ARight: Nullable<T>): Boolean;
+var
+  Comparer: IEqualityComparer<T>;
+begin
+  if ALeft.HasValue and ARight.HasValue then
+  begin
+    Comparer := TEqualityComparer<T>.Default;
+    Result := Comparer.Equals(ALeft.Value, ARight.Value);
+  end else
+    Result := ALeft.HasValue = ARight.HasValue;
+end;
+
+class operator Nullable<T>.Explicit(Value: Nullable<T>): T;
+begin
+  Result := Value.Value;
+end;
+
+function Nullable<T>.GetHasValue: Boolean;
+begin
+  Result := FHasValue <> nil;
+end;
+
+function Nullable<T>.GetValue: T;
+begin
+  if not HasValue then
+    raise Exception.Create('Invalid operation, Nullable type has no value');
+  Result := FValue;
+end;
+
+function Nullable<T>.GetValueOrDefault: T;
+begin
+  if HasValue then
+    Result := FValue
+  else
+    Result := Default(T);
+end;
+
+function Nullable<T>.GetValueOrDefault(Default: T): T;
+begin
+  if not HasValue then
+    Result := Default
+  else
+    Result := FValue;
+end;
+
+class operator Nullable<T>.Implicit(Value: Nullable<T>): T;
+begin
+  Result := Value.Value;
+end;
+
+class operator Nullable<T>.Implicit(Value: T): Nullable<T>;
+begin
+  Result := Nullable<T>.Create(Value);
+end;
+
+class operator Nullable<T>.NotEqual(ALeft, ARight: Nullable<T>): Boolean;
+var
+  Comparer: IEqualityComparer<T>;
+begin
+  if ALeft.HasValue and ARight.HasValue then
+  begin
+    Comparer := TEqualityComparer<T>.Default;
+    Result := not Comparer.Equals(ALeft.Value, ARight.Value);
+  end else
+    Result := ALeft.HasValue <> ARight.HasValue;
+end;
+
 
 end.
 

--- a/intf.ZUGFeRDInvoiceDescriptor.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor.pas
@@ -1467,7 +1467,8 @@ begin
   newItem.NetUnitPrice := netUnitPrice;
   newItem.BilledQuantity := billedQuantity;
   if lineTotalAmount <> 0.0 then
-    newItem.LineTotalAmount.SetValue(LineTotalAmount);
+//    newItem.LineTotalAmount.SetValue(LineTotalAmount);
+    newItem.LineTotalAmount:= LineTotalAmount;
   newItem.TaxType := taxType;
   newItem.TaxCategoryCode := categoryCode;
   newItem.TaxPercent := taxPercent;

--- a/intf.ZUGFeRDInvoiceDescriptor1Reader.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor1Reader.pas
@@ -358,7 +358,8 @@ begin
   Result.Description := _nodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:Description');
   Result.UnitQuantity.SetValue(_nodeAsDecimal(tradeLineItem, './/ram:BasisQuantity', 1));
   Result.BilledQuantity := _nodeAsDecimal(tradeLineItem, './/ram:BilledQuantity', 0);
-  Result.LineTotalAmount.SetValue(_nodeAsDecimal(tradeLineItem, './/ram:LineTotalAmount', 0));
+//  Result.LineTotalAmount.SetValue(_nodeAsDecimal(tradeLineItem, './/ram:LineTotalAmount', 0));
+  Result.LineTotalAmount:= _nodeAsDecimal(tradeLineItem, './/ram:LineTotalAmount', 0);
   Result.TaxCategoryCode := TZUGFeRDTaxCategoryCodesExtensions.FromString(_nodeAsString(tradeLineItem, './/ram:ApplicableTradeTax/ram:CategoryCode'));
   Result.TaxType := TZUGFeRDTaxTypesExtensions.FromString(_nodeAsString(tradeLineItem, './/ram:ApplicableTradeTax/ram:TypeCode'));
   Result.TaxPercent := _nodeAsDecimal(tradeLineItem, './/ram:ApplicableTradeTax/ram:ApplicablePercent', 0);

--- a/intf.ZUGFeRDInvoiceDescriptor20Reader.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor20Reader.pas
@@ -439,7 +439,8 @@ begin
   Result.Description := _nodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:Description');
   Result.UnitQuantity.SetValue(_nodeAsDecimal(tradeLineItem, './/ram:BasisQuantity', 1));
   Result.BilledQuantity := _nodeAsDecimal(tradeLineItem, './/ram:BilledQuantity', 0);
-  Result.LineTotalAmount.SetValue(_nodeAsDecimal(tradeLineItem, './/ram:LineTotalAmount', 0));
+//  Result.LineTotalAmount.SetValue(_nodeAsDecimal(tradeLineItem, './/ram:LineTotalAmount', 0));
+  Result.LineTotalAmount:= _nodeAsDecimal(tradeLineItem, './/ram:LineTotalAmount', 0);
   Result.TaxCategoryCode := TZUGFeRDTaxCategoryCodesExtensions.FromString(_nodeAsString(tradeLineItem, './/ram:ApplicableTradeTax/ram:CategoryCode'));
   Result.TaxType := TZUGFeRDTaxTypesExtensions.FromString(_nodeAsString(tradeLineItem, './/ram:ApplicableTradeTax/ram:TypeCode'));
   Result.TaxPercent := _nodeAsDecimal(tradeLineItem, './/ram:ApplicableTradeTax/ram:RateApplicablePercent', 0);

--- a/intf.ZUGFeRDInvoiceDescriptor22Reader.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor22Reader.pas
@@ -558,7 +558,8 @@ begin
   Result.Description := _nodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:Description');
   Result.UnitQuantity.SetValue(_nodeAsDecimal(tradeLineItem, './/ram:BasisQuantity', 1));
   Result.BilledQuantity := _nodeAsDecimal(tradeLineItem, './/ram:BilledQuantity', 0);
-  Result.LineTotalAmount.SetValue(_nodeAsDecimal(tradeLineItem, './/ram:LineTotalAmount', 0));
+//  Result.LineTotalAmount.SetValue(_nodeAsDecimal(tradeLineItem, './/ram:LineTotalAmount', 0));
+  Result.LineTotalAmount:= _nodeAsDecimal(tradeLineItem, './/ram:LineTotalAmount', 0);
   Result.TaxCategoryCode := TZUGFeRDTaxCategoryCodesExtensions.FromString(_nodeAsString(tradeLineItem, './/ram:ApplicableTradeTax/ram:CategoryCode'));
   Result.TaxType := TZUGFeRDTaxTypesExtensions.FromString(_nodeAsString(tradeLineItem, './/ram:ApplicableTradeTax/ram:TypeCode'));
   Result.TaxPercent := _nodeAsDecimal(tradeLineItem, './/ram:ApplicableTradeTax/ram:RateApplicablePercent', 0);

--- a/intf.ZUGFeRDProfileAwareXmlTextWriter.pas
+++ b/intf.ZUGFeRDProfileAwareXmlTextWriter.pas
@@ -285,9 +285,9 @@ var
   maskedProfile: Integer;
   i : TZUGFeRDProfile;
 begin
-  Result := false;
+  if profile = TZUGFERDPROFILES_DEFAULT then
+    Exit(true);
 
-  if profile <> TZUGFERDPROFILES_DEFAULT then
   for i := Low(TZUGFeRDProfile) to High(TZUGFeRDProfile) do
   begin
     if i = TZUGFeRDProfile.Unknown then

--- a/intf.ZUGFeRDProfileAwareXmlTextWriter.pas
+++ b/intf.ZUGFeRDProfileAwareXmlTextWriter.pas
@@ -302,7 +302,7 @@ begin
     end;
   end;
 
-  Result := true;
+  Result := false; // profile does not fit
 end;
 
 function TZUGFeRDProfileAwareXmlTextWriter._IsNodeVisible: Boolean;

--- a/intf.ZUGFeRDTradeLineItem.pas
+++ b/intf.ZUGFeRDTradeLineItem.pas
@@ -65,7 +65,7 @@ type
     FAssociatedDocument: TZUGFeRDAssociatedDocument;
     FTaxCategoryCode: TZUGFeRDTaxCategoryCodes;
     FNetUnitPrice: TZUGFeRDNullableCurrency;
-    FLineTotalAmount: TZUGFeRDNullable<Double>;
+    FLineTotalAmount: Nullable<Double>; // TZUGFeRDNullable<Double>;
     FDeliveryNoteReferencedDocument: TZUGFeRDDeliveryNoteReferencedDocument;
     FGlobalID: TZUGFeRDGlobalID;
     FBuyerOrderReferencedDocument: TZUGFeRDBuyerOrderReferencedDocument;
@@ -165,7 +165,7 @@ type
     /// Invoice line net amount including (!) trade allowance charges for the line item
     /// BT-131
     /// </summary>
-    property LineTotalAmount: TZUGFeRDNullable<Double> read FLineTotalAmount write FLineTotalAmount;
+    property LineTotalAmount: Nullable<Double> {TZUGFeRDNullable<Double>} read FLineTotalAmount write FLineTotalAmount;
 
     /// <summary>
     /// Detailed information about the invoicing period
@@ -267,7 +267,7 @@ begin
   FGlobalID := TZUGFeRDGlobalID.Create;
   // UnitQuantity := TZUGFeRDNullable<Double>.Create; // should be unneccesary
   FUnitQuantity:= TZUGFeRDNullable<Double>.Create;
-  FLineTotalAmount:= TZUGFeRDNullable<Double>.Create;
+//  FLineTotalAmount:= NTZUGFeRDNullable<Double>.Create;
   FBillingPeriodStart:= TZUGFeRDNullable<TDateTime>.Create;
   FBillingPeriodEnd:= TZUGFeRDNullable<TDateTime>.Create;
   FNetUnitPrice := TZUGFeRDNullableCurrency.CreateWithValue(0.0);
@@ -287,7 +287,7 @@ destructor TZUGFeRDTradeLineItem.Destroy;
 begin
   if Assigned(FGlobalID) then begin FGlobalID.Free; FGlobalID := nil; end;
   if Assigned(FUnitQuantity) then begin FUnitQuantity.Free; FUnitQuantity := nil; end;
-  if Assigned(FLineTotalAmount) then begin FLineTotalAmount.Free; FLineTotalAmount := nil; end;
+//  if Assigned(FLineTotalAmount) then begin FLineTotalAmount.Free; FLineTotalAmount := nil; end;
   if Assigned(FBillingPeriodStart) then begin FBillingPeriodStart.Free; FBillingPeriodStart := nil; end;
   if Assigned(FBillingPeriodEnd) then begin FBillingPeriodEnd.Free; FBillingPeriodEnd := nil; end;
   if Assigned(FNetUnitPrice) then begin FNetUnitPrice.Free; FNetUnitPrice := nil; end;

--- a/intf.ZUGFeRDTradeLineItem.pas
+++ b/intf.ZUGFeRDTradeLineItem.pas
@@ -265,7 +265,7 @@ constructor TZUGFeRDTradeLineItem.Create;
 begin
   inherited;
   FGlobalID := TZUGFeRDGlobalID.Create;
-  UnitQuantity := TZUGFeRDNullable<Double>.Create;
+  // UnitQuantity := TZUGFeRDNullable<Double>.Create; // should be unneccesary
   FUnitQuantity:= TZUGFeRDNullable<Double>.Create;
   FLineTotalAmount:= TZUGFeRDNullable<Double>.Create;
   FBillingPeriodStart:= TZUGFeRDNullable<TDateTime>.Create;


### PR DESCRIPTION
Ich habe von https://blog.therealoracleatdelphi.com/2008/09/a-post_18.html inspiriert mit einer kleinen Modifikation eine Nullable<T> Record Version in ZUGFeRDHelper.pas gepackt und am Beispiel von LineTotalAmount getestet. Durch die Verwendung als Record Version entfällt das Erstellen einer Instanz mit .Create, das Freigeben und man kann sorglos einfahc Werte zuweisen und übergeben. Wäre es nicht gut so die von C# übernommenen Nullable Typen abzuhandeln ?