### PR TITLE
Add receiving advice references

### DIFF
--- a/Unittest/intf.XRechnungUBLTests.UnitTests.pas
+++ b/Unittest/intf.XRechnungUBLTests.UnitTests.pas
@@ -82,6 +82,8 @@ type
     [Test]
     procedure TestDespatchDocumentReference;
     [Test]
+    procedure TestReceivingAdviceDocumentReference;
+    [Test]
     procedure TestSampleCreditNote326;
     [Test]
     procedure TestSampleCreditNote384;
@@ -1675,6 +1677,53 @@ begin
         Assert.IsNotNull(loadedInvoice.DespatchAdviceReferencedDocument);
         Assert.AreEqual(reference, loadedInvoice.DespatchAdviceReferencedDocument.ID);
         Assert.IsFalse(loadedInvoice.DespatchAdviceReferencedDocument.IssueDateTime.HasValue); // not defined in Peppol standard!
+      finally
+        loadedInvoice.Free;
+      end;
+    finally
+      ms.Free;
+    end;
+  finally
+    desc.Free;
+  end;
+end;
+
+procedure TXRechnungUBLTests.TestReceivingAdviceDocumentReference;
+var
+  desc, loadedInvoice: TZUGFeRDInvoiceDescriptor;
+  ms: TMemoryStream;
+  reference: string;
+  adviceDate: TDateTime;
+  bytes: TBytes;
+  xmlContent: string;
+begin
+  reference := 'RAR123456789';
+  adviceDate := EncodeDate(2024, 5, 14);
+
+  desc := TZUGFeRDInvoiceProvider.CreateInvoice;
+  try
+    desc.SetReceivingAdviceReferencedDocument(reference,
+      TZUGFeRDNullableParam<TDateTime>.Create(adviceDate));
+
+    ms := TMemoryStream.Create;
+    try
+      desc.Save(ms, TZUGFeRDVersion.Version23, TZUGFeRDProfile.XRechnung, TZUGFeRDFormats.UBL);
+      ms.Position := 0;
+      SetLength(bytes, ms.Size);
+      ms.ReadBuffer(bytes[0], ms.Size);
+      xmlContent := TEncoding.UTF8.GetString(bytes);
+
+      Assert.IsTrue(TRegEx.IsMatch(xmlContent,
+        '<cac:ReceiptDocumentReference>\s*<cbc:ID>' + reference + '</cbc:ID>\s*</cac:ReceiptDocumentReference>'));
+      Assert.IsFalse(TRegEx.IsMatch(xmlContent,
+        '<cac:ReceiptDocumentReference>.*<cbc:IssueDate>', [roSingleLine]));
+
+      ms.Position := 0;
+      loadedInvoice := TZUGFeRDInvoiceDescriptor.Load(ms);
+      try
+        Assert.IsNotNull(loadedInvoice.ReceivingAdviceReferencedDocument);
+        Assert.AreEqual(reference, loadedInvoice.ReceivingAdviceReferencedDocument.ID);
+        Assert.IsFalse(loadedInvoice.ReceivingAdviceReferencedDocument.IssueDateTime.HasValue); // not defined in Peppol standard!
       finally
         loadedInvoice.Free;
       end;

--- a/Unittest/intf.ZUGFeRDCrossVersionTests.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRDCrossVersionTests.UnitTests.pas
@@ -95,6 +95,29 @@ type
     procedure TestDeliveryNoteReferencedDocumentLineIdInExtended(_version: Integer);
 
     [Test]
+    [TestCase('V20-Comfort',     '200,2')]
+    [TestCase('V20-Extended',    '200,4')]
+    [TestCase('V23-Comfort',     '230,2')]
+    [TestCase('V23-Extended',    '230,4')]
+    [TestCase('V23-XRechnung',   '230,32')]
+    [TestCase('V23-XRechnung1',  '230,64')]
+    procedure TestReceivingAdviceReferencedDocumentRoundtrip(_version: Integer; _profile: Integer);
+
+    [Test]
+    [TestCase('V20-Minimum', '200,8')]
+    [TestCase('V20-BasicWL', '200,16')]
+    [TestCase('V20-Basic',   '200,1')]
+    [TestCase('V23-Minimum', '230,8')]
+    [TestCase('V23-BasicWL', '230,16')]
+    [TestCase('V23-Basic',   '230,1')]
+    procedure TestReceivingAdviceReferencedDocumentUnsupportedProfiles(_version: Integer; _profile: Integer);
+
+    [Test]
+    [TestCase('V20', '200')]
+    [TestCase('V23', '230')]
+    procedure TestReceivingAdviceReferencedDocumentOrder(_version: Integer);
+
+    [Test]
     [TestCase('V1',  '100')]
     [TestCase('V20', '200')]
     [TestCase('V23', '230')]
@@ -803,6 +826,136 @@ begin
       finally
         loadedInvoice.Free;
       end;
+    finally
+      ms.Free;
+    end;
+  finally
+    desc.Free;
+  end;
+end;
+
+procedure TZUGFeRDCrossVersionTests.TestReceivingAdviceReferencedDocumentRoundtrip(
+  _version: Integer; _profile: Integer);
+const
+  ReceivingAdviceNumber = 'RAR123456789';
+var
+  version: TZUGFeRDVersion;
+  profile: TZUGFeRDProfile;
+  receivingAdviceDate: TDateTime;
+  desc, loadedInvoice: TZUGFeRDInvoiceDescriptor;
+  ms: TMemoryStream;
+begin
+  version := TZUGFeRDVersion(_version);
+  profile := TZUGFeRDProfile(_profile);
+  receivingAdviceDate := EncodeDate(2024, 5, 14);
+
+  desc := TZUGFeRDInvoiceProvider.CreateInvoice;
+  try
+    desc.SetReceivingAdviceReferencedDocument(ReceivingAdviceNumber,
+      TZUGFeRDNullableParam<TDateTime>.Create(receivingAdviceDate));
+
+    ms := TMemoryStream.Create;
+    try
+      desc.Save(ms, version, profile);
+      ms.Position := 0;
+
+      loadedInvoice := TZUGFeRDInvoiceDescriptor.Load(ms);
+      try
+        Assert.IsNotNull(loadedInvoice.ReceivingAdviceReferencedDocument);
+        Assert.AreEqual(ReceivingAdviceNumber, loadedInvoice.ReceivingAdviceReferencedDocument.ID);
+
+        if profile = TZUGFeRDProfile.Extended then
+        begin
+          Assert.IsTrue(loadedInvoice.ReceivingAdviceReferencedDocument.IssueDateTime.HasValue);
+          Assert.AreEqual<TDateTime>(receivingAdviceDate,
+            loadedInvoice.ReceivingAdviceReferencedDocument.IssueDateTime.Value);
+        end
+        else
+          Assert.IsFalse(loadedInvoice.ReceivingAdviceReferencedDocument.IssueDateTime.HasValue);
+      finally
+        loadedInvoice.Free;
+      end;
+    finally
+      ms.Free;
+    end;
+  finally
+    desc.Free;
+  end;
+end;
+
+procedure TZUGFeRDCrossVersionTests.TestReceivingAdviceReferencedDocumentUnsupportedProfiles(
+  _version: Integer; _profile: Integer);
+var
+  version: TZUGFeRDVersion;
+  profile: TZUGFeRDProfile;
+  desc, loadedInvoice: TZUGFeRDInvoiceDescriptor;
+  ms: TMemoryStream;
+begin
+  version := TZUGFeRDVersion(_version);
+  profile := TZUGFeRDProfile(_profile);
+
+  desc := TZUGFeRDInvoiceProvider.CreateInvoice;
+  try
+    desc.SetReceivingAdviceReferencedDocument('RAR123456789');
+
+    ms := TMemoryStream.Create;
+    try
+      desc.Save(ms, version, profile);
+      ms.Position := 0;
+
+      loadedInvoice := TZUGFeRDInvoiceDescriptor.Load(ms);
+      try
+        Assert.IsNull(loadedInvoice.ReceivingAdviceReferencedDocument);
+      finally
+        loadedInvoice.Free;
+      end;
+    finally
+      ms.Free;
+    end;
+  finally
+    desc.Free;
+  end;
+end;
+
+procedure TZUGFeRDCrossVersionTests.TestReceivingAdviceReferencedDocumentOrder(_version: Integer);
+var
+  version: TZUGFeRDVersion;
+  desc: TZUGFeRDInvoiceDescriptor;
+  ms: TMemoryStream;
+  bytes: TBytes;
+  xmlContent: string;
+  despatchPosition: Integer;
+  receivingPosition: Integer;
+  deliveryNotePosition: Integer;
+begin
+  version := TZUGFeRDVersion(_version);
+  desc := TZUGFeRDInvoiceProvider.CreateInvoice;
+  try
+    if version = TZUGFeRDVersion.Version23 then
+      desc.SetDespatchAdviceReferencedDocument('DESPATCH-1');
+    desc.SetReceivingAdviceReferencedDocument('RECEIVING-1');
+    desc.SetDeliveryNoteReferenceDocument('DELIVERY-1');
+
+    ms := TMemoryStream.Create;
+    try
+      desc.Save(ms, version, TZUGFeRDProfile.Extended);
+      ms.Position := 0;
+      SetLength(bytes, ms.Size);
+      ms.ReadBuffer(bytes[0], ms.Size);
+      xmlContent := TEncoding.UTF8.GetString(bytes);
+
+      despatchPosition := Pos('<ram:DespatchAdviceReferencedDocument>', xmlContent);
+      receivingPosition := Pos('<ram:ReceivingAdviceReferencedDocument>', xmlContent);
+      deliveryNotePosition := Pos('<ram:DeliveryNoteReferencedDocument>', xmlContent);
+
+      if version = TZUGFeRDVersion.Version23 then
+      begin
+        Assert.IsTrue(despatchPosition > 0);
+        Assert.IsTrue(receivingPosition > despatchPosition);
+      end
+      else
+        Assert.IsTrue(receivingPosition > 0);
+      Assert.IsTrue(deliveryNotePosition > receivingPosition);
     finally
       ms.Free;
     end;

--- a/intf.ZUGFeRDInvoiceDescriptor.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor.pas
@@ -67,6 +67,7 @@ uses
   intf.ZUGFeRDElectronicAddress,
   intf.ZUGFeRDElectronicAddressSchemeIdentifiers,
   intf.ZUGFeRDDespatchAdviceReferencedDocument,
+  intf.ZUGFeRDReceivingAdviceReferencedDocument,
   intf.ZUGFeRDFormats,
   intf.ZUGFeRDTransportmodeCodes,
   intf.ZUGFeRDAllowanceReasonCodes,
@@ -146,9 +147,11 @@ type
     FSellerOrderReferencedDocument: TZUGFeRDSellerOrderReferencedDocument;
     FTransportMode: ZUGFeRDNullable<TZUGFeRDTransportModeCodes>;
     FDespatchAdviceReferencedDocument: TZUGFeRDDespatchAdviceReferencedDocument;
+    FReceivingAdviceReferencedDocument: TZUGFeRDReceivingAdviceReferencedDocument;
     FInvoicer: TZUGFeRDParty;
     FInvoicerContact: TZUGFeRDContact;
     FSellerReferenceNo: String;
+    procedure SetReceivingAdviceReferencedDocumentValue(const value: TZUGFeRDReceivingAdviceReferencedDocument);
   public
     /// <summary>
     /// Invoice Number
@@ -186,6 +189,11 @@ type
     /// Detailed information about the corresponding despatch advice
     /// </summary>
     property DespatchAdviceReferencedDocument : TZUGFeRDDespatchAdviceReferencedDocument read FDespatchAdviceReferencedDocument write FDespatchAdviceReferencedDocument;
+
+    /// <summary>
+    /// Detailed information about the corresponding receiving advice
+    /// </summary>
+    property ReceivingAdviceReferencedDocument: TZUGFeRDReceivingAdviceReferencedDocument read FReceivingAdviceReferencedDocument write SetReceivingAdviceReferencedDocumentValue;
 
     /// <summary>
     /// Detailed information about the corresponding delivery note
@@ -725,6 +733,13 @@ type
     procedure SetDespatchAdviceReferencedDocument(despatchAdviceNo : String; despatchAdviceDate: IZUGFeRDNullableParam<TDateTime> = Nil);
 
     /// <summary>
+    /// Sets detailed information about the corresponding receiving advice
+    /// </summary>
+    /// <param name="receivingAdviceNo"></param>
+    /// <param name="receivingAdviceDate"></param>
+    procedure SetReceivingAdviceReferencedDocument(const receivingAdviceNo: string; receivingAdviceDate: IZUGFeRDNullableParam<TDateTime> = Nil);
+
+    /// <summary>
     /// Sets detailed information about the corresponding delivery note
     /// </summary>
     /// <param name="deliveryNoteNo"></param>
@@ -1126,6 +1141,7 @@ constructor TZUGFeRDInvoiceDescriptor.Create;
 begin
   FAdditionalReferencedDocuments := TObjectList<TZUGFeRDAdditionalReferencedDocument>.Create;
   FDespatchAdviceReferencedDocument := nil;
+  FReceivingAdviceReferencedDocument := nil;
   FDeliveryNoteReferencedDocument:= nil;//TZUGFeRDDeliveryNoteReferencedDocument.Create;
   FContractReferencedDocument    := nil;//TZUGFeRDContractReferencedDocument.Create;
   FSpecifiedProcuringProject     := nil;//TZUGFeRDSpecifiedProcuringProject.Create;
@@ -1170,6 +1186,7 @@ destructor TZUGFeRDInvoiceDescriptor.Destroy;
 begin
   if Assigned(FAdditionalReferencedDocuments ) then begin FAdditionalReferencedDocuments.Free; FAdditionalReferencedDocuments  := nil; end;
   if Assigned(FDespatchAdviceReferencedDocument) then begin FDespatchAdviceReferencedDocument.Free; FDespatchAdviceReferencedDocument := nil; end;
+  if Assigned(FReceivingAdviceReferencedDocument) then begin FReceivingAdviceReferencedDocument.Free; FReceivingAdviceReferencedDocument := nil; end;
   if Assigned(FDeliveryNoteReferencedDocument) then begin FDeliveryNoteReferencedDocument.Free; FDeliveryNoteReferencedDocument := nil; end;
   if Assigned(FContractReferencedDocument    ) then begin FContractReferencedDocument.Free; FContractReferencedDocument := nil; end;
   if Assigned(FSpecifiedProcuringProject     ) then begin FSpecifiedProcuringProject.Free; FSpecifiedProcuringProject := nil; end;
@@ -1650,6 +1667,25 @@ begin
     FDespatchAdviceReferencedDocument := TZUGFeRDDespatchAdviceReferencedDocument.Create;
   FDespatchAdviceReferencedDocument.ID := despatchAdviceNo;
   FDespatchAdviceReferencedDocument.IssueDateTime:= despatchAdviceDate;
+end;
+
+procedure TZUGFeRDInvoiceDescriptor.SetReceivingAdviceReferencedDocument(
+  const receivingAdviceNo: string; receivingAdviceDate: IZUGFeRDNullableParam<TDateTime> = Nil);
+begin
+  if FReceivingAdviceReferencedDocument = nil then
+    FReceivingAdviceReferencedDocument := TZUGFeRDReceivingAdviceReferencedDocument.Create;
+  FReceivingAdviceReferencedDocument.ID := receivingAdviceNo;
+  FReceivingAdviceReferencedDocument.IssueDateTime := receivingAdviceDate;
+end;
+
+procedure TZUGFeRDInvoiceDescriptor.SetReceivingAdviceReferencedDocumentValue(
+  const value: TZUGFeRDReceivingAdviceReferencedDocument);
+begin
+  if FReceivingAdviceReferencedDocument = value then
+    Exit;
+
+  FReceivingAdviceReferencedDocument.Free;
+  FReceivingAdviceReferencedDocument := value;
 end;
 
 procedure TZUGFeRDInvoiceDescriptor.SetContractReferencedDocument(const contractNo: string; const contractDate: TDateTime);

--- a/intf.ZUGFeRDInvoiceDescriptor20Reader.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor20Reader.pas
@@ -41,6 +41,7 @@ uses
   ,intf.ZUGFeRDAdditionalReferencedDocumentTypeCodes
   ,intf.ZUGFeRDReferenceTypeCodes
   ,intf.ZUGFeRDDeliveryNoteReferencedDocument
+  ,intf.ZUGFeRDReceivingAdviceReferencedDocument
   ,intf.ZUGFeRDCurrencyCodes
   ,intf.ZUGFeRDPaymentMeans,intf.ZUGFeRDPaymentMeansTypeCodes
   ,intf.ZUGFeRDFinancialCard
@@ -256,6 +257,15 @@ begin
 
   Result.ShipFrom := _nodeAsParty(doc.DocumentElement, '//ram:ApplicableHeaderTradeDelivery/ram:ShipFromTradeParty');
   Result.ActualDeliveryDate:= TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableHeaderTradeDelivery/ram:ActualDeliverySupplyChainEvent/ram:OccurrenceDateTime/udt:DateTimeString');
+
+  var _receivingAdviceNo : String := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableHeaderTradeDelivery/ram:ReceivingAdviceReferencedDocument/ram:IssuerAssignedID');
+  var _receivingAdviceDate : ZUGFeRDNullable<TDateTime> := TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableHeaderTradeDelivery/ram:ReceivingAdviceReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString');
+
+  if Not(_receivingAdviceDate.HasValue) then
+    _receivingAdviceDate := TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableHeaderTradeDelivery/ram:ReceivingAdviceReferencedDocument/ram:FormattedIssueDateTime');
+
+  if _receivingAdviceDate.HasValue or (_receivingAdviceNo <> '') then
+    Result.SetReceivingAdviceReferencedDocument(_receivingAdviceNo, _receivingAdviceDate);
 
   var _deliveryNoteNo : String := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableHeaderTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssuerAssignedID');
   var _deliveryNoteDate : ZUGFeRDNullable<TDateTime> := TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableHeaderTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssueDateTime/udt:DateTimeString');

--- a/intf.ZUGFeRDInvoiceDescriptor20Writer.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor20Writer.pas
@@ -624,6 +624,26 @@ if (Descriptor.Profile = TZUGFeRDProfile.Extended) then
     Writer.WriteEndElement(); // !ActualDeliverySupplyChainEvent
   end;
 
+  //#region ReceivingAdviceReferencedDocument
+  if Descriptor.ReceivingAdviceReferencedDocument <> nil then
+  begin
+    Writer.WriteStartElement('ram:ReceivingAdviceReferencedDocument', PROFILE_COMFORT_EXTENDED_XRECHNUNG);
+    Writer.WriteElementString('ram:IssuerAssignedID', Descriptor.ReceivingAdviceReferencedDocument.ID);
+
+    if Descriptor.ReceivingAdviceReferencedDocument.IssueDateTime.HasValue then
+    begin
+      Writer.WriteStartElement('ram:FormattedIssueDateTime', [TZUGFeRDProfile.Extended]);
+      Writer.WriteStartElement('qdt:DateTimeString');
+      Writer.WriteAttributeString('format', '102');
+      Writer.WriteValue(_formatDate(Descriptor.ReceivingAdviceReferencedDocument.IssueDateTime.Value));
+      Writer.WriteEndElement(); // !qdt:DateTimeString
+      Writer.WriteEndElement(); // !ram:FormattedIssueDateTime
+    end;
+
+    Writer.WriteEndElement(); // !ReceivingAdviceReferencedDocument
+  end;
+  //#endregion
+
   if (Descriptor.DeliveryNoteReferencedDocument <> nil) then
   begin
     Writer.WriteStartElement('ram:DeliveryNoteReferencedDocument');

--- a/intf.ZUGFeRDInvoiceDescriptor22UBLWriter.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor22UBLWriter.pas
@@ -277,6 +277,14 @@ begin
     Writer.WriteEndElement; // !DespatchDocumentReference
   end;
 
+  // ReceiptDocumentReference (BT-15)
+  if Descriptor.ReceivingAdviceReferencedDocument <> nil then
+  begin
+    Writer.WriteStartElement('cac:ReceiptDocumentReference');
+    Writer.WriteOptionalElementString('cbc:ID', Descriptor.ReceivingAdviceReferencedDocument.ID);
+    Writer.WriteEndElement; // !ReceiptDocumentReference
+  end;
+
   // ContractDocumentReference
   if Descriptor.ContractReferencedDocument <> nil then
   begin

--- a/intf.ZUGFeRDInvoiceDescriptor22UblReader.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor22UblReader.pas
@@ -46,6 +46,7 @@ uses
   ,intf.ZUGFeRDReferenceTypeCodes
   ,intf.ZUGFeRDDeliveryNoteReferencedDocument
   ,intf.ZUGFeRDDespatchAdviceReferencedDocument
+  ,intf.ZUGFeRDReceivingAdviceReferencedDocument
   ,intf.ZUGFeRDCurrencyCodes
   ,intf.ZUGFeRDPaymentMeans
   ,intf.ZUGFeRDPaymentMeansTypeCodes
@@ -476,6 +477,11 @@ begin
   node := baseNode.selectSingleNode('cac:DespatchDocumentReference/cbc:ID');
   if node <> nil then
     Result.SetDespatchAdviceReferencedDocument(node.text);
+
+  // Receiving Advice Reference (BT-15)
+  node := baseNode.selectSingleNode('cac:ReceiptDocumentReference/cbc:ID');
+  if node <> nil then
+    Result.SetReceivingAdviceReferencedDocument(node.text);
 
   // Payment Terms
   Result.AddTradePaymentTerms(

--- a/intf.ZUGFeRDInvoiceDescriptor23CIIReader.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor23CIIReader.pas
@@ -66,6 +66,7 @@ uses
   ,intf.ZUGFeRDNote
   ,intf.ZUGFeRDContentCodes
   ,intf.ZUGFeRDDespatchAdviceReferencedDocument
+  ,intf.ZUGFeRDReceivingAdviceReferencedDocument
   ,intf.ZUGFeRDDesignatedProductClassificationClassCodes
   ,intf.ZUGFeRDXmlUtils
   ,intf.ZUGFeRDIncludedReferencedProduct
@@ -388,6 +389,15 @@ begin
     Result.DespatchAdviceReferencedDocument.ID := _despatchAdviceNo;
     Result.DespatchAdviceReferencedDocument.IssueDateTime := _despatchAdviceDate
   end;
+
+  var _receivingAdviceNo : String := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableHeaderTradeDelivery/ram:ReceivingAdviceReferencedDocument/ram:IssuerAssignedID');
+  var _receivingAdviceDate : ZUGFeRDNullable<TDateTime> := TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableHeaderTradeDelivery/ram:ReceivingAdviceReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString');
+
+  if Not(_receivingAdviceDate.HasValue) then
+    _receivingAdviceDate := TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableHeaderTradeDelivery/ram:ReceivingAdviceReferencedDocument/ram:FormattedIssueDateTime');
+
+  if _receivingAdviceDate.HasValue or (_receivingAdviceNo <> '') then
+    Result.SetReceivingAdviceReferencedDocument(_receivingAdviceNo, _receivingAdviceDate);
 
   var _deliveryNoteNo : String := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableHeaderTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssuerAssignedID');
   var _deliveryNoteDate : ZUGFeRDNullable<TDateTime> := TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableHeaderTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:FormattedIssueDateTime/udt:DateTimeString');

--- a/intf.ZUGFeRDInvoiceDescriptor23CIIWriter.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor23CIIWriter.pas
@@ -860,7 +860,25 @@ begin
   end;
   //#endregion
 
-  // TODO: ReceivingAdviceReferencedDocument+IssuerAssignedID for [TZUGFeRDProfile.Extended, TZUGFeRDProfile.XRechnung1, TZUGFeRDProfile.XRechnung]
+  //#region ReceivingAdviceReferencedDocument
+  if Descriptor.ReceivingAdviceReferencedDocument <> nil then
+  begin
+    Writer.WriteStartElement('ram:ReceivingAdviceReferencedDocument', PROFILE_COMFORT_EXTENDED_XRECHNUNG);
+    Writer.WriteElementString('ram:IssuerAssignedID', Descriptor.ReceivingAdviceReferencedDocument.ID);
+
+    if Descriptor.ReceivingAdviceReferencedDocument.IssueDateTime.HasValue then
+    begin
+      Writer.WriteStartElement('ram:FormattedIssueDateTime', [TZUGFeRDProfile.Extended]);
+      Writer.WriteStartElement('qdt:DateTimeString');
+      Writer.WriteAttributeString('format', '102');
+      Writer.WriteValue(_formatDate(Descriptor.ReceivingAdviceReferencedDocument.IssueDateTime.Value));
+      Writer.WriteEndElement(); // !qdt:DateTimeString
+      Writer.WriteEndElement(); // !ram:FormattedIssueDateTime
+    end;
+
+    Writer.WriteEndElement(); // !ReceivingAdviceReferencedDocument
+  end;
+  //#endregion
 
   //#region DeliveryNoteReferencedDocument
   if Descriptor.DeliveryNoteReferencedDocument <> nil then

--- a/intf.ZUGFeRDReceivingAdviceReferencedDocument.pas
+++ b/intf.ZUGFeRDReceivingAdviceReferencedDocument.pas
@@ -1,0 +1,35 @@
+{* Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.}
+
+unit intf.ZUGFeRDReceivingAdviceReferencedDocument;
+
+interface
+
+uses
+  intf.ZUGFeRDBaseReferencedDocument;
+
+type
+  /// <summary>
+  /// Structure containing detailed information about the corresponding receiving advice
+  /// </summary>
+  TZUGFeRDReceivingAdviceReferencedDocument = class(TZUGFeRDBaseReferencedDocument)
+  public
+  end;
+
+implementation
+
+end.


### PR DESCRIPTION
## Summary
- add `TZUGFeRDReceivingAdviceReferencedDocument` and the corresponding `InvoiceDescriptor` API for EN 16931 BT-15
- read and write `ReceivingAdviceReferencedDocument` in CII 2.0 and CII 2.3 with profile-specific date handling and schema-compliant element ordering
- map the same reference to UBL `cac:ReceiptDocumentReference/cbc:ID` without writing a CII-only issue date
- add CII 2.0, CII 2.3, profile-boundary, ordering, and UBL round-trip tests

## Specification references
- [Peppol BIS: Despatch and receipt advice references](https://docs.peppol.eu/poacc/billing/3.0/bis/#_despatch_and_receipt_advice_references)
- [Peppol UBL syntax: ReceiptDocumentReference](https://docs.peppol.eu/poacc/billing/3.0/2022-Q4/syntax/ubl-invoice/cac-ReceiptDocumentReference/)

## Validation
- Win64 Debug build succeeds
- DUnitX: 350 tests passed, 0 failed, 0 errors