### PR TITLE
Validate and complete advance payment handling

### DIFF
--- a/Unittest/intf.ZUGFeRD22Tests.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRD22Tests.UnitTests.pas
@@ -38,6 +38,10 @@ type
     [Test]
     procedure TestAdvancePayment;
     [Test]
+    procedure TestAdvancePaymentMandatoryDataValidation;
+    [Test]
+    procedure TestAdvancePaymentReaderRejectsMissingMandatoryData;
+    [Test]
     procedure TestReferenceAdvancePaymentFromDocumentation;
     [Test]
     procedure TestExtendedInvoiceWithIncludedItems;
@@ -256,6 +260,7 @@ implementation
 
 uses
   System.SysUtils, System.Classes, System.Generics.Collections, System.IOUtils,
+  System.RegularExpressions,
   intf.ZUGFeRDInvoiceDescriptor,
   intf.ZUGFeRDInvoiceProvider,
   intf.ZUGFeRDProfile,
@@ -309,7 +314,8 @@ uses
   intf.ZUGFeRDIncludedReferencedProduct,
   intf.ZUGFeRDDeliveryNoteReferencedDocument,
   intf.ZUGFeRDBuyerOrderReferencedDocument,
-  intf.ZUGFeRDFormats;
+  intf.ZUGFeRDFormats,
+  intf.ZUGFeRDExceptions;
 
 { TZUGFeRD22Tests }
 
@@ -559,7 +565,7 @@ begin
 end;
 
 /// <summary>
-/// Vorauszahlungen / Anzahlungen, BG-X-45. Nur EXTENDED fuehrt das Element.
+/// Vorauszahlungen / Anzahlungen, BG-X-45. Nur EXTENDED führt das Element.
 /// </summary>
 procedure TZUGFeRD22Tests.TestAdvancePayment;
 var
@@ -584,7 +590,8 @@ begin
     advancePayment.IncludedTradeTaxes.Add(includedTax);
 
     advancePayment.SetInvoiceReferencedDocument('R202506-01',
-      TZUGFeRDNullableParam<TDateTime>.Create(EncodeDate(2025, 6, 1)));
+      TZUGFeRDNullableParam<TDateTime>.Create(EncodeDate(2025, 6, 1)),
+      TZUGFeRDNullableParam<TZUGFeRDInvoiceType>.Create(TZUGFeRDInvoiceType.PartialInvoice));
     desc.AdvancePayments.Add(advancePayment);
 
     ms := TMemoryStream.Create;
@@ -606,6 +613,9 @@ begin
 
         Assert.IsNotNull(loadedInvoice.AdvancePayments[0].InvoiceSpecifiedReferencedDocument);
         Assert.AreEqual('R202506-01', loadedInvoice.AdvancePayments[0].InvoiceSpecifiedReferencedDocument.ID);
+        Assert.IsTrue(loadedInvoice.AdvancePayments[0].InvoiceSpecifiedReferencedDocument.TypeCode.HasValue);
+        Assert.AreEqual<TZUGFeRDInvoiceType>(TZUGFeRDInvoiceType.PartialInvoice,
+          loadedInvoice.AdvancePayments[0].InvoiceSpecifiedReferencedDocument.TypeCode.Value);
         Assert.AreEqual(EncodeDate(2025, 6, 1), loadedInvoice.AdvancePayments[0].InvoiceSpecifiedReferencedDocument.IssueDateTime.Value);
       finally
         loadedInvoice.Free;
@@ -614,7 +624,7 @@ begin
       ms.Free;
     end;
 
-    // Ausserhalb von EXTENDED darf das Element nicht geschrieben werden
+    // Außerhalb von EXTENDED darf das Element nicht geschrieben werden
     ms := TMemoryStream.Create;
     try
       desc.Save(ms, TZUGFeRDVersion.Version23, TZUGFeRDProfile.Comfort);
@@ -635,8 +645,138 @@ begin
 end;
 
 /// <summary>
+/// Prüft die Pflichtangaben von Vorauszahlungen vor dem Schreiben.
+/// </summary>
+procedure TZUGFeRD22Tests.TestAdvancePaymentMandatoryDataValidation;
+var
+  desc: TZUGFeRDInvoiceDescriptor;
+  advancePayment: TZUGFeRDAdvancePayment;
+  includedTax: TZUGFeRDTax;
+
+  procedure AssertSaveRaisesMissingData;
+  var
+    stream: TMemoryStream;
+  begin
+    stream := TMemoryStream.Create;
+    try
+      Assert.WillRaise(
+        procedure
+        begin
+          desc.Save(stream, TZUGFeRDVersion.Version23, TZUGFeRDProfile.Extended);
+        end,
+        TZUGFeRDMissingDataException);
+    finally
+      stream.Free;
+    end;
+  end;
+
+begin
+  desc := TZUGFeRDInvoiceDescriptor.Load(DemodataPath('zugferd21\zugferd_2p1_EXTENDED_Warenrechnung-factur-x.xml'));
+  try
+    desc.AdvancePayments.Clear;
+    advancePayment := TZUGFeRDAdvancePayment.Create;
+    desc.AdvancePayments.Add(advancePayment);
+
+    AssertSaveRaisesMissingData;
+
+    advancePayment.PaidAmount := 2975.0;
+    AssertSaveRaisesMissingData;
+
+    includedTax := TZUGFeRDTax.Create;
+    includedTax.TypeCode := nil;
+    advancePayment.IncludedTradeTaxes.Add(includedTax);
+    AssertSaveRaisesMissingData;
+
+    includedTax.TypeCode := TZUGFeRDTaxTypes.VAT;
+    includedTax.CategoryCode := nil;
+    AssertSaveRaisesMissingData;
+
+    includedTax.CategoryCode := TZUGFeRDTaxCategoryCodes.S;
+    advancePayment.SetInvoiceReferencedDocument('');
+    AssertSaveRaisesMissingData;
+  finally
+    desc.Free;
+  end;
+end;
+
+/// <summary>
+/// Prüft, dass fehlende XML-Pflichtwerte nicht als Nullwerte übernommen werden.
+/// </summary>
+procedure TZUGFeRD22Tests.TestAdvancePaymentReaderRejectsMissingMandatoryData;
+var
+  desc: TZUGFeRDInvoiceDescriptor;
+  advancePayment: TZUGFeRDAdvancePayment;
+  includedTax: TZUGFeRDTax;
+  stream: TMemoryStream;
+  bytes: TBytes;
+  xmlContent: string;
+
+  procedure AssertRemovalRaisesMissingData(const pattern: string);
+  var
+    invalidXml: string;
+    invalidStream: TStringStream;
+    loadedInvoice: TZUGFeRDInvoiceDescriptor;
+  begin
+    invalidXml := TRegEx.Replace(xmlContent, pattern, '', [roSingleLine]);
+    Assert.IsTrue(invalidXml <> xmlContent, 'Das zu entfernende XML-Pflichtfeld wurde nicht gefunden.');
+
+    invalidStream := TStringStream.Create(invalidXml, TEncoding.UTF8);
+    loadedInvoice := nil;
+    try
+      Assert.WillRaise(
+        procedure
+        begin
+          invalidStream.Position := 0;
+          loadedInvoice := TZUGFeRDInvoiceDescriptor.Load(invalidStream);
+        end,
+        TZUGFeRDMissingDataException);
+    finally
+      loadedInvoice.Free;
+      invalidStream.Free;
+    end;
+  end;
+
+begin
+  desc := TZUGFeRDInvoiceDescriptor.Load(DemodataPath('zugferd21\zugferd_2p1_EXTENDED_Warenrechnung-factur-x.xml'));
+  try
+    desc.AdvancePayments.Clear;
+    advancePayment := TZUGFeRDAdvancePayment.Create;
+    advancePayment.PaidAmount := 2975.0;
+
+    includedTax := TZUGFeRDTax.Create;
+    includedTax.TaxAmount := 1900;
+    includedTax.TypeCode := TZUGFeRDTaxTypes.VAT;
+    includedTax.CategoryCode := TZUGFeRDTaxCategoryCodes.S;
+    advancePayment.IncludedTradeTaxes.Add(includedTax);
+
+    advancePayment.SetInvoiceReferencedDocument('R202506-01');
+    desc.AdvancePayments.Add(advancePayment);
+
+    stream := TMemoryStream.Create;
+    try
+      desc.Save(stream, TZUGFeRDVersion.Version23, TZUGFeRDProfile.Extended);
+      SetLength(bytes, stream.Size);
+      stream.Position := 0;
+      stream.ReadBuffer(bytes, stream.Size);
+      xmlContent := TEncoding.UTF8.GetString(bytes);
+    finally
+      stream.Free;
+    end;
+
+    AssertRemovalRaisesMissingData('<ram:PaidAmount(?:\s[^>]*)?>.*?</ram:PaidAmount>');
+    AssertRemovalRaisesMissingData('<ram:IncludedTradeTax>.*?</ram:IncludedTradeTax>');
+    AssertRemovalRaisesMissingData('<ram:CalculatedAmount(?:\s[^>]*)?>.*?</ram:CalculatedAmount>');
+    AssertRemovalRaisesMissingData('<ram:TypeCode>VAT</ram:TypeCode>');
+    AssertRemovalRaisesMissingData('<ram:CategoryCode>S</ram:CategoryCode>');
+    AssertRemovalRaisesMissingData('<ram:IssuerAssignedID>R202506-01</ram:IssuerAssignedID>');
+  finally
+    desc.Free;
+  end;
+end;
+
+/// <summary>
 /// Liest die Anzahlungen aus dem offiziellen Beispiel der Projektabschlussrechnung.
-/// Wird uebersprungen, wenn die Dokumentation lokal nicht ausgepackt ist.
+/// Wird übersprungen, wenn die Dokumentation lokal nicht ausgepackt ist.
 /// </summary>
 procedure TZUGFeRD22Tests.TestReferenceAdvancePaymentFromDocumentation;
 var

--- a/intf.ZUGFeRDAdvancePayment.pas
+++ b/intf.ZUGFeRDAdvancePayment.pas
@@ -23,15 +23,14 @@ uses
   System.SysUtils, System.Generics.Collections,
   intf.ZUGFeRDTax,
   intf.ZUGFeRDInvoiceReferencedDocument,
+  intf.ZUGFeRDInvoiceTypes,
   intf.ZUGFeRDHelper;
 
 type
   /// <summary>
   /// Detailangaben zu einer Vorauszahlung / Anzahlung, BG-X-45.
   ///
-  /// Nur im EXTENDED-Profil zulaessig (ram:SpecifiedAdvancePayment, 0..n).
-  /// Das Element InvoiceSpecifiedReferencedDocument gibt es erst ab
-  /// Factur-X 1.08 / ZUGFeRD 2.4.
+  /// Nur im EXTENDED-Profil zulässig (ram:SpecifiedAdvancePayment, 0..n).
   /// </summary>
   TZUGFeRDAdvancePayment = class
   private
@@ -59,7 +58,7 @@ type
     property IncludedTradeTaxes: TObjectList<TZUGFeRDTax> read FIncludedTradeTaxes;
 
     /// <summary>
-    /// Referenz auf die zugehoerige Vorauszahlungsrechnung, BT-X-47.
+    /// Referenz auf die zugehörige Vorauszahlungsrechnung, BT-X-47.
     /// nil, solange keine Referenz gesetzt wurde.
     /// </summary>
     property InvoiceSpecifiedReferencedDocument: TZUGFeRDInvoiceReferencedDocument read FInvoiceSpecifiedReferencedDocument write FInvoiceSpecifiedReferencedDocument;
@@ -67,10 +66,12 @@ type
     /// <summary>
     /// Legt die Referenz auf die Vorauszahlungsrechnung an bzw. aktualisiert sie.
     /// </summary>
-    procedure SetInvoiceReferencedDocument(const id: string; const issueDateTime: IZUGFeRDNullableParam<TDateTime> = nil);
+    procedure SetInvoiceReferencedDocument(const id: string;
+      const issueDateTime: IZUGFeRDNullableParam<TDateTime> = nil;
+      const typeCode: IZUGFeRDNullableParam<TZUGFeRDInvoiceType> = nil);
 
     /// <summary>
-    /// Fuegt eine enthaltene Steuer hinzu und liefert sie zurueck.
+    /// Fügt eine enthaltene Steuer hinzu und liefert sie zurück.
     /// </summary>
     function AddIncludedTradeTax(const tax: TZUGFeRDTax): TZUGFeRDTax;
   end;
@@ -102,12 +103,14 @@ begin
 end;
 
 procedure TZUGFeRDAdvancePayment.SetInvoiceReferencedDocument(const id: string;
-  const issueDateTime: IZUGFeRDNullableParam<TDateTime>);
+  const issueDateTime: IZUGFeRDNullableParam<TDateTime>;
+  const typeCode: IZUGFeRDNullableParam<TZUGFeRDInvoiceType>);
 begin
   if not Assigned(FInvoiceSpecifiedReferencedDocument) then
     FInvoiceSpecifiedReferencedDocument := TZUGFeRDInvoiceReferencedDocument.Create;
   FInvoiceSpecifiedReferencedDocument.ID := id;
   FInvoiceSpecifiedReferencedDocument.IssueDateTime := issueDateTime;
+  FInvoiceSpecifiedReferencedDocument.TypeCode := typeCode;
 end;
 
 function TZUGFeRDAdvancePayment.AddIncludedTradeTax(const tax: TZUGFeRDTax): TZUGFeRDTax;

--- a/intf.ZUGFeRDInvoiceDescriptor23CIIReader.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor23CIIReader.pas
@@ -612,33 +612,76 @@ begin
       TEnumExtensions<TZUGFeRDAccountingAccountTypeCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:TypeCode')));
 
   // Vorauszahlungen / Anzahlungen, BG-X-45 (nur EXTENDED)
-  nodes := doc.SelectNodes('//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedAdvancePayment');
-  for i := 0 to nodes.length-1 do
-  begin
-    var advancePayment: TZUGFeRDAdvancePayment := TZUGFeRDAdvancePayment.Create;
-    advancePayment.PaidAmount := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './ram:PaidAmount');
-    advancePayment.FormattedReceivedDateTime := TZUGFeRDXmlUtils.NodeAsDateTime(nodes[i],
-      './ram:FormattedReceivedDateTime/qdt:DateTimeString');
-
-    var taxNodes: IXMLDOMNodeList := nodes[i].selectNodes('./ram:IncludedTradeTax');
-    for var taxIndex: Integer := 0 to taxNodes.length-1 do
+  try
+    nodes := doc.SelectNodes('//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedAdvancePayment');
+    for i := 0 to nodes.length-1 do
     begin
-      var includedTax: TZUGFeRDTax := TZUGFeRDTax.Create;
-      includedTax.TaxAmount := TZUGFeRDXmlUtils.NodeAsDecimal(taxNodes[taxIndex], './ram:CalculatedAmount', 0).Value;
-      includedTax.TypeCode := TEnumExtensions<TZUGFeRDTaxTypes>.StringToNullableEnum(
-        TZUGFeRDXmlUtils.NodeAsString(taxNodes[taxIndex], './ram:TypeCode'));
-      includedTax.CategoryCode := TEnumExtensions<TZUGFeRDTaxCategoryCodes>.StringToNullableEnum(
-        TZUGFeRDXmlUtils.NodeAsString(taxNodes[taxIndex], './ram:CategoryCode'));
-      includedTax.Percent := TZUGFeRDXmlUtils.NodeAsDecimal(taxNodes[taxIndex], './ram:RateApplicablePercent', 0).Value;
-      advancePayment.IncludedTradeTaxes.Add(includedTax);
+      var advancePayment: TZUGFeRDAdvancePayment := TZUGFeRDAdvancePayment.Create;
+      try
+        advancePayment.PaidAmount := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './ram:PaidAmount');
+        if not advancePayment.PaidAmount.HasValue then
+          raise TZUGFeRDMissingDataException.Create('Advance payment paid amount is required (BG-X-45).');
+
+        advancePayment.FormattedReceivedDateTime := TZUGFeRDXmlUtils.NodeAsDateTime(nodes[i],
+          './ram:FormattedReceivedDateTime/qdt:DateTimeString');
+
+        var taxNodes: IXMLDOMNodeList := nodes[i].selectNodes('./ram:IncludedTradeTax');
+        if taxNodes.length = 0 then
+          raise TZUGFeRDMissingDataException.Create('At least one included trade tax is required for an advance payment (BG-X-45).');
+
+        for var taxIndex: Integer := 0 to taxNodes.length-1 do
+        begin
+          var taxAmount: ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(
+            taxNodes[taxIndex], './ram:CalculatedAmount');
+          var taxTypeCode: ZUGFeRDNullable<TZUGFeRDTaxTypes> :=
+            TEnumExtensions<TZUGFeRDTaxTypes>.StringToNullableEnum(
+              TZUGFeRDXmlUtils.NodeAsString(taxNodes[taxIndex], './ram:TypeCode'));
+          var taxCategoryCode: ZUGFeRDNullable<TZUGFeRDTaxCategoryCodes> :=
+            TEnumExtensions<TZUGFeRDTaxCategoryCodes>.StringToNullableEnum(
+              TZUGFeRDXmlUtils.NodeAsString(taxNodes[taxIndex], './ram:CategoryCode'));
+          if not taxAmount.HasValue or not taxTypeCode.HasValue or not taxCategoryCode.HasValue then
+            raise TZUGFeRDMissingDataException.Create('Advance payment tax amount, type and category are required (BG-X-45).');
+
+          var includedTax: TZUGFeRDTax := TZUGFeRDTax.Create;
+          try
+            includedTax.TaxAmount := taxAmount.Value;
+            includedTax.TypeCode := taxTypeCode;
+            includedTax.CategoryCode := taxCategoryCode;
+            includedTax.Percent := TZUGFeRDXmlUtils.NodeAsDecimal(
+              taxNodes[taxIndex], './ram:RateApplicablePercent', 0).Value;
+            advancePayment.IncludedTradeTaxes.Add(includedTax);
+            includedTax := nil;
+          finally
+            includedTax.Free;
+          end;
+        end;
+
+        if nodes[i].selectSingleNode('./ram:InvoiceSpecifiedReferencedDocument') <> nil then
+        begin
+          var invoiceReferenceID: string := TZUGFeRDXmlUtils.NodeAsString(nodes[i],
+            './ram:InvoiceSpecifiedReferencedDocument/ram:IssuerAssignedID');
+          if Trim(invoiceReferenceID) = '' then
+            raise TZUGFeRDMissingDataException.Create('Advance payment invoice reference ID is required when a reference is specified (BG-X-45).');
+
+          advancePayment.SetInvoiceReferencedDocument(
+            invoiceReferenceID,
+            TZUGFeRDXmlUtils.NodeAsDateTime(nodes[i],
+              './ram:InvoiceSpecifiedReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString'),
+            TEnumExtensions<TZUGFeRDInvoiceType>.StringToNullableEnum(
+              TZUGFeRDXmlUtils.NodeAsString(nodes[i],
+                './ram:InvoiceSpecifiedReferencedDocument/ram:TypeCode')));
+        end;
+
+        Result.AdvancePayments.Add(advancePayment);
+        advancePayment := nil;
+      finally
+        advancePayment.Free;
+      end;
     end;
-
-    if nodes[i].selectSingleNode('./ram:InvoiceSpecifiedReferencedDocument') <> nil then
-      advancePayment.SetInvoiceReferencedDocument(
-        TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:InvoiceSpecifiedReferencedDocument/ram:IssuerAssignedID'),
-        TZUGFeRDXmlUtils.NodeAsDateTime(nodes[i], './ram:InvoiceSpecifiedReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString'));
-
-    Result.AdvancePayments.Add(advancePayment);
+  except
+    Result.Free;
+    Result := nil;
+    raise;
   end;
 
   Result.OrderDate:= TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableHeaderTradeAgreement/ram:BuyerOrderReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString');

--- a/intf.ZUGFeRDInvoiceDescriptor23CIIWriter.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor23CIIWriter.pas
@@ -101,6 +101,7 @@ type
     procedure _WriteItemLevelSpecifiedTradeAllowanceCharge(_writer: TZUGFeRDProfileAwareXmlTextWriter; specifiedTradeAllowanceCharge: TZUGFeRDAbstractTradeAllowanceCharge);
     function _translateTaxCategoryCode(taxCategoryCode : TZUGFeRDTaxCategoryCodes) : String;
     function GetNameSpaces: TDictionary<string, string>;
+    procedure _validateAdvancePayments;
   private const
     ALL_PROFILES = [TZUGFeRDProfile.Minimum,
                     TZUGFeRDProfile.BasicWL,
@@ -146,6 +147,40 @@ begin
   Result.Add('xs', 'http://www.w3.org/2001/XMLSchema');
 end;
 
+/// <summary>
+/// Prüft die Pflichtangaben der nur im EXTENDED-Profil ausgegebenen Vorauszahlungen.
+/// </summary>
+procedure TZUGFeRDInvoiceDescriptor23CIIWriter._validateAdvancePayments;
+begin
+  if Descriptor.Profile <> TZUGFeRDProfile.Extended then
+    Exit;
+
+  for var advancePayment: TZUGFeRDAdvancePayment in Descriptor.AdvancePayments do
+  begin
+    if not Assigned(advancePayment) then
+      raise TZUGFeRDMissingDataException.Create('Advance payment paid amount is required (BG-X-45).');
+    if not advancePayment.PaidAmount.HasValue then
+      raise TZUGFeRDMissingDataException.Create('Advance payment paid amount is required (BG-X-45).');
+
+    if not Assigned(advancePayment.IncludedTradeTaxes) then
+      raise TZUGFeRDMissingDataException.Create('At least one included trade tax is required for an advance payment (BG-X-45).');
+    if advancePayment.IncludedTradeTaxes.Count = 0 then
+      raise TZUGFeRDMissingDataException.Create('At least one included trade tax is required for an advance payment (BG-X-45).');
+
+    for var includedTax: TZUGFeRDTax in advancePayment.IncludedTradeTaxes do
+    begin
+      if not Assigned(includedTax) then
+        raise TZUGFeRDMissingDataException.Create('Advance payment tax type and category are required (BG-X-45).');
+      if not includedTax.TypeCode.HasValue or not includedTax.CategoryCode.HasValue then
+        raise TZUGFeRDMissingDataException.Create('Advance payment tax type and category are required (BG-X-45).');
+    end;
+
+    if Assigned(advancePayment.InvoiceSpecifiedReferencedDocument) and
+      (Trim(advancePayment.InvoiceSpecifiedReferencedDocument.ID) = '') then
+      raise TZUGFeRDMissingDataException.Create('Advance payment invoice reference ID is required when a reference is specified (BG-X-45).');
+  end;
+end;
+
 procedure TZUGFeRDInvoiceDescriptor23CIIWriter.Save (_descriptor: TZUGFeRDInvoiceDescriptor; _stream: TStream; _format : TZUGFeRDFormats = TZUGFeRDFormats.CII; options: TZUGFeRDInvoiceFormatOptions = Nil);
 var
   streamPosition : Int64;
@@ -157,6 +192,7 @@ begin
   streamPosition := _stream.Position;
 
   Descriptor := _descriptor;
+  _validateAdvancePayments;
   var automaticallyCleanInvalidXmlCharacters: boolean := false;
   if options<>Nil then
     automaticallyCleanInvalidXmlCharacters:= TZUGFeRDInvoiceFormatOptions(options).AutomaticallyCleanInvalidCharacters;
@@ -1266,6 +1302,10 @@ begin
     begin
       Writer.WriteStartElement('ram:InvoiceSpecifiedReferencedDocument', [TZUGFeRDProfile.Extended]);
       Writer.WriteOptionalElementString('ram:IssuerAssignedID', advancePayment.InvoiceSpecifiedReferencedDocument.ID);
+      if advancePayment.InvoiceSpecifiedReferencedDocument.TypeCode.HasValue then
+        Writer.WriteOptionalElementString('ram:TypeCode',
+          TEnumExtensions<TZUGFeRDInvoiceType>.EnumToString(
+            advancePayment.InvoiceSpecifiedReferencedDocument.TypeCode));
       if advancePayment.InvoiceSpecifiedReferencedDocument.IssueDateTime.HasValue then
       begin
         Writer.WriteStartElement('ram:FormattedIssueDateTime');


### PR DESCRIPTION
## Summary
- validate mandatory BG-X-45 advance payment data when reading and writing CII 2.3
- preserve XML element presence checks with local nullable reader values without changing the public `TZUGFeRDTax` API
- read and write the optional invoice reference `TypeCode`
- correct the Factur-X version documentation and add positive and negative DUnitX tests
- release partially constructed reader objects when mandatory data is missing

## Validation
- Delphi 11 Win64 build: 0 errors, 0 warnings, 0 hints
- DUnitX: 307 of 307 tests passed, 0 ignored, 0 leaks, 0 failures, 0 errors