### PR TITLE
Validate prepaid and due amounts

### DIFF
--- a/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
@@ -38,11 +38,12 @@ type
   private
     /// <summary>
     /// Baut eine Rechnung mit einer Position (2 x 100,00 zu 19%) und optionalen
-    /// Zu- und Abschlägen. Die Summen im Descriptor sind passend gesetzt, der
-    /// Validator muss die Rechnung also als gueltig ansehen.
+    /// Zu- und Abschlägen, Vorauszahlung und Rundung. Die Summen im Descriptor
+    /// sind passend gesetzt, der Validator muss die Rechnung also als gueltig ansehen.
     /// </summary>
     function CreateBalancedInvoice(const withCharge: Boolean;
-      const lineAllowance: Currency = 0; const lineCharge: Currency = 0): TZUGFeRDInvoiceDescriptor;
+      const lineAllowance: Currency = 0; const lineCharge: Currency = 0;
+      const prepaidAmount: Currency = 0; const roundingAmount: Currency = 0): TZUGFeRDInvoiceDescriptor;
   public
     [Test]
     procedure TestValidInvoiceWithoutAllowanceOrCharge;
@@ -54,6 +55,16 @@ type
     procedure TestValidInvoiceWithLineCharge;
     [Test]
     procedure TestPriceAllowanceIsNotSubtractedTwice;
+    [Test]
+    procedure TestValidInvoiceWithPrepaidAmount;
+    [Test]
+    procedure TestValidInvoiceWithRoundingAmount;
+    [Test]
+    procedure TestMissingDuePayableAmountIsReported;
+    [Test]
+    procedure TestInvalidDuePayableAmountIsReported;
+    [Test]
+    procedure TestDuePayableUsesDeclaredGrandTotalAmount;
     [Test]
     procedure TestInvalidTaxTotalIsReported;
     [Test]
@@ -80,9 +91,10 @@ uses
 { TZUGFeRDInvoiceValidatorTests }
 
 function TZUGFeRDInvoiceValidatorTests.CreateBalancedInvoice(
-  const withCharge: Boolean; const lineAllowance, lineCharge: Currency): TZUGFeRDInvoiceDescriptor;
+  const withCharge: Boolean; const lineAllowance, lineCharge, prepaidAmount,
+  roundingAmount: Currency): TZUGFeRDInvoiceDescriptor;
 var
-  lineTotal, chargeTotal, taxBasis, taxTotal: Currency;
+  lineTotal, chargeTotal, taxBasis, taxTotal, grandTotal: Currency;
   lineItem: TZUGFeRDTradeLineItem;
 begin
   Result := TZUGFeRDInvoiceDescriptor.CreateInvoice('RE-4711', EncodeDate(2026, 1, 15),
@@ -130,6 +142,7 @@ begin
   // Ein Zuschlag erhoeht die Bemessungsgrundlage
   taxBasis := lineTotal + chargeTotal;
   taxTotal := taxBasis * 19 / 100;
+  grandTotal := taxBasis + taxTotal;
 
   Result.AddApplicableTradeTax({calculatedAmount=} taxTotal, {basisAmount=} taxBasis,
     {percent=} 19.0, TZUGFeRDTaxTypes.VAT, TZUGFeRDTaxCategoryCodes.S);
@@ -140,9 +153,10 @@ begin
     {aAllowanceTotalAmount=} 0,
     {aTaxBasisAmount=}       taxBasis,
     {aTaxTotalAmount=}       taxTotal,
-    {aGrandTotalAmount=}     taxBasis + taxTotal,
-    {aTotalPrepaidAmount=}   0,
-    {aDuePayableAmount=}     taxBasis + taxTotal);
+    {aGrandTotalAmount=}     grandTotal,
+    {aTotalPrepaidAmount=}   prepaidAmount,
+    {aDuePayableAmount=}     grandTotal - prepaidAmount + roundingAmount,
+    {aRoundingAmount=}       roundingAmount);
 end;
 
 procedure TZUGFeRDInvoiceValidatorTests.TestValidInvoiceWithLineAllowance;
@@ -198,6 +212,116 @@ begin
     try
       Assert.IsTrue(validationResult.IsValid,
         'Preisnachlass wurde bei der Positionssumme doppelt abgezogen:'#13#10 + validationResult.Messages.Text);
+    finally
+      validationResult.Free;
+    end;
+  finally
+    desc.Free;
+  end;
+end;
+
+procedure TZUGFeRDInvoiceValidatorTests.TestValidInvoiceWithPrepaidAmount;
+var
+  desc: TZUGFeRDInvoiceDescriptor;
+  validationResult: TZUGFeRDValidationResult;
+begin
+  desc := CreateBalancedInvoice(False, {lineAllowance=} 0, {lineCharge=} 0,
+    {prepaidAmount=} 50);
+  try
+    validationResult := TZUGFeRDInvoiceValidator.Validate(desc, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsTrue(validationResult.IsValid,
+        'Rechnung mit Vorauszahlung wurde als ungueltig gemeldet:'#13#10 + validationResult.Messages.Text);
+    finally
+      validationResult.Free;
+    end;
+  finally
+    desc.Free;
+  end;
+end;
+
+procedure TZUGFeRDInvoiceValidatorTests.TestValidInvoiceWithRoundingAmount;
+var
+  desc: TZUGFeRDInvoiceDescriptor;
+  validationResult: TZUGFeRDValidationResult;
+begin
+  desc := CreateBalancedInvoice(False, {lineAllowance=} 0, {lineCharge=} 0,
+    {prepaidAmount=} 0, {roundingAmount=} 0.05);
+  try
+    validationResult := TZUGFeRDInvoiceValidator.Validate(desc, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsTrue(validationResult.IsValid,
+        'Rechnung mit Rundungsbetrag wurde als ungueltig gemeldet:'#13#10 + validationResult.Messages.Text);
+    finally
+      validationResult.Free;
+    end;
+  finally
+    desc.Free;
+  end;
+end;
+
+procedure TZUGFeRDInvoiceValidatorTests.TestMissingDuePayableAmountIsReported;
+var
+  desc: TZUGFeRDInvoiceDescriptor;
+  validationResult: TZUGFeRDValidationResult;
+begin
+  desc := CreateBalancedInvoice(False);
+  try
+    desc.DuePayableAmount := ZUGFeRDNullable<Currency>.Create(False);
+
+    validationResult := TZUGFeRDInvoiceValidator.Validate(desc, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsFalse(validationResult.IsValid, 'Fehlender Zahlbetrag wurde nicht beanstandet');
+      Assert.IsTrue(validationResult.Messages.Text.Contains('Kein DuePayableAmount vorhanden'),
+        'Die Meldungen benennen den fehlenden Zahlbetrag nicht');
+    finally
+      validationResult.Free;
+    end;
+  finally
+    desc.Free;
+  end;
+end;
+
+procedure TZUGFeRDInvoiceValidatorTests.TestInvalidDuePayableAmountIsReported;
+var
+  desc: TZUGFeRDInvoiceDescriptor;
+  validationResult: TZUGFeRDValidationResult;
+begin
+  desc := CreateBalancedInvoice(False, {lineAllowance=} 0, {lineCharge=} 0,
+    {prepaidAmount=} 50, {roundingAmount=} 0.05);
+  try
+    desc.DuePayableAmount := desc.GrandTotalAmount.Value;
+
+    validationResult := TZUGFeRDInvoiceValidator.Validate(desc, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsFalse(validationResult.IsValid, 'Abweichender Zahlbetrag wurde nicht beanstandet');
+      Assert.IsTrue(validationResult.Messages.Text.Contains('duePayable'),
+        'Die Meldungen benennen den abweichenden Zahlbetrag nicht');
+    finally
+      validationResult.Free;
+    end;
+  finally
+    desc.Free;
+  end;
+end;
+
+procedure TZUGFeRDInvoiceValidatorTests.TestDuePayableUsesDeclaredGrandTotalAmount;
+var
+  desc: TZUGFeRDInvoiceDescriptor;
+  validationResult: TZUGFeRDValidationResult;
+begin
+  desc := CreateBalancedInvoice(False, {lineAllowance=} 0, {lineCharge=} 0,
+    {prepaidAmount=} 50);
+  try
+    // BR-CO-16 verwendet den deklarierten BT-112, auch wenn dessen eigene Nachrechnung abweicht.
+    desc.GrandTotalAmount := desc.GrandTotalAmount.Value + 1;
+
+    validationResult := TZUGFeRDInvoiceValidator.Validate(desc, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsFalse(validationResult.IsValid, 'Abweichende Summen wurden nicht beanstandet');
+      Assert.IsTrue(validationResult.Messages.Text.Contains(
+        'monetarySummation.duePayable Message: Berechneter Wert ist['),
+        'BT-115 wurde nicht gegen den deklarierten BT-112 geprueft');
     finally
       validationResult.Free;
     end;

--- a/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
@@ -18,13 +18,12 @@
 unit intf.ZUGFeRDInvoiceValidatorTests.UnitTests;
 
 /// <summary>
-/// Tests fuer TZUGFeRDInvoiceValidator.
+/// Tests für TZUGFeRDInvoiceValidator.
 ///
 /// Der Validator rechnet die Summen einer Rechnung nach und vergleicht sie mit den
-/// angegebenen Werten. Die Tests bauen dafuer bewusst minimale Rechnungen auf, deren
-/// Summen exakt aufgehen - die Beispielrechnungen der Dokumentation eignen sich nicht,
-/// weil der Validator Positionsrabatte noch nicht beruecksichtigt (siehe das @todo in
-/// der Unit).
+/// angegebenen Werten. Die Tests bauen dafür bewusst minimale Rechnungen auf, deren
+/// Summen exakt aufgehen. Die Beispielrechnungen der Dokumentation eignen sich nicht,
+/// weil die vorgelagerte Nachrechnung Positionsrabatte weiterhin nicht berücksichtigt.
 /// </summary>
 
 interface

--- a/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
@@ -52,6 +52,10 @@ type
     [Test]
     procedure TestInvalidTaxTotalIsReported;
     [Test]
+    procedure TestMissingTaxBasisAmountIsReported;
+    [Test]
+    procedure TestInvalidTaxBasisAmountIsReported;
+    [Test]
     procedure TestValidationDoesNotRaiseOnDeviation;
   end;
 
@@ -183,6 +187,50 @@ begin
       Assert.IsFalse(validationResult.IsValid, 'Falscher Steuerbetrag wurde nicht bemaengelt');
       Assert.IsTrue(validationResult.Messages.Text.Contains('taxTotal'),
         'Die Meldungen benennen den beanstandeten Wert nicht');
+    finally
+      validationResult.Free;
+    end;
+  finally
+    desc.Free;
+  end;
+end;
+
+procedure TZUGFeRDInvoiceValidatorTests.TestMissingTaxBasisAmountIsReported;
+var
+  desc: TZUGFeRDInvoiceDescriptor;
+  validationResult: TZUGFeRDValidationResult;
+begin
+  desc := CreateBalancedInvoice(False);
+  try
+    desc.TaxBasisAmount := ZUGFeRDNullable<Currency>.Create(False);
+
+    validationResult := TZUGFeRDInvoiceValidator.Validate(desc, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsFalse(validationResult.IsValid, 'Fehlende Steuerbasis wurde nicht beanstandet');
+      Assert.IsTrue(validationResult.Messages.Text.Contains('Kein TaxBasisAmount vorhanden'),
+        'Die Meldungen benennen die fehlende Steuerbasis nicht');
+    finally
+      validationResult.Free;
+    end;
+  finally
+    desc.Free;
+  end;
+end;
+
+procedure TZUGFeRDInvoiceValidatorTests.TestInvalidTaxBasisAmountIsReported;
+var
+  desc: TZUGFeRDInvoiceDescriptor;
+  validationResult: TZUGFeRDValidationResult;
+begin
+  desc := CreateBalancedInvoice(False);
+  try
+    desc.TaxBasisAmount := 199;
+
+    validationResult := TZUGFeRDInvoiceValidator.Validate(desc, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsFalse(validationResult.IsValid, 'Abweichende Steuerbasis wurde nicht beanstandet');
+      Assert.IsTrue(validationResult.Messages.Text.Contains('taxBasisTotal'),
+        'Die Meldungen benennen die abweichende Steuerbasis nicht');
     finally
       validationResult.Free;
     end;

--- a/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
@@ -22,8 +22,7 @@ unit intf.ZUGFeRDInvoiceValidatorTests.UnitTests;
 ///
 /// Der Validator rechnet die Summen einer Rechnung nach und vergleicht sie mit den
 /// angegebenen Werten. Die Tests bauen dafür bewusst minimale Rechnungen auf, deren
-/// Summen exakt aufgehen. Die Beispielrechnungen der Dokumentation eignen sich nicht,
-/// weil die vorgelagerte Nachrechnung Positionsrabatte weiterhin nicht berücksichtigt.
+/// Summen exakt aufgehen.
 /// </summary>
 
 interface
@@ -38,16 +37,23 @@ type
   TZUGFeRDInvoiceValidatorTests = class(TZUGFeRDTestBase)
   private
     /// <summary>
-    /// Baut eine Rechnung mit einer Position (2 x 100,00 zu 19%) und optional einem
-    /// Zuschlag auf Kopfebene. Die Summen im Descriptor sind passend gesetzt, der
+    /// Baut eine Rechnung mit einer Position (2 x 100,00 zu 19%) und optionalen
+    /// Zu- und Abschlägen. Die Summen im Descriptor sind passend gesetzt, der
     /// Validator muss die Rechnung also als gueltig ansehen.
     /// </summary>
-    function CreateBalancedInvoice(const withCharge: Boolean): TZUGFeRDInvoiceDescriptor;
+    function CreateBalancedInvoice(const withCharge: Boolean;
+      const lineAllowance: Currency = 0; const lineCharge: Currency = 0): TZUGFeRDInvoiceDescriptor;
   public
     [Test]
     procedure TestValidInvoiceWithoutAllowanceOrCharge;
     [Test]
     procedure TestValidInvoiceWithCharge;
+    [Test]
+    procedure TestValidInvoiceWithLineAllowance;
+    [Test]
+    procedure TestValidInvoiceWithLineCharge;
+    [Test]
+    procedure TestPriceAllowanceIsNotSubtractedTwice;
     [Test]
     procedure TestInvalidTaxTotalIsReported;
     [Test]
@@ -68,19 +74,21 @@ uses
   intf.ZUGFeRDQuantityCodes,
   intf.ZUGFeRDTaxTypes,
   intf.ZUGFeRDTaxCategoryCodes,
+  intf.ZUGFeRDTradeLineItem,
   intf.ZUGFeRDHelper;
 
 { TZUGFeRDInvoiceValidatorTests }
 
 function TZUGFeRDInvoiceValidatorTests.CreateBalancedInvoice(
-  const withCharge: Boolean): TZUGFeRDInvoiceDescriptor;
+  const withCharge: Boolean; const lineAllowance, lineCharge: Currency): TZUGFeRDInvoiceDescriptor;
 var
   lineTotal, chargeTotal, taxBasis, taxTotal: Currency;
+  lineItem: TZUGFeRDTradeLineItem;
 begin
   Result := TZUGFeRDInvoiceDescriptor.CreateInvoice('RE-4711', EncodeDate(2026, 1, 15),
     TZUGFeRDCurrencyCodes.EUR);
 
-  Result.AddTradeLineItem(
+  lineItem := Result.AddTradeLineItem(
     {name=}            'Testartikel',
     {netUnitPrice=}    TZUGFeRDNullableParam<Currency>.Create(100),
     {description=}     '',
@@ -94,7 +102,16 @@ begin
     {taxPercent=}      19.0
   );
 
-  lineTotal := 200;
+  if lineAllowance <> 0 then
+    lineItem.AddSpecifiedTradeAllowance(TZUGFeRDCurrencyCodes.EUR, 200,
+      lineAllowance, 'Mengenrabatt');
+  if lineCharge <> 0 then
+    lineItem.AddSpecifiedTradeCharge(TZUGFeRDCurrencyCodes.EUR, 200,
+      lineCharge, 'Positionszuschlag');
+
+  // BT-131 enthält BG-28-Positionszuschläge und vermindert sich um BG-27-Positionsabschläge.
+  lineTotal := 200 - lineAllowance + lineCharge;
+  lineItem.LineTotalAmount := lineTotal;
   chargeTotal := 0;
 
   if withCharge then
@@ -126,6 +143,67 @@ begin
     {aGrandTotalAmount=}     taxBasis + taxTotal,
     {aTotalPrepaidAmount=}   0,
     {aDuePayableAmount=}     taxBasis + taxTotal);
+end;
+
+procedure TZUGFeRDInvoiceValidatorTests.TestValidInvoiceWithLineAllowance;
+var
+  desc: TZUGFeRDInvoiceDescriptor;
+  validationResult: TZUGFeRDValidationResult;
+begin
+  desc := CreateBalancedInvoice(False, {lineAllowance=} 10);
+  try
+    validationResult := TZUGFeRDInvoiceValidator.Validate(desc, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsTrue(validationResult.IsValid,
+        'Rechnung mit Positionsabschlag wurde als ungueltig gemeldet:'#13#10 + validationResult.Messages.Text);
+    finally
+      validationResult.Free;
+    end;
+  finally
+    desc.Free;
+  end;
+end;
+
+procedure TZUGFeRDInvoiceValidatorTests.TestValidInvoiceWithLineCharge;
+var
+  desc: TZUGFeRDInvoiceDescriptor;
+  validationResult: TZUGFeRDValidationResult;
+begin
+  desc := CreateBalancedInvoice(False, {lineAllowance=} 0, {lineCharge=} 10);
+  try
+    validationResult := TZUGFeRDInvoiceValidator.Validate(desc, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsTrue(validationResult.IsValid,
+        'Rechnung mit Positionszuschlag wurde als ungueltig gemeldet:'#13#10 + validationResult.Messages.Text);
+    finally
+      validationResult.Free;
+    end;
+  finally
+    desc.Free;
+  end;
+end;
+
+procedure TZUGFeRDInvoiceValidatorTests.TestPriceAllowanceIsNotSubtractedTwice;
+var
+  desc: TZUGFeRDInvoiceDescriptor;
+  validationResult: TZUGFeRDValidationResult;
+begin
+  desc := CreateBalancedInvoice(False);
+  try
+    // Der Preisnachlass ist bereits im Nettoeinzelpreis BT-146 enthalten und darf BT-131 nicht erneut vermindern.
+    desc.TradeLineItems[0].AddTradeAllowance(TZUGFeRDCurrencyCodes.EUR, 110,
+      10, 'Preisnachlass');
+
+    validationResult := TZUGFeRDInvoiceValidator.Validate(desc, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsTrue(validationResult.IsValid,
+        'Preisnachlass wurde bei der Positionssumme doppelt abgezogen:'#13#10 + validationResult.Messages.Text);
+    finally
+      validationResult.Free;
+    end;
+  finally
+    desc.Free;
+  end;
 end;
 
 procedure TZUGFeRDInvoiceValidatorTests.TestValidInvoiceWithoutAllowanceOrCharge;

--- a/intf.ZUGFeRDInvoiceValidator.pas
+++ b/intf.ZUGFeRDInvoiceValidator.pas
@@ -259,25 +259,27 @@ begin
     end;
 
     {
-      * @todo Richtige Validierung implementieren.
+      * Die Summe der Steuerbemessungsgrundlagen der Steueraufschlüsselung (BT-116)
+      * muss dem Rechnungsbetrag ohne Umsatzsteuer (BT-109) entsprechen.
       *
-      * Der Vergleich unten stellt _taxBasisTotal gegen sich selbst und kann deshalb
-      * nie fehlschlagen - die Pruefung ist wirkungslos. Offen ist die fachliche Frage,
-      * wogegen die Bemessungsgrundlage zu pruefen ist: gegen descriptor.TaxBasisAmount
-      * oder gegen die nachgerechnete Summe (lineTotal - allowanceTotal + chargeTotal).
-      *
-      * Zweite offene Baustelle in dieser Routine: die Nachrechnung ignoriert
-      * Positionsrabatte (tradeLineItem.TradeAllowanceCharges) und rundet nicht je
-      * Steuersatz. Deshalb meldet der Validator die Beispielrechnungen der
-      * Dokumentation als ungueltig, obwohl sie es nicht sind.
+      * Die vorgelagerte Nachrechnung ignoriert weiterhin Positionsrabatte
+      * (tradeLineItem.TradeAllowanceCharges) und rundet nicht je Steuersatz.
+      * Deshalb meldet der Validator die Beispielrechnungen der Dokumentation
+      * teilweise als ungültig.
     }
-    if Abs(_taxBasisTotal - _taxBasisTotal) < 0.01 then
+    if not descriptor.TaxBasisAmount.HasValue then
+    begin
+      Result.Messages.Add(Format('trade.settlement.monetarySummation.taxBasisTotal Message: Kein TaxBasisAmount vorhanden', []));
+      Result.IsValid := false;
+    end
+    else if Abs(_taxBasisTotal - descriptor.TaxBasisAmount.Value) < 0.01 then
     begin
       Result.Messages.Add(Format('trade.settlement.monetarySummation.taxBasisTotal Message: Berechneter Wert ist wie vorhanden:[%4f]', [_taxBasisTotal]));
     end
     else
     begin
-      Result.Messages.Add(Format('trade.settlement.monetarySummation.taxBasisTotal Message: Berechneter Wert ist[%4f] aber tatsächliche vorhander Wert ist[%4f]', [_taxBasisTotal, _taxBasisTotal]));
+      Result.Messages.Add(Format('trade.settlement.monetarySummation.taxBasisTotal Message: Berechneter Wert ist[%4f] aber tatsächlicher vorhandener Wert ist[%4f]',
+        [_taxBasisTotal, descriptor.TaxBasisAmount.Value]));
       Result.IsValid := false;
     end;
 

--- a/intf.ZUGFeRDInvoiceValidator.pas
+++ b/intf.ZUGFeRDInvoiceValidator.pas
@@ -90,7 +90,8 @@ end;
 class function TZUGFeRDInvoiceValidator.Validate(descriptor: TZUGFeRDInvoiceDescriptor; version: TZUGFeRDVersion): TZUGFeRDValidationResult;
 var
   lineCounter: Integer;
-  lineTotal, allowanceTotal, chargeTotal, taxTotal, grandTotal: Currency;
+  lineTotal, allowanceTotal, chargeTotal, taxTotal, grandTotal, prepaid,
+    rounding, duePayable, expectedDuePayable: Currency;
   lineTotalPerTax: TDictionary<Currency, Currency>;
   item: TZUGFeRDTradeLineItem;
   kv: TPair<Currency, Currency>;
@@ -197,6 +198,11 @@ begin
     end;
 
     grandTotal := lineTotal - allowanceTotal + taxTotal + chargeTotal;
+    prepaid := descriptor.TotalPrepaidAmount.GetValueOrDefault;
+    rounding := descriptor.RoundingAmount.GetValueOrDefault;
+
+    // BT-115 ergibt sich aus BT-112 abzüglich BT-113 zuzüglich BT-114.
+    duePayable := grandTotal - prepaid + rounding;
 
     Result.Messages.Add(Format('Recalculated tax total = %f', [taxTotal]));
     Result.Messages.Add(Format('Recalculated grand total = %f EUR(tax basis total + tax total)', [grandTotal]));
@@ -208,8 +214,8 @@ begin
        lineTotal - allowanceTotal + chargeTotal, // tax basis total
        taxTotal,
        grandTotal,
-       0.0, // prepaid (TODO)
-       lineTotal - allowanceTotal + taxTotal + chargeTotal // + prepaid
+       prepaid,
+       duePayable
        ]));
 
     var _taxBasisTotal : Currency := 0;
@@ -263,6 +269,26 @@ begin
     begin
       Result.Messages.Add(Format('trade.settlement.monetarySummation.grandTotal Message: Berechneter Wert ist[%4f] aber tatsächliche vorhander Wert ist[%4f]', [grandTotal, descriptor.GrandTotalAmount.GetValueOrDefault]));
       Result.IsValid := false;
+    end;
+
+    if not descriptor.DuePayableAmount.HasValue then
+    begin
+      Result.Messages.Add('trade.settlement.monetarySummation.duePayable Message: Kein DuePayableAmount vorhanden');
+      Result.IsValid := false;
+    end
+    else if descriptor.GrandTotalAmount.HasValue then
+    begin
+      expectedDuePayable := descriptor.GrandTotalAmount.Value - prepaid + rounding;
+      if Abs(expectedDuePayable - descriptor.DuePayableAmount.Value) < 0.01 then
+      begin
+        Result.Messages.Add(Format('trade.settlement.monetarySummation.duePayable Message: Berechneter Wert ist wie vorhanden:[%4f]', [expectedDuePayable]));
+      end
+      else
+      begin
+        Result.Messages.Add(Format('trade.settlement.monetarySummation.duePayable Message: Berechneter Wert ist[%4f] aber tatsächlicher vorhandener Wert ist[%4f]',
+          [expectedDuePayable, descriptor.DuePayableAmount.Value]));
+        Result.IsValid := false;
+      end;
     end;
 
     {

--- a/intf.ZUGFeRDInvoiceValidator.pas
+++ b/intf.ZUGFeRDInvoiceValidator.pas
@@ -125,6 +125,13 @@ begin
       if item.NetUnitPrice.HasValue then
       begin
         _total := (item.NetUnitPrice.Value * item.BilledQuantity);
+
+        // BT-131 enthält BG-28-Positionszuschläge und vermindert sich um BG-27-Positionsabschläge.
+        for var lineAllowance in item.GetSpecifiedTradeAllowances do
+          _total := _total - lineAllowance.ActualAmount;
+        for var lineCharge in item.GetSpecifiedTradeCharges do
+          _total := _total + lineCharge.ActualAmount;
+
         lineTotal := lineTotal + _total;
       end;
 
@@ -262,8 +269,8 @@ begin
       * Die Summe der Steuerbemessungsgrundlagen der Steueraufschlüsselung (BT-116)
       * muss dem Rechnungsbetrag ohne Umsatzsteuer (BT-109) entsprechen.
       *
-      * Die vorgelagerte Nachrechnung ignoriert weiterhin Positionsrabatte
-      * (tradeLineItem.TradeAllowanceCharges) und rundet nicht je Steuersatz.
+      * Preisnachlässe aus tradeLineItem.TradeAllowanceCharges sind bereits im
+      * Nettoeinzelpreis BT-146 enthalten. Die Nachrechnung rundet nicht je Steuersatz.
       * Deshalb meldet der Validator die Beispielrechnungen der Dokumentation
       * teilweise als ungültig.
     }


### PR DESCRIPTION
## Summary

- validate BT-115 against declared BT-112 minus BT-113 plus BT-114
- treat the optional paid and rounding amounts as zero when absent
- report a missing or inconsistent BT-115
- add positive and negative validator tests for paid amounts, rounding, missing values, and an inconsistent declared BT-112

## Reason

BR-CO-16 defines the amount due for payment from the declared invoice total amount with VAT, paid amount, and rounding amount. The validator previously displayed a hard-coded paid amount of zero and did not validate BT-115.

`SpecifiedAdvancePayment` remains independent detail information. No normative rule requiring its sum to equal BT-113 was identified.

This pull request is based on #97. After #97 is merged, the remaining change is commit `2fc4780`.

## Verification

- counterproof before the implementation: 312 of 314 tests passed; only the new missing and inconsistent BT-115 cases failed
- Delphi 11 Win64 Debug build: 0 errors, 0 warnings, 0 hints
- DUnitX after the implementation and declared-BT-112 counterproof: 315 of 315 tests passed
