### PR TITLE
Update C# synchronization point to bbac287

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Subject to the Apache license https://www.apache.org/licenses/LICENSE-2.0.html
 
 ## Synchronization point to the C# library
 
-https://github.com/stephanstapel/ZUGFeRD-csharp/commit/a6d5e244283d5d24fe1dd8e6fecd267deb07142c
+https://github.com/stephanstapel/ZUGFeRD-csharp/commit/bbac287f2d91bda9ad1ab12a57042eb6aba3b1ce
 
 ## TODO
 Tests and writing support for ZUGFeRD invoices are still missing.


### PR DESCRIPTION
Updates the C# sync point in README.md to the latest upstream commit [bbac287](https://github.com/stephanstapel/ZUGFeRD-csharp/commit/bbac287f2d91bda9ad1ab12a57042eb6aba3b1ce), which includes two recently merged PRs from MGGM:

- [#894](https://github.com/stephanstapel/ZUGFeRD-csharp/pull/894) Allow FC TaxRegistration for SellerTradeParty in XRechnung profile
- [#895](https://github.com/stephanstapel/ZUGFeRD-csharp/pull/895) Parse #SKONTO#/#VERZUG# format from Description in CII reader