### PR TITLE
SpecifiedTradeAllowanceCharge wird auf Docebene nicht korrekt ausgelesen

### DIFF
--- a/intf.ZUGFeRDInvoiceDescriptor20Reader.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor20Reader.pas
@@ -325,7 +325,7 @@ begin
                                  _nodeAsString(nodes[i], './/ram:ExemptionReason'));
   end;
 
-  nodes := doc.SelectNodes('//ram:SpecifiedTradeAllowanceCharge');
+  nodes := doc.SelectNodes('//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeAllowanceCharge');
   for i := 0 to nodes.length-1 do
   begin
     Result.AddTradeAllowanceCharge(not _nodeAsBool(nodes[i], './/ram:ChargeIndicator'), // wichtig: das not (!) beachten

--- a/intf.ZUGFeRDInvoiceDescriptor22Reader.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor22Reader.pas
@@ -400,7 +400,7 @@ begin
                                  _nodeAsString(nodes[i], './/ram:ExemptionReason'));
   end;
 
-  nodes := doc.SelectNodes('//ram:SpecifiedTradeAllowanceCharge');
+  nodes := doc.SelectNodes('//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeAllowanceCharge');
   for i := 0 to nodes.length-1 do
   begin
     Result.AddTradeAllowanceCharge(not _nodeAsBool(nodes[i], './/ram:ChargeIndicator'), // wichtig: das not (!) beachten


### PR DESCRIPTION
SpecifiedTradeAllowanceCharge wird auf Docebene nicht korrekt ausgelesen wenn Einträge auf Positionsebene vorhanden sind