### PR TITLE
Validate line allowances and charges

### DIFF
--- a/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
@@ -18,13 +18,12 @@
 unit intf.ZUGFeRDInvoiceValidatorTests.UnitTests;
 
 /// <summary>
-/// Tests fuer TZUGFeRDInvoiceValidator.
+/// Tests für TZUGFeRDInvoiceValidator.
 ///
 /// Der Validator rechnet die Summen einer Rechnung nach und vergleicht sie mit den
-/// angegebenen Werten. Die Tests bauen dafuer bewusst minimale Rechnungen auf, deren
-/// Summen exakt aufgehen - die Beispielrechnungen der Dokumentation eignen sich nicht,
-/// weil der Validator Positionsrabatte noch nicht beruecksichtigt (siehe das @todo in
-/// der Unit).
+/// angegebenen Werten. Die Tests bauen dafür bewusst minimale Rechnungen auf, deren
+/// Summen exakt aufgehen. Die Beispielrechnungen der Dokumentation eignen sich nicht,
+/// weil die vorgelagerte Nachrechnung Positionsrabatte weiterhin nicht berücksichtigt.
 /// </summary>
 
 interface

--- a/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
@@ -52,6 +52,10 @@ type
     [Test]
     procedure TestInvalidTaxTotalIsReported;
     [Test]
+    procedure TestMissingTaxBasisAmountIsReported;
+    [Test]
+    procedure TestInvalidTaxBasisAmountIsReported;
+    [Test]
     procedure TestValidationDoesNotRaiseOnDeviation;
   end;
 
@@ -183,6 +187,50 @@ begin
       Assert.IsFalse(validationResult.IsValid, 'Falscher Steuerbetrag wurde nicht bemaengelt');
       Assert.IsTrue(validationResult.Messages.Text.Contains('taxTotal'),
         'Die Meldungen benennen den beanstandeten Wert nicht');
+    finally
+      validationResult.Free;
+    end;
+  finally
+    desc.Free;
+  end;
+end;
+
+procedure TZUGFeRDInvoiceValidatorTests.TestMissingTaxBasisAmountIsReported;
+var
+  desc: TZUGFeRDInvoiceDescriptor;
+  validationResult: TZUGFeRDValidationResult;
+begin
+  desc := CreateBalancedInvoice(False);
+  try
+    desc.TaxBasisAmount := ZUGFeRDNullable<Currency>.Create(False);
+
+    validationResult := TZUGFeRDInvoiceValidator.Validate(desc, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsFalse(validationResult.IsValid, 'Fehlende Steuerbasis wurde nicht beanstandet');
+      Assert.IsTrue(validationResult.Messages.Text.Contains('Kein TaxBasisAmount vorhanden'),
+        'Die Meldungen benennen die fehlende Steuerbasis nicht');
+    finally
+      validationResult.Free;
+    end;
+  finally
+    desc.Free;
+  end;
+end;
+
+procedure TZUGFeRDInvoiceValidatorTests.TestInvalidTaxBasisAmountIsReported;
+var
+  desc: TZUGFeRDInvoiceDescriptor;
+  validationResult: TZUGFeRDValidationResult;
+begin
+  desc := CreateBalancedInvoice(False);
+  try
+    desc.TaxBasisAmount := 199;
+
+    validationResult := TZUGFeRDInvoiceValidator.Validate(desc, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsFalse(validationResult.IsValid, 'Abweichende Steuerbasis wurde nicht beanstandet');
+      Assert.IsTrue(validationResult.Messages.Text.Contains('taxBasisTotal'),
+        'Die Meldungen benennen die abweichende Steuerbasis nicht');
     finally
       validationResult.Free;
     end;

--- a/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
@@ -22,8 +22,7 @@ unit intf.ZUGFeRDInvoiceValidatorTests.UnitTests;
 ///
 /// Der Validator rechnet die Summen einer Rechnung nach und vergleicht sie mit den
 /// angegebenen Werten. Die Tests bauen dafür bewusst minimale Rechnungen auf, deren
-/// Summen exakt aufgehen. Die Beispielrechnungen der Dokumentation eignen sich nicht,
-/// weil die vorgelagerte Nachrechnung Positionsrabatte weiterhin nicht berücksichtigt.
+/// Summen exakt aufgehen.
 /// </summary>
 
 interface
@@ -38,16 +37,23 @@ type
   TZUGFeRDInvoiceValidatorTests = class(TZUGFeRDTestBase)
   private
     /// <summary>
-    /// Baut eine Rechnung mit einer Position (2 x 100,00 zu 19%) und optional einem
-    /// Zuschlag auf Kopfebene. Die Summen im Descriptor sind passend gesetzt, der
+    /// Baut eine Rechnung mit einer Position (2 x 100,00 zu 19%) und optionalen
+    /// Zu- und Abschlägen. Die Summen im Descriptor sind passend gesetzt, der
     /// Validator muss die Rechnung also als gueltig ansehen.
     /// </summary>
-    function CreateBalancedInvoice(const withCharge: Boolean): TZUGFeRDInvoiceDescriptor;
+    function CreateBalancedInvoice(const withCharge: Boolean;
+      const lineAllowance: Currency = 0; const lineCharge: Currency = 0): TZUGFeRDInvoiceDescriptor;
   public
     [Test]
     procedure TestValidInvoiceWithoutAllowanceOrCharge;
     [Test]
     procedure TestValidInvoiceWithCharge;
+    [Test]
+    procedure TestValidInvoiceWithLineAllowance;
+    [Test]
+    procedure TestValidInvoiceWithLineCharge;
+    [Test]
+    procedure TestPriceAllowanceIsNotSubtractedTwice;
     [Test]
     procedure TestInvalidTaxTotalIsReported;
     [Test]
@@ -68,19 +74,21 @@ uses
   intf.ZUGFeRDQuantityCodes,
   intf.ZUGFeRDTaxTypes,
   intf.ZUGFeRDTaxCategoryCodes,
+  intf.ZUGFeRDTradeLineItem,
   intf.ZUGFeRDHelper;
 
 { TZUGFeRDInvoiceValidatorTests }
 
 function TZUGFeRDInvoiceValidatorTests.CreateBalancedInvoice(
-  const withCharge: Boolean): TZUGFeRDInvoiceDescriptor;
+  const withCharge: Boolean; const lineAllowance, lineCharge: Currency): TZUGFeRDInvoiceDescriptor;
 var
   lineTotal, chargeTotal, taxBasis, taxTotal: Currency;
+  lineItem: TZUGFeRDTradeLineItem;
 begin
   Result := TZUGFeRDInvoiceDescriptor.CreateInvoice('RE-4711', EncodeDate(2026, 1, 15),
     TZUGFeRDCurrencyCodes.EUR);
 
-  Result.AddTradeLineItem(
+  lineItem := Result.AddTradeLineItem(
     {name=}            'Testartikel',
     {netUnitPrice=}    TZUGFeRDNullableParam<Currency>.Create(100),
     {description=}     '',
@@ -94,7 +102,16 @@ begin
     {taxPercent=}      19.0
   );
 
-  lineTotal := 200;
+  if lineAllowance <> 0 then
+    lineItem.AddSpecifiedTradeAllowance(TZUGFeRDCurrencyCodes.EUR, 200,
+      lineAllowance, 'Mengenrabatt');
+  if lineCharge <> 0 then
+    lineItem.AddSpecifiedTradeCharge(TZUGFeRDCurrencyCodes.EUR, 200,
+      lineCharge, 'Positionszuschlag');
+
+  // BT-131 enthält BG-28-Positionszuschläge und vermindert sich um BG-27-Positionsabschläge.
+  lineTotal := 200 - lineAllowance + lineCharge;
+  lineItem.LineTotalAmount := lineTotal;
   chargeTotal := 0;
 
   if withCharge then
@@ -126,6 +143,67 @@ begin
     {aGrandTotalAmount=}     taxBasis + taxTotal,
     {aTotalPrepaidAmount=}   0,
     {aDuePayableAmount=}     taxBasis + taxTotal);
+end;
+
+procedure TZUGFeRDInvoiceValidatorTests.TestValidInvoiceWithLineAllowance;
+var
+  desc: TZUGFeRDInvoiceDescriptor;
+  validationResult: TZUGFeRDValidationResult;
+begin
+  desc := CreateBalancedInvoice(False, {lineAllowance=} 10);
+  try
+    validationResult := TZUGFeRDInvoiceValidator.Validate(desc, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsTrue(validationResult.IsValid,
+        'Rechnung mit Positionsabschlag wurde als ungueltig gemeldet:'#13#10 + validationResult.Messages.Text);
+    finally
+      validationResult.Free;
+    end;
+  finally
+    desc.Free;
+  end;
+end;
+
+procedure TZUGFeRDInvoiceValidatorTests.TestValidInvoiceWithLineCharge;
+var
+  desc: TZUGFeRDInvoiceDescriptor;
+  validationResult: TZUGFeRDValidationResult;
+begin
+  desc := CreateBalancedInvoice(False, {lineAllowance=} 0, {lineCharge=} 10);
+  try
+    validationResult := TZUGFeRDInvoiceValidator.Validate(desc, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsTrue(validationResult.IsValid,
+        'Rechnung mit Positionszuschlag wurde als ungueltig gemeldet:'#13#10 + validationResult.Messages.Text);
+    finally
+      validationResult.Free;
+    end;
+  finally
+    desc.Free;
+  end;
+end;
+
+procedure TZUGFeRDInvoiceValidatorTests.TestPriceAllowanceIsNotSubtractedTwice;
+var
+  desc: TZUGFeRDInvoiceDescriptor;
+  validationResult: TZUGFeRDValidationResult;
+begin
+  desc := CreateBalancedInvoice(False);
+  try
+    // Der Preisnachlass ist bereits im Nettoeinzelpreis BT-146 enthalten und darf BT-131 nicht erneut vermindern.
+    desc.TradeLineItems[0].AddTradeAllowance(TZUGFeRDCurrencyCodes.EUR, 110,
+      10, 'Preisnachlass');
+
+    validationResult := TZUGFeRDInvoiceValidator.Validate(desc, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsTrue(validationResult.IsValid,
+        'Preisnachlass wurde bei der Positionssumme doppelt abgezogen:'#13#10 + validationResult.Messages.Text);
+    finally
+      validationResult.Free;
+    end;
+  finally
+    desc.Free;
+  end;
 end;
 
 procedure TZUGFeRDInvoiceValidatorTests.TestValidInvoiceWithoutAllowanceOrCharge;

--- a/intf.ZUGFeRDInvoiceValidator.pas
+++ b/intf.ZUGFeRDInvoiceValidator.pas
@@ -259,25 +259,27 @@ begin
     end;
 
     {
-      * @todo Richtige Validierung implementieren.
+      * Die Summe der Steuerbemessungsgrundlagen der Steueraufschlüsselung (BT-116)
+      * muss dem Rechnungsbetrag ohne Umsatzsteuer (BT-109) entsprechen.
       *
-      * Der Vergleich unten stellt _taxBasisTotal gegen sich selbst und kann deshalb
-      * nie fehlschlagen - die Pruefung ist wirkungslos. Offen ist die fachliche Frage,
-      * wogegen die Bemessungsgrundlage zu pruefen ist: gegen descriptor.TaxBasisAmount
-      * oder gegen die nachgerechnete Summe (lineTotal - allowanceTotal + chargeTotal).
-      *
-      * Zweite offene Baustelle in dieser Routine: die Nachrechnung ignoriert
-      * Positionsrabatte (tradeLineItem.TradeAllowanceCharges) und rundet nicht je
-      * Steuersatz. Deshalb meldet der Validator die Beispielrechnungen der
-      * Dokumentation als ungueltig, obwohl sie es nicht sind.
+      * Die vorgelagerte Nachrechnung ignoriert weiterhin Positionsrabatte
+      * (tradeLineItem.TradeAllowanceCharges) und rundet nicht je Steuersatz.
+      * Deshalb meldet der Validator die Beispielrechnungen der Dokumentation
+      * teilweise als ungültig.
     }
-    if Abs(_taxBasisTotal - _taxBasisTotal) < 0.01 then
+    if not descriptor.TaxBasisAmount.HasValue then
+    begin
+      Result.Messages.Add(Format('trade.settlement.monetarySummation.taxBasisTotal Message: Kein TaxBasisAmount vorhanden', []));
+      Result.IsValid := false;
+    end
+    else if Abs(_taxBasisTotal - descriptor.TaxBasisAmount.Value) < 0.01 then
     begin
       Result.Messages.Add(Format('trade.settlement.monetarySummation.taxBasisTotal Message: Berechneter Wert ist wie vorhanden:[%4f]', [_taxBasisTotal]));
     end
     else
     begin
-      Result.Messages.Add(Format('trade.settlement.monetarySummation.taxBasisTotal Message: Berechneter Wert ist[%4f] aber tatsächliche vorhander Wert ist[%4f]', [_taxBasisTotal, _taxBasisTotal]));
+      Result.Messages.Add(Format('trade.settlement.monetarySummation.taxBasisTotal Message: Berechneter Wert ist[%4f] aber tatsächlicher vorhandener Wert ist[%4f]',
+        [_taxBasisTotal, descriptor.TaxBasisAmount.Value]));
       Result.IsValid := false;
     end;
 

--- a/intf.ZUGFeRDInvoiceValidator.pas
+++ b/intf.ZUGFeRDInvoiceValidator.pas
@@ -125,6 +125,13 @@ begin
       if item.NetUnitPrice.HasValue then
       begin
         _total := (item.NetUnitPrice.Value * item.BilledQuantity);
+
+        // BT-131 enthält BG-28-Positionszuschläge und vermindert sich um BG-27-Positionsabschläge.
+        for var lineAllowance in item.GetSpecifiedTradeAllowances do
+          _total := _total - lineAllowance.ActualAmount;
+        for var lineCharge in item.GetSpecifiedTradeCharges do
+          _total := _total + lineCharge.ActualAmount;
+
         lineTotal := lineTotal + _total;
       end;
 
@@ -262,8 +269,8 @@ begin
       * Die Summe der Steuerbemessungsgrundlagen der Steueraufschlüsselung (BT-116)
       * muss dem Rechnungsbetrag ohne Umsatzsteuer (BT-109) entsprechen.
       *
-      * Die vorgelagerte Nachrechnung ignoriert weiterhin Positionsrabatte
-      * (tradeLineItem.TradeAllowanceCharges) und rundet nicht je Steuersatz.
+      * Preisnachlässe aus tradeLineItem.TradeAllowanceCharges sind bereits im
+      * Nettoeinzelpreis BT-146 enthalten. Die Nachrechnung rundet nicht je Steuersatz.
       * Deshalb meldet der Validator die Beispielrechnungen der Dokumentation
       * teilweise als ungültig.
     }


### PR DESCRIPTION
## Summary

- recalculate BT-131 with BG-28 line charges and BG-27 line allowances
- keep price-level allowances out of the recalculation because they are already reflected in BT-146
- add validator tests for both signs and for preventing a duplicate price-allowance deduction

## Reason

The validator currently derives each invoice line net amount only from net unit price multiplied by quantity. This ignores line-level allowances and charges even though they are part of BT-131 and therefore also affect the VAT category taxable amount.

This pull request is based on #96. After #96 is merged, the remaining change is commit `885085b`.

## Verification

- counterproof before the implementation: 307 of 309 tests passed; only the new line-allowance and line-charge cases failed
- Delphi 11 Win64 Debug build: 0 errors, 0 warnings, 0 hints
- DUnitX after the implementation: 310 of 310 tests passed
