### PR TITLE
Validate VAT rounding per tax breakdown

### DIFF
--- a/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
@@ -30,6 +30,7 @@ interface
 uses
   DUnitX.TestFramework,
   intf.ZUGFeRDInvoiceDescriptor,
+  intf.ZUGFeRDTaxCategoryCodes,
   intf.ZUGFeRDTestBase;
 
 type
@@ -44,6 +45,11 @@ type
     function CreateBalancedInvoice(const withCharge: Boolean;
       const lineAllowance: Currency = 0; const lineCharge: Currency = 0;
       const prepaidAmount: Currency = 0; const roundingAmount: Currency = 0): TZUGFeRDInvoiceDescriptor;
+    /// <summary>
+    /// Ergänzt eine Rechnungsposition und die zugehörige Steueraufschlüsselung.
+    /// </summary>
+    procedure AddTaxGroup(Descriptor: TZUGFeRDInvoiceDescriptor; const Name: string;
+      const BasisAmount, TaxPercent, TaxAmount: Currency; const CategoryCode: TZUGFeRDTaxCategoryCodes);
   public
     [Test]
     procedure TestValidInvoiceWithoutAllowanceOrCharge;
@@ -70,6 +76,18 @@ type
     [Test]
     procedure TestInvalidTaxTotalIsReported;
     [Test]
+    procedure TestTaxAmountsAreRoundedPerTaxGroup;
+    [Test]
+    procedure TestUnroundedTaxAmountIsReported;
+    [Test]
+    procedure TestTaxAmountDeviationsWithinSameRateAreReported;
+    [Test]
+    procedure TestNegativeMidpointTaxAmountIsRoundedAwayFromZero;
+    [Test]
+    procedure TestNonVatTaxDoesNotAffectVatTotals;
+    [Test]
+    procedure TestMissingTaxTypeIsReported;
+    [Test]
     procedure TestMissingTaxBasisAmountIsReported;
     [Test]
     procedure TestInvalidTaxBasisAmountIsReported;
@@ -86,11 +104,31 @@ uses
   intf.ZUGFeRDCurrencyCodes,
   intf.ZUGFeRDQuantityCodes,
   intf.ZUGFeRDTaxTypes,
-  intf.ZUGFeRDTaxCategoryCodes,
   intf.ZUGFeRDTradeLineItem,
   intf.ZUGFeRDHelper;
 
 { TZUGFeRDInvoiceValidatorTests }
+
+procedure TZUGFeRDInvoiceValidatorTests.AddTaxGroup(
+  Descriptor: TZUGFeRDInvoiceDescriptor; const Name: string;
+  const BasisAmount, TaxPercent, TaxAmount: Currency;
+  const CategoryCode: TZUGFeRDTaxCategoryCodes);
+begin
+  Descriptor.AddTradeLineItem(
+    {name=}            Name,
+    {netUnitPrice=}    TZUGFeRDNullableParam<Currency>.Create(BasisAmount),
+    {description=}     '',
+    {unitCode=}        TZUGFeRDNullableParam<TZUGFeRDQuantityCodes>.Create(TZUGFeRDQuantityCodes.H87),
+    {unitQuantity=}    nil,
+    {grossUnitPrice=}  nil,
+    {billedQuantity=}  1,
+    {lineTotalAmount=} BasisAmount,
+    {taxType=}         TZUGFeRDNullableParam<TZUGFeRDTaxTypes>.Create(TZUGFeRDTaxTypes.VAT),
+    {categoryCode=}    TZUGFeRDNullableParam<TZUGFeRDTaxCategoryCodes>.Create(CategoryCode),
+    {taxPercent=}      TaxPercent);
+  Descriptor.AddApplicableTradeTax({calculatedAmount=} TaxAmount, {basisAmount=} BasisAmount,
+    {percent=} TaxPercent, TZUGFeRDTaxTypes.VAT, CategoryCode);
+end;
 
 function TZUGFeRDInvoiceValidatorTests.CreateBalancedInvoice(
   const withCharge: Boolean; const lineAllowance, lineCharge, prepaidAmount,
@@ -421,6 +459,152 @@ begin
     end;
   finally
     desc.Free;
+  end;
+end;
+
+procedure TZUGFeRDInvoiceValidatorTests.TestTaxAmountsAreRoundedPerTaxGroup;
+var
+  Descriptor: TZUGFeRDInvoiceDescriptor;
+  ValidationResult: TZUGFeRDValidationResult;
+begin
+  Descriptor := TZUGFeRDInvoiceDescriptor.CreateInvoice('RE-ROUND-GROUPS', EncodeDate(2026, 1, 15), TZUGFeRDCurrencyCodes.EUR);
+  try
+    // BR-CO-17 rundet jede Steuergruppe vor der Summierung auf zwei Dezimalstellen.
+    AddTaxGroup(Descriptor, 'Group 19', 0.03, 19, 0.01, TZUGFeRDTaxCategoryCodes.S);
+    AddTaxGroup(Descriptor, 'Group 7', 0.08, 7, 0.01, TZUGFeRDTaxCategoryCodes.S);
+    AddTaxGroup(Descriptor, 'Group 5', 0.11, 5, 0.01, TZUGFeRDTaxCategoryCodes.S);
+    Descriptor.SetTotals(0.22, 0, 0, 0.22, 0.03, 0.25, 0, 0.25);
+
+    ValidationResult := TZUGFeRDInvoiceValidator.Validate(Descriptor, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsTrue(ValidationResult.IsValid,
+        'Tax amounts rounded per group were rejected:'#13#10 + ValidationResult.Messages.Text);
+    finally
+      FreeAndNil(ValidationResult);
+    end;
+  finally
+    FreeAndNil(Descriptor);
+  end;
+end;
+
+procedure TZUGFeRDInvoiceValidatorTests.TestUnroundedTaxAmountIsReported;
+var
+  Descriptor: TZUGFeRDInvoiceDescriptor;
+  ValidationResult: TZUGFeRDValidationResult;
+begin
+  Descriptor := TZUGFeRDInvoiceDescriptor.CreateInvoice('RE-ROUND-INVALID', EncodeDate(2026, 1, 15), TZUGFeRDCurrencyCodes.EUR);
+  try
+    AddTaxGroup(Descriptor, 'Unrounded group', 0.03, 19, 0.0057, TZUGFeRDTaxCategoryCodes.S);
+    Descriptor.SetTotals(0.03, 0, 0, 0.03, 0.0057, 0.0357, 0, 0.0357);
+
+    ValidationResult := TZUGFeRDInvoiceValidator.Validate(Descriptor, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsFalse(ValidationResult.IsValid, 'Unrounded tax amount was not reported');
+      Assert.IsTrue(ValidationResult.Messages.Text.Contains('BR-CO-17'),
+        'Validation messages do not identify BR-CO-17');
+    finally
+      FreeAndNil(ValidationResult);
+    end;
+  finally
+    FreeAndNil(Descriptor);
+  end;
+end;
+
+procedure TZUGFeRDInvoiceValidatorTests.TestTaxAmountDeviationsWithinSameRateAreReported;
+var
+  Descriptor: TZUGFeRDInvoiceDescriptor;
+  ValidationResult: TZUGFeRDValidationResult;
+  Message: string;
+  BRCO17MessageCount: Integer;
+begin
+  Descriptor := TZUGFeRDInvoiceDescriptor.CreateInvoice('RE-ROUND-CATEGORY', EncodeDate(2026, 1, 15), TZUGFeRDCurrencyCodes.EUR);
+  try
+    // Gegensätzliche Abweichungen dürfen sich bei gleichem Steuersatz nicht gegenseitig aufheben.
+    AddTaxGroup(Descriptor, 'Standard rate', 1, 7, 0.08, TZUGFeRDTaxCategoryCodes.S);
+    AddTaxGroup(Descriptor, 'Lower rate', 1, 7, 0.06, TZUGFeRDTaxCategoryCodes.AA);
+    Descriptor.SetTotals(2, 0, 0, 2, 0.14, 2.14, 0, 2.14);
+
+    ValidationResult := TZUGFeRDInvoiceValidator.Validate(Descriptor, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsFalse(ValidationResult.IsValid, 'Tax amount deviations within one rate were not reported');
+      BRCO17MessageCount := 0;
+      for Message in ValidationResult.Messages do
+        if Message.Contains('BR-CO-17') then
+          Inc(BRCO17MessageCount);
+      Assert.AreEqual(2, BRCO17MessageCount, 'Not every tax group was validated separately');
+    finally
+      FreeAndNil(ValidationResult);
+    end;
+  finally
+    FreeAndNil(Descriptor);
+  end;
+end;
+
+procedure TZUGFeRDInvoiceValidatorTests.TestNegativeMidpointTaxAmountIsRoundedAwayFromZero;
+var
+  Descriptor: TZUGFeRDInvoiceDescriptor;
+  ValidationResult: TZUGFeRDValidationResult;
+begin
+  Descriptor := TZUGFeRDInvoiceDescriptor.CreateInvoice('RE-ROUND-NEGATIVE', EncodeDate(2026, 1, 15), TZUGFeRDCurrencyCodes.EUR);
+  try
+    // Der Rundungsmodus entspricht der Betragsformatierung der Writer und rundet Mittelpunkte von null weg.
+    AddTaxGroup(Descriptor, 'Negative midpoint', -0.025, 20, -0.01, TZUGFeRDTaxCategoryCodes.S);
+    Descriptor.SetTotals(-0.025, 0, 0, -0.025, -0.01, -0.035, 0, -0.035);
+
+    ValidationResult := TZUGFeRDInvoiceValidator.Validate(Descriptor, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsTrue(ValidationResult.IsValid,
+        'Negative midpoint tax amount was not rounded away from zero:'#13#10 + ValidationResult.Messages.Text);
+    finally
+      FreeAndNil(ValidationResult);
+    end;
+  finally
+    FreeAndNil(Descriptor);
+  end;
+end;
+
+procedure TZUGFeRDInvoiceValidatorTests.TestNonVatTaxDoesNotAffectVatTotals;
+var
+  Descriptor: TZUGFeRDInvoiceDescriptor;
+  ValidationResult: TZUGFeRDValidationResult;
+begin
+  Descriptor := CreateBalancedInvoice(False);
+  try
+    // Zusätzliche Extended-Steuern gehören weder zu BT-110 noch zur Summe der VAT-Bemessungsgrundlagen.
+    Descriptor.AddApplicableTradeTax({calculatedAmount=} 10, {basisAmount=} 200,
+      {percent=} 5, TZUGFeRDTaxTypes.AAA, TZUGFeRDTaxCategoryCodes.S);
+
+    ValidationResult := TZUGFeRDInvoiceValidator.Validate(Descriptor, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsTrue(ValidationResult.IsValid,
+        'Non-VAT tax affected VAT totals:'#13#10 + ValidationResult.Messages.Text);
+    finally
+      FreeAndNil(ValidationResult);
+    end;
+  finally
+    FreeAndNil(Descriptor);
+  end;
+end;
+
+procedure TZUGFeRDInvoiceValidatorTests.TestMissingTaxTypeIsReported;
+var
+  Descriptor: TZUGFeRDInvoiceDescriptor;
+  ValidationResult: TZUGFeRDValidationResult;
+begin
+  Descriptor := CreateBalancedInvoice(False);
+  try
+    Descriptor.Taxes[0].TypeCode := ZUGFeRDNullable<TZUGFeRDTaxTypes>.Create(False);
+
+    ValidationResult := TZUGFeRDInvoiceValidator.Validate(Descriptor, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsFalse(ValidationResult.IsValid, 'Missing tax type was not reported');
+      Assert.IsTrue(ValidationResult.Messages.Text.Contains('Tax type code is required'),
+        'Validation messages do not identify the missing tax type');
+    finally
+      FreeAndNil(ValidationResult);
+    end;
+  finally
+    FreeAndNil(Descriptor);
   end;
 end;
 

--- a/intf.ZUGFeRDInvoiceValidator.pas
+++ b/intf.ZUGFeRDInvoiceValidator.pas
@@ -20,12 +20,12 @@ unit intf.ZUGFeRDInvoiceValidator;
 interface
 
 uses
-  System.SysUtils,System.TypInfo,System.Classes,
-  System.Generics.Collections
+  System.SysUtils,System.TypInfo,System.Classes,System.Math
   ,intf.ZUGFeRDInvoiceDescriptor
   ,intf.ZUGFeRDTradeLineItem
   ,intf.ZUGFeRDTradeAllowanceCharge
   ,intf.ZUGFeRDTax
+  ,intf.ZUGFeRDTaxTypes
   ,intf.ZUGFeRDVersion
   ;
 
@@ -91,10 +91,8 @@ class function TZUGFeRDInvoiceValidator.Validate(descriptor: TZUGFeRDInvoiceDesc
 var
   lineCounter: Integer;
   lineTotal, allowanceTotal, chargeTotal, taxTotal, grandTotal, prepaid,
-    rounding, duePayable, expectedDuePayable: Currency;
-  lineTotalPerTax: TDictionary<Currency, Currency>;
+    rounding, duePayable, expectedDuePayable, expectedTaxAmount: Currency;
   item: TZUGFeRDTradeLineItem;
-  kv: TPair<Currency, Currency>;
   tax: TZUGFeRDTax;
 begin
   Result := TZUGFeRDValidationResult.Create;
@@ -114,9 +112,7 @@ begin
   chargeTotal := 0;
   taxTotal := 0;
   //grandTotal := 0;
-  lineTotalPerTax := TDictionary<Currency, Currency>.Create;
-  try
-    // line item summation
+  // line item summation
     Result.Messages.Add('Validating invoice monetary summation');
     Result.Messages.Add(Format('Starting recalculating line total from %d items...', [descriptor.TradeLineItems.Count]));
 
@@ -135,11 +131,6 @@ begin
 
         lineTotal := lineTotal + _total;
       end;
-
-      if not lineTotalPerTax.ContainsKey(item.TaxPercent) then
-        lineTotalPerTax.Add(item.TaxPercent, 0);
-
-      lineTotalPerTax[item.TaxPercent] := lineTotalPerTax[item.TaxPercent] + _total;
 
       //retval.Add(String.Format("==> {0}:", ++lineCounter));
       //retval.Add(String.Format("Recalculating item: [{0}]", item.Name));
@@ -163,11 +154,6 @@ begin
       // fuer Zu- und Abschlaege nirgends befuellt und ist daher immer 0
       Result.Messages.Add(Format('==> added %f to %f%%', [charge.ActualAmount, charge.Tax.Percent]));
 
-      if not lineTotalPerTax.ContainsKey(charge.Tax.Percent) then
-        lineTotalPerTax.Add(charge.Tax.Percent, 0);
-
-      // Ein Zuschlag erhoeht die Bemessungsgrundlage, nur der Abschlag weiter unten verringert sie
-      lineTotalPerTax[charge.Tax.Percent] := lineTotalPerTax[charge.Tax.Percent] + charge.ActualAmount;
       chargeTotal:= chargeTotal + charge.ActualAmount
     end;
 
@@ -175,10 +161,6 @@ begin
     begin
       Result.Messages.Add(Format('==> subtracted %f from %f%%', [allowance.ActualAmount, allowance.Tax.Percent]));
 
-      if not lineTotalPerTax.ContainsKey(allowance.Tax.Percent) then
-        lineTotalPerTax.Add(allowance.Tax.Percent, 0);
-
-      lineTotalPerTax[allowance.Tax.Percent] := lineTotalPerTax[allowance.Tax.Percent] - allowance.ActualAmount;
       allowanceTotal := allowanceTotal + allowance.ActualAmount;
     end;
 
@@ -190,11 +172,29 @@ begin
     Result.Messages.Add(Format('Recalculated tax basis = %f', [lineTotal - allowanceTotal + chargeTotal]));
     Result.Messages.Add('Calculating tax total...');
 
-    for kv in lineTotalPerTax do
+    for tax in descriptor.Taxes do
     begin
-      var _taxTotal : Currency := (kv.Value * kv.Key / 100);
-      taxTotal := taxTotal + _taxTotal;
-      Result.Messages.Add(Format('===> %f x %f%% = %f', [kv.Value, kv.Key, _taxTotal]));
+      if not tax.TypeCode.HasValue then
+      begin
+        Result.Messages.Add('Tax type code is required for every tax breakdown');
+        Result.IsValid := false;
+        Continue;
+      end;
+      if tax.TypeCode.Value <> TZUGFeRDTaxTypes.VAT then
+        Continue;
+
+      // BR-CO-17 verlangt die Rundung jeder Steuergruppe vor der Summierung zu BT-110.
+      expectedTaxAmount := SimpleRoundTo(tax.BasisAmount * tax.Percent / 100, -2);
+      taxTotal := taxTotal + expectedTaxAmount;
+      Result.Messages.Add(Format('===> %f x %f%% = %f', [tax.BasisAmount, tax.Percent, expectedTaxAmount]));
+
+      if tax.TaxAmount <> expectedTaxAmount then
+      begin
+        Result.Messages.Add(Format(
+          'BR-CO-17: Berechneter Steuerbetrag ist[%4f] aber vorhandener Steuerbetrag ist[%4f] bei Bemessungsgrundlage[%4f] und Steuersatz[%4f]',
+          [expectedTaxAmount, tax.TaxAmount, tax.BasisAmount, tax.Percent]));
+        Result.IsValid := false;
+      end;
     end;
 
     grandTotal := lineTotal - allowanceTotal + taxTotal + chargeTotal;
@@ -221,7 +221,9 @@ begin
     var _taxBasisTotal : Currency := 0;
     for tax in descriptor.Taxes do
     begin
-      _taxBasisTotal := _taxBasisTotal + tax.BasisAmount;
+      if tax.TypeCode.HasValue then
+        if tax.TypeCode.Value = TZUGFeRDTaxTypes.VAT then
+          _taxBasisTotal := _taxBasisTotal + tax.BasisAmount;
     end;
 
     var _allowanceTotal : Currency := 0;
@@ -339,9 +341,6 @@ begin
     // version-specific validation
     // ZUGFeRD 1.0 version specific validation skipped
 
-  finally
-    lineTotalPerTax.Free;
-  end;
 end;
 
 end.


### PR DESCRIPTION
## Summary
- validate each VAT breakdown against BR-CO-17 after rounding its calculated tax amount to two decimals
- sum the rounded VAT breakdown amounts for the invoice VAT total
- exclude additional Extended tax types from VAT totals and report a missing tax type explicitly
- cover multiple rates, equal rates in different categories, unrounded amounts, negative midpoint rounding, non-VAT taxes, and missing tax types

## Verification
- Delphi 11 Win64 Debug build completed with 0 errors and 0 warnings
- DUnitX: 324/324 tests passed
