### PR TITLE
Include charges in recalculated tax basis message

### DIFF
--- a/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
@@ -50,6 +50,8 @@ type
     [Test]
     procedure TestValidInvoiceWithCharge;
     [Test]
+    procedure TestRecalculatedTaxBasisMessageIncludesCharge;
+    [Test]
     procedure TestInvalidTaxTotalIsReported;
     [Test]
     procedure TestValidationDoesNotRaiseOnDeviation;
@@ -160,6 +162,32 @@ begin
     try
       Assert.IsTrue(validationResult.IsValid,
         'Rechnung mit Zuschlag wurde als ungueltig gemeldet:'#13#10 + validationResult.Messages.Text);
+    finally
+      validationResult.Free;
+    end;
+  finally
+    desc.Free;
+  end;
+end;
+
+/// <summary>
+/// Die protokollierte Neuberechnung von BT-109 muss Kopfzuschläge ebenso
+/// berücksichtigen wie die eigentliche Summenberechnung.
+/// </summary>
+procedure TZUGFeRDInvoiceValidatorTests.TestRecalculatedTaxBasisMessageIncludesCharge;
+var
+  desc: TZUGFeRDInvoiceDescriptor;
+  validationResult: TZUGFeRDValidationResult;
+  expectedMessage: string;
+begin
+  desc := CreateBalancedInvoice(True);
+  try
+    validationResult := TZUGFeRDInvoiceValidator.Validate(desc, TZUGFeRDVersion.Version23);
+    try
+      expectedMessage := Format('Recalculated tax basis = %f', [210.0]);
+      Assert.IsTrue(validationResult.Messages.IndexOf(expectedMessage) >= 0,
+        'Die protokollierte Steuerbasis enthält den Kopfzuschlag nicht:'#13#10 +
+        validationResult.Messages.Text);
     finally
       validationResult.Free;
     end;

--- a/intf.ZUGFeRDInvoiceValidator.pas
+++ b/intf.ZUGFeRDInvoiceValidator.pas
@@ -179,7 +179,7 @@ begin
 
     // TODO ausgeben: Recalculating tax basis for tax percentages: [Key{percentage=7.00, code=[VAT] Value added tax, category=[S] Standard rate}, Key{percentage=19.00, code=[VAT] Value added tax, category=[S] Standard rate}]
 
-    Result.Messages.Add(Format('Recalculated tax basis = %f', [lineTotal - allowanceTotal]));
+    Result.Messages.Add(Format('Recalculated tax basis = %f', [lineTotal - allowanceTotal + chargeTotal]));
     Result.Messages.Add('Calculating tax total...');
 
     for kv in lineTotalPerTax do


### PR DESCRIPTION
## Summary

- Include document-level charges in the `Recalculated tax basis` diagnostic message.
- Add a regression test covering an invoice with a document-level charge.

## Reason

The validator calculation already includes document-level charges, but its diagnostic message omitted them. The message now uses the same `lineTotal - allowanceTotal + chargeTotal` formula as the calculation and the corresponding Factur-X tax basis rule.

## Verification

- Delphi 11 Win64 Debug build succeeded without warnings.
- DUnitX: 306 of 306 tests passed.