### PR TITLE
Bind reader XPath prefixes to standard namespace URIs

### DIFF
--- a/Unittest/intf.ZUGFeRDCrossVersionTests.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRDCrossVersionTests.UnitTests.pas
@@ -274,6 +274,19 @@ type
 
     [Test]
     procedure TestTaxTotalAmountBT110OnlyWhenTaxCurrencyEqualsCurrencyUBL;
+
+    [Test]
+    [TestCase('V1-CII-Ext',  '100,0,4')]
+    [TestCase('V20-CII-Ext', '200,0,4')]
+    [TestCase('V23-CII-Ext', '230,0,4')]
+    [TestCase('V23-UBL-XR',  '230,1,32')]
+    procedure TestReaderAcceptsAlternativeNamespacePrefixes(_version: Integer; _format: Integer; _profile: Integer);
+
+    [Test]
+    procedure TestCIIReaderAcceptsLocallyDeclaredRamNamespace;
+
+    [Test]
+    procedure TestCIIReaderDoesNotTreatDifferentNamespaceUriAsRam;
   end;
 
 implementation
@@ -2349,6 +2362,173 @@ begin
     Desc.Free;
   end;
 end; // !TestTaxTotalAmountBT110OnlyWhenTaxCurrencyEqualsCurrencyUBL()
+
+procedure TZUGFeRDCrossVersionTests.TestReaderAcceptsAlternativeNamespacePrefixes(_version: Integer; _format: Integer; _profile: Integer);
+var
+  Version: TZUGFeRDVersion;
+  Format: TZUGFeRDFormats;
+  Profile: TZUGFeRDProfile;
+  Desc, LoadedInvoice: TZUGFeRDInvoiceDescriptor;
+  InvoiceStream: TMemoryStream;
+  ModifiedStream: TStringStream;
+  Bytes: TBytes;
+  XmlContent, ModifiedXml, ExpectedInvoiceNo: string;
+  ExpectedLineItemCount: Integer;
+begin
+  Version := TZUGFeRDVersion(_version);
+  Format := TZUGFeRDFormats(_format);
+  Profile := TZUGFeRDProfile(_profile);
+
+  Desc := TZUGFeRDInvoiceProvider.CreateInvoice;
+  try
+    ExpectedInvoiceNo := Desc.InvoiceNo;
+    ExpectedLineItemCount := Desc.TradeLineItems.Count;
+
+    InvoiceStream := TMemoryStream.Create;
+    try
+      Desc.Save(InvoiceStream, Version, Profile, Format);
+      SetLength(Bytes, InvoiceStream.Size);
+      InvoiceStream.Position := 0;
+      InvoiceStream.ReadBuffer(Bytes[0], InvoiceStream.Size);
+      XmlContent := TEncoding.UTF8.GetString(Bytes);
+    finally
+      FreeAndNil(InvoiceStream);
+    end;
+
+    ModifiedXml := StringReplace(XmlContent, 'xmlns:rsm=', 'xmlns:document=', [rfReplaceAll]);
+    ModifiedXml := StringReplace(ModifiedXml, 'xmlns:ram=', 'xmlns:aggregate=', [rfReplaceAll]);
+    ModifiedXml := StringReplace(ModifiedXml, 'xmlns:udt=', 'xmlns:unqualified=', [rfReplaceAll]);
+    ModifiedXml := StringReplace(ModifiedXml, 'xmlns:qdt=', 'xmlns:qualified=', [rfReplaceAll]);
+    ModifiedXml := StringReplace(ModifiedXml, 'xmlns:cac=', 'xmlns:commonAggregate=', [rfReplaceAll]);
+    ModifiedXml := StringReplace(ModifiedXml, 'xmlns:cbc=', 'xmlns:commonBasic=', [rfReplaceAll]);
+    ModifiedXml := StringReplace(ModifiedXml, 'xmlns:ubl=', 'xmlns:invoiceDocument=', [rfReplaceAll]);
+    ModifiedXml := StringReplace(ModifiedXml, 'rsm:', 'document:', [rfReplaceAll]);
+    ModifiedXml := StringReplace(ModifiedXml, 'ram:', 'aggregate:', [rfReplaceAll]);
+    ModifiedXml := StringReplace(ModifiedXml, 'udt:', 'unqualified:', [rfReplaceAll]);
+    ModifiedXml := StringReplace(ModifiedXml, 'qdt:', 'qualified:', [rfReplaceAll]);
+    ModifiedXml := StringReplace(ModifiedXml, 'cac:', 'commonAggregate:', [rfReplaceAll]);
+    ModifiedXml := StringReplace(ModifiedXml, 'cbc:', 'commonBasic:', [rfReplaceAll]);
+    ModifiedXml := StringReplace(ModifiedXml, '<ubl:', '<invoiceDocument:', [rfReplaceAll]);
+    ModifiedXml := StringReplace(ModifiedXml, '</ubl:', '</invoiceDocument:', [rfReplaceAll]);
+    Assert.AreNotEqual(XmlContent, ModifiedXml, 'The test invoice must contain namespace prefixes to replace');
+
+    ModifiedStream := TStringStream.Create(ModifiedXml, TEncoding.UTF8);
+    try
+      LoadedInvoice := TZUGFeRDInvoiceDescriptor.Load(ModifiedStream);
+      try
+        Assert.AreEqual(ExpectedInvoiceNo, LoadedInvoice.InvoiceNo, 'Invoice number must be read independently of document prefixes');
+        Assert.AreEqual(ExpectedLineItemCount, LoadedInvoice.TradeLineItems.Count, 'Line items must be read independently of document prefixes');
+        Assert.AreEqual<Currency>(Desc.TaxTotalAmount.Value, LoadedInvoice.TaxTotalAmount.Value,
+          'Tax total must be read independently of document prefixes');
+      finally
+        FreeAndNil(LoadedInvoice);
+      end;
+    finally
+      FreeAndNil(ModifiedStream);
+    end;
+  finally
+    FreeAndNil(Desc);
+  end;
+end; // !TestReaderAcceptsAlternativeNamespacePrefixes()
+
+procedure TZUGFeRDCrossVersionTests.TestCIIReaderAcceptsLocallyDeclaredRamNamespace;
+const
+  RamNamespaceUri = 'urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100';
+  RamNamespaceDeclaration = 'xmlns:ram="' + RamNamespaceUri + '"';
+var
+  Desc, LoadedInvoice: TZUGFeRDInvoiceDescriptor;
+  InvoiceStream: TMemoryStream;
+  ModifiedStream: TStringStream;
+  Bytes: TBytes;
+  XmlContent, ModifiedXml: string;
+begin
+  Desc := TZUGFeRDInvoiceProvider.CreateInvoice;
+  try
+    InvoiceStream := TMemoryStream.Create;
+    try
+      Desc.Save(InvoiceStream, TZUGFeRDVersion.Version23, TZUGFeRDProfile.Extended, TZUGFeRDFormats.CII);
+      SetLength(Bytes, InvoiceStream.Size);
+      InvoiceStream.Position := 0;
+      InvoiceStream.ReadBuffer(Bytes[0], InvoiceStream.Size);
+      XmlContent := TEncoding.UTF8.GetString(Bytes);
+    finally
+      FreeAndNil(InvoiceStream);
+    end;
+
+    Assert.IsTrue(Pos(RamNamespaceDeclaration, XmlContent) > 0, 'The generated CII invoice must declare the ram namespace');
+    ModifiedXml := StringReplace(XmlContent, RamNamespaceDeclaration, '', []);
+    ModifiedXml := StringReplace(ModifiedXml, '<rsm:ExchangedDocumentContext>',
+      '<rsm:ExchangedDocumentContext ' + RamNamespaceDeclaration + '>', []);
+    ModifiedXml := StringReplace(ModifiedXml, '<rsm:ExchangedDocument>',
+      '<rsm:ExchangedDocument ' + RamNamespaceDeclaration + '>', []);
+    ModifiedXml := StringReplace(ModifiedXml, '<rsm:SupplyChainTradeTransaction>',
+      '<rsm:SupplyChainTradeTransaction ' + RamNamespaceDeclaration + '>', []);
+
+    ModifiedStream := TStringStream.Create(ModifiedXml, TEncoding.UTF8);
+    try
+      LoadedInvoice := TZUGFeRDInvoiceDescriptor.Load(ModifiedStream);
+      try
+        Assert.AreEqual(Desc.InvoiceNo, LoadedInvoice.InvoiceNo, 'Invoice number must be read with locally declared namespaces');
+        Assert.AreEqual(Desc.TradeLineItems.Count, LoadedInvoice.TradeLineItems.Count,
+          'Line items must be read with locally declared namespaces');
+        Assert.AreEqual<Currency>(Desc.TaxTotalAmount.Value, LoadedInvoice.TaxTotalAmount.Value,
+          'Tax total must be read with locally declared namespaces');
+      finally
+        FreeAndNil(LoadedInvoice);
+      end;
+    finally
+      FreeAndNil(ModifiedStream);
+    end;
+  finally
+    FreeAndNil(Desc);
+  end;
+end; // !TestCIIReaderAcceptsLocallyDeclaredRamNamespace()
+
+procedure TZUGFeRDCrossVersionTests.TestCIIReaderDoesNotTreatDifferentNamespaceUriAsRam;
+const
+  RamNamespaceUri = 'urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100';
+  DifferentNamespaceUri = 'urn:example:invalid:ReusableAggregateBusinessInformationEntity';
+var
+  Desc, LoadedInvoice: TZUGFeRDInvoiceDescriptor;
+  InvoiceStream: TMemoryStream;
+  ModifiedStream: TStringStream;
+  Bytes: TBytes;
+  XmlContent, ModifiedXml: string;
+begin
+  Desc := TZUGFeRDInvoiceProvider.CreateInvoice;
+  try
+    InvoiceStream := TMemoryStream.Create;
+    try
+      Desc.Save(InvoiceStream, TZUGFeRDVersion.Version23, TZUGFeRDProfile.Extended, TZUGFeRDFormats.CII);
+      SetLength(Bytes, InvoiceStream.Size);
+      InvoiceStream.Position := 0;
+      InvoiceStream.ReadBuffer(Bytes[0], InvoiceStream.Size);
+      XmlContent := TEncoding.UTF8.GetString(Bytes);
+    finally
+      FreeAndNil(InvoiceStream);
+    end;
+
+    ModifiedXml := StringReplace(XmlContent, RamNamespaceUri, DifferentNamespaceUri, [rfReplaceAll]);
+    Assert.AreNotEqual(XmlContent, ModifiedXml, 'The test invoice must contain the standard ram namespace URI');
+
+    ModifiedStream := TStringStream.Create(ModifiedXml, TEncoding.UTF8);
+    try
+      LoadedInvoice := TZUGFeRDInvoiceDescriptor.Load(ModifiedStream);
+      try
+        Assert.AreEqual(0, LoadedInvoice.TradeLineItems.Count,
+          'Elements from a different namespace URI must not be treated as ram elements');
+        Assert.IsFalse(LoadedInvoice.TaxTotalAmount.HasValue,
+          'Amounts from a different namespace URI must not be treated as ram amounts');
+      finally
+        FreeAndNil(LoadedInvoice);
+      end;
+    finally
+      FreeAndNil(ModifiedStream);
+    end;
+  finally
+    FreeAndNil(Desc);
+  end;
+end; // !TestCIIReaderDoesNotTreatDifferentNamespaceUriAsRam()
 
 procedure TZUGFeRDCrossVersionTests.TestSellerOrderReferencedDocumentOnItemLevel(_version: Integer);
 var

--- a/intf.ZUGFeRDXmlHelper.pas
+++ b/intf.ZUGFeRDXmlHelper.pas
@@ -98,39 +98,38 @@ end;
 
 class function TZUGFeRDXmlHelper.PrepareDocumentForXPathQuerys(_Xml: IXMLDocument; IsZUGFeRD1: boolean = false): IXMLDOMDocument2;
 var
-  sNsLine: string;
-  ram, rsm, udt, qdt, cac, cbc: string;
-
-  function ReturnNS (Value: string; Default: String; Default1: string = ''): string;
-  begin
-    Result:= Trim(Value);
-    if Result='' then
-      if IsZUGFeRD1 and (Default1<>'') then
-        Result:= Default1
-      else
-        Result:= Default
-  end;
-
+  LNamespaceDeclarations: string;
+  LRamNamespace, LRsmNamespace, LUdtNamespace: string;
 begin
   Result := nil;
   if not _Xml.Active then
     exit;
-  ram:= ReturnNS(_XML.DocumentElement.FindNamespaceURI('ram'), 'urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100',
-                                                               'urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12');
-  rsm:= ReturnNS(_XML.DocumentElement.FindNamespaceURI('rsm'), 'urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100',
-                                                               'urn:ferd:CrossIndustryDocument:invoice:1p0');
-  udt:= ReturnNS(_XML.DocumentElement.FindNamespaceURI('udt'), 'urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100',
-                                                               'urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15');
-  qdt:= ReturnNS(_XML.DocumentElement.FindNamespaceURI('qdt'), 'urn:un:unece:uncefact:data:standard:QualifiedDataType:100');
-  cac:= ReturnNS(_XML.DocumentElement.FindNamespaceURI('cac'), 'urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2');
-  cbc:= ReturnNS(_XML.DocumentElement.FindNamespaceURI('cbc'), 'urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2');
 
-  sNsLine := Format('xmlns:qdt="%s" xmlns:ram="%s" xmlns:rsm="%s" xmlns:udt="%s" xmlns:cac="%s" xmlns:cbc="%s"', [qdt, ram, rsm, udt, cac, cbc]);
+  // XPath-Präfixe sind interne Bezeichner. Die Namespace-URI bestimmt die fachliche Identität eines XML-Elements.
+  if IsZUGFeRD1 then
+  begin
+    LRamNamespace := 'urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12';
+    LRsmNamespace := 'urn:ferd:CrossIndustryDocument:invoice:1p0';
+    LUdtNamespace := 'urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15';
+  end
+  else
+  begin
+    LRamNamespace := 'urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100';
+    LRsmNamespace := 'urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100';
+    LUdtNamespace := 'urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100';
+  end;
+
+  LNamespaceDeclarations := Format(
+    'xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" ' +
+    'xmlns:ram="%s" xmlns:rsm="%s" xmlns:udt="%s" ' +
+    'xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" ' +
+    'xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"',
+    [LRamNamespace, LRsmNamespace, LUdtNamespace]);
   Result := CoDOMDocument60.Create;
   Result.preserveWhiteSpace := True; // preserve CRLF on multiline strings also
   Result.loadXML(_Xml.XML.Text);
   Result.setProperty('SelectionLanguage', 'XPath');  // ab 4.0 ist SelectionLanguage eh immer XPath
-  Result.setProperty('SelectionNamespaces', sNsLine);
+  Result.setProperty('SelectionNamespaces', LNamespaceDeclarations);
 end;
 
 


### PR DESCRIPTION
## Summary
- bind the reader's internal XPath prefixes to the version-specific standard namespace URIs
- read CII and UBL documents independently of the prefixes used by the document
- avoid treating elements from a different namespace URI as ZUGFeRD elements

XML namespace identity is defined by the namespace URI and local name, not by the chosen prefix. MSXML's `SelectionNamespaces` property independently declares the prefixes used by XPath expressions.

References:
- https://www.w3.org/TR/xml-names/
- https://learn.microsoft.com/en-us/previous-versions/windows/desktop/ms756048(v=vs.85)

## Verification
- DUnitX: 335 of 335 tests passed
- Delphi 11 Win64 Debug build: 0 errors