### PR TITLE
Validate invoice tax basis total

### DIFF
--- a/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
@@ -18,13 +18,12 @@
 unit intf.ZUGFeRDInvoiceValidatorTests.UnitTests;
 
 /// <summary>
-/// Tests fuer TZUGFeRDInvoiceValidator.
+/// Tests für TZUGFeRDInvoiceValidator.
 ///
 /// Der Validator rechnet die Summen einer Rechnung nach und vergleicht sie mit den
-/// angegebenen Werten. Die Tests bauen dafuer bewusst minimale Rechnungen auf, deren
-/// Summen exakt aufgehen - die Beispielrechnungen der Dokumentation eignen sich nicht,
-/// weil der Validator Positionsrabatte noch nicht beruecksichtigt (siehe das @todo in
-/// der Unit).
+/// angegebenen Werten. Die Tests bauen dafür bewusst minimale Rechnungen auf, deren
+/// Summen exakt aufgehen. Die Beispielrechnungen der Dokumentation eignen sich nicht,
+/// weil die vorgelagerte Nachrechnung Positionsrabatte weiterhin nicht berücksichtigt.
 /// </summary>
 
 interface

--- a/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
@@ -52,6 +52,10 @@ type
     [Test]
     procedure TestInvalidTaxTotalIsReported;
     [Test]
+    procedure TestMissingTaxBasisAmountIsReported;
+    [Test]
+    procedure TestInvalidTaxBasisAmountIsReported;
+    [Test]
     procedure TestValidationDoesNotRaiseOnDeviation;
   end;
 
@@ -183,6 +187,50 @@ begin
       Assert.IsFalse(validationResult.IsValid, 'Falscher Steuerbetrag wurde nicht bemaengelt');
       Assert.IsTrue(validationResult.Messages.Text.Contains('taxTotal'),
         'Die Meldungen benennen den beanstandeten Wert nicht');
+    finally
+      validationResult.Free;
+    end;
+  finally
+    desc.Free;
+  end;
+end;
+
+procedure TZUGFeRDInvoiceValidatorTests.TestMissingTaxBasisAmountIsReported;
+var
+  desc: TZUGFeRDInvoiceDescriptor;
+  validationResult: TZUGFeRDValidationResult;
+begin
+  desc := CreateBalancedInvoice(False);
+  try
+    desc.TaxBasisAmount := ZUGFeRDNullable<Currency>.Create(False);
+
+    validationResult := TZUGFeRDInvoiceValidator.Validate(desc, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsFalse(validationResult.IsValid, 'Fehlende Steuerbasis wurde nicht beanstandet');
+      Assert.IsTrue(validationResult.Messages.Text.Contains('Kein TaxBasisAmount vorhanden'),
+        'Die Meldungen benennen die fehlende Steuerbasis nicht');
+    finally
+      validationResult.Free;
+    end;
+  finally
+    desc.Free;
+  end;
+end;
+
+procedure TZUGFeRDInvoiceValidatorTests.TestInvalidTaxBasisAmountIsReported;
+var
+  desc: TZUGFeRDInvoiceDescriptor;
+  validationResult: TZUGFeRDValidationResult;
+begin
+  desc := CreateBalancedInvoice(False);
+  try
+    desc.TaxBasisAmount := 199;
+
+    validationResult := TZUGFeRDInvoiceValidator.Validate(desc, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsFalse(validationResult.IsValid, 'Abweichende Steuerbasis wurde nicht beanstandet');
+      Assert.IsTrue(validationResult.Messages.Text.Contains('taxBasisTotal'),
+        'Die Meldungen benennen die abweichende Steuerbasis nicht');
     finally
       validationResult.Free;
     end;

--- a/intf.ZUGFeRDInvoiceValidator.pas
+++ b/intf.ZUGFeRDInvoiceValidator.pas
@@ -259,25 +259,27 @@ begin
     end;
 
     {
-      * @todo Richtige Validierung implementieren.
+      * Die Summe der Steuerbemessungsgrundlagen der Steueraufschlüsselung (BT-116)
+      * muss dem Rechnungsbetrag ohne Umsatzsteuer (BT-109) entsprechen.
       *
-      * Der Vergleich unten stellt _taxBasisTotal gegen sich selbst und kann deshalb
-      * nie fehlschlagen - die Pruefung ist wirkungslos. Offen ist die fachliche Frage,
-      * wogegen die Bemessungsgrundlage zu pruefen ist: gegen descriptor.TaxBasisAmount
-      * oder gegen die nachgerechnete Summe (lineTotal - allowanceTotal + chargeTotal).
-      *
-      * Zweite offene Baustelle in dieser Routine: die Nachrechnung ignoriert
-      * Positionsrabatte (tradeLineItem.TradeAllowanceCharges) und rundet nicht je
-      * Steuersatz. Deshalb meldet der Validator die Beispielrechnungen der
-      * Dokumentation als ungueltig, obwohl sie es nicht sind.
+      * Die vorgelagerte Nachrechnung ignoriert weiterhin Positionsrabatte
+      * (tradeLineItem.TradeAllowanceCharges) und rundet nicht je Steuersatz.
+      * Deshalb meldet der Validator die Beispielrechnungen der Dokumentation
+      * teilweise als ungültig.
     }
-    if Abs(_taxBasisTotal - _taxBasisTotal) < 0.01 then
+    if not descriptor.TaxBasisAmount.HasValue then
+    begin
+      Result.Messages.Add(Format('trade.settlement.monetarySummation.taxBasisTotal Message: Kein TaxBasisAmount vorhanden', []));
+      Result.IsValid := false;
+    end
+    else if Abs(_taxBasisTotal - descriptor.TaxBasisAmount.Value) < 0.01 then
     begin
       Result.Messages.Add(Format('trade.settlement.monetarySummation.taxBasisTotal Message: Berechneter Wert ist wie vorhanden:[%4f]', [_taxBasisTotal]));
     end
     else
     begin
-      Result.Messages.Add(Format('trade.settlement.monetarySummation.taxBasisTotal Message: Berechneter Wert ist[%4f] aber tatsächliche vorhander Wert ist[%4f]', [_taxBasisTotal, _taxBasisTotal]));
+      Result.Messages.Add(Format('trade.settlement.monetarySummation.taxBasisTotal Message: Berechneter Wert ist[%4f] aber tatsächlicher vorhandener Wert ist[%4f]',
+        [_taxBasisTotal, descriptor.TaxBasisAmount.Value]));
       Result.IsValid := false;
     end;
 


### PR DESCRIPTION
## Summary

- Compare the sum of VAT category taxable amounts (BT-116) with the invoice total amount without VAT (BT-109).
- Report a missing `TaxBasisAmount` instead of silently accepting it.
- Add regression tests for missing and mismatching tax basis totals.
- Keep the existing valid invoice cases unchanged.

## Reason

The previous validator compared the calculated tax basis total with itself, so the check could never fail.

## Verification

- Countercheck before the fix: 307 tests found, 305 passed, and only the two new regression tests failed.
- Delphi 11 Win64 Debug build succeeded with 0 warnings and 0 hints.
- DUnitX after the fix: 307 of 307 tests passed.