### PR TITLE
Fix EN 16931 totals validation and tighten the documentation sweep

### DIFF
--- a/Unittest/intf.ZUGFeRDCrossVersionTests.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRDCrossVersionTests.UnitTests.pas
@@ -2417,7 +2417,7 @@ begin
       LoadedInvoice := TZUGFeRDInvoiceDescriptor.Load(ModifiedStream);
       try
         Assert.AreEqual(ExpectedInvoiceNo, LoadedInvoice.InvoiceNo, 'Invoice number must be read independently of document prefixes');
-        Assert.AreEqual(ExpectedLineItemCount, LoadedInvoice.TradeLineItems.Count, 'Line items must be read independently of document prefixes');
+        Assert.AreEqual(ExpectedLineItemCount, Integer(LoadedInvoice.TradeLineItems.Count), 'Line items must be read independently of document prefixes');
         Assert.AreEqual<Currency>(Desc.TaxTotalAmount.Value, LoadedInvoice.TaxTotalAmount.Value,
           'Tax total must be read independently of document prefixes');
       finally
@@ -2515,7 +2515,7 @@ begin
     try
       LoadedInvoice := TZUGFeRDInvoiceDescriptor.Load(ModifiedStream);
       try
-        Assert.AreEqual(0, LoadedInvoice.TradeLineItems.Count,
+        Assert.AreEqual(0, Integer(LoadedInvoice.TradeLineItems.Count),
           'Elements from a different namespace URI must not be treated as ram elements');
         Assert.IsFalse(LoadedInvoice.TaxTotalAmount.HasValue,
           'Amounts from a different namespace URI must not be treated as ram amounts');

--- a/Unittest/intf.ZUGFeRDCrossVersionTests.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRDCrossVersionTests.UnitTests.pas
@@ -2201,6 +2201,8 @@ begin
         'Two TaxTotalAmount elements expected when TaxCurrency differs from Currency');
       Assert.IsTrue(Pos('currencyID="CHF"', xmlContent) > 0,
         'BT-111 element with accounting currencyID="CHF" must be present');
+      Assert.AreEqual(1, _CountSubstring(xmlContent, '<ram:TaxCurrencyCode'),
+        'BT-6 must be written when TaxCurrency differs from Currency');
 
       // Verify round-trip
       ms.Position := 0;
@@ -2248,6 +2250,9 @@ begin
 
       Assert.AreEqual(1, _CountSubstring(xmlContent, '<ram:TaxTotalAmount'),
         'Only BT-110 expected when TaxCurrency equals Currency');
+      // BR-53: ohne BT-111 darf auch kein BT-6 geschrieben werden.
+      Assert.AreEqual(0, _CountSubstring(xmlContent, '<ram:TaxCurrencyCode'),
+        'No BT-6 expected when TaxCurrency equals Currency');
     finally
       ms.Free;
     end;
@@ -2289,6 +2294,9 @@ begin
 
       TaxTotalNodes := XmlDoc.selectNodes('/*/cac:TaxTotal');
       Assert.AreEqual(2, TaxTotalNodes.length, 'Two TaxTotal groups expected for BT-110 and BT-111');
+
+      Assert.AreEqual(1, XmlDoc.selectNodes('/*/cbc:TaxCurrencyCode').length,
+        'BT-6 must be written when accounting currency differs from invoice currency');
 
       Bt110Node := XmlDoc.selectSingleNode('/*/cac:TaxTotal[cbc:TaxAmount/@currencyID="EUR"]');
       Assert.IsNotNull(Bt110Node, 'BT-110 TaxTotal in invoice currency must be present');
@@ -2351,10 +2359,14 @@ begin
       Assert.IsTrue(XmlDoc.loadXML(XmlContent), 'The generated UBL invoice must be valid XML');
       XmlDoc.setProperty('SelectionLanguage', 'XPath');
       XmlDoc.setProperty('SelectionNamespaces',
-        'xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"');
+        'xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" ' +
+        'xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"');
 
       Assert.AreEqual(1, XmlDoc.selectNodes('/*/cac:TaxTotal').length,
         'Only BT-110 expected when accounting currency equals invoice currency');
+      // BR-53: ein BT-6 ohne zugehoeriges BT-111 waere ungueltig.
+      Assert.AreEqual(0, XmlDoc.selectNodes('/*/cbc:TaxCurrencyCode').length,
+        'No BT-6 expected when accounting currency equals invoice currency');
     finally
       InvoiceStream.Free;
     end;

--- a/Unittest/intf.ZUGFeRDCrossVersionTests.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRDCrossVersionTests.UnitTests.pas
@@ -2364,7 +2364,7 @@ begin
 
       Assert.AreEqual(1, XmlDoc.selectNodes('/*/cac:TaxTotal').length,
         'Only BT-110 expected when accounting currency equals invoice currency');
-      // BR-53: ein BT-6 ohne zugehoeriges BT-111 waere ungueltig.
+      // BR-53: ein BT-6 ohne zugehöriges BT-111 wäre ungültig.
       Assert.AreEqual(0, XmlDoc.selectNodes('/*/cbc:TaxCurrencyCode').length,
         'No BT-6 expected when accounting currency equals invoice currency');
     finally

--- a/Unittest/intf.ZUGFeRDDocumentationSweep.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRDDocumentationSweep.UnitTests.pas
@@ -171,7 +171,7 @@ begin
           Continue;
         end;
 
-        // MINIMUM und BASIC-WL fuehren keine Positionen, alle uebrigen Profile schon.
+        // MINIMUM und BASIC-WL führen keine Positionen, alle übrigen Profile schon.
         if not (desc.Profile in [TZUGFeRDProfile.Minimum, TZUGFeRDProfile.BasicWL]) and
            (desc.TradeLineItems.Count = 0) then
         begin
@@ -221,7 +221,7 @@ begin
                 [rel, reloaded.TradeLineItems.Count, desc.TradeLineItems.Count]));
 
             if reloaded.Currency <> desc.Currency then
-              errors.Add(Format('%s: Waehrung nach Roundtrip [%s] statt [%s]',
+              errors.Add(Format('%s: Währung nach Roundtrip [%s] statt [%s]',
                 [rel,
                  TEnumExtensions<TZUGFeRDCurrencyCodes>.EnumToString(reloaded.Currency),
                  TEnumExtensions<TZUGFeRDCurrencyCodes>.EnumToString(desc.Currency)]));

--- a/Unittest/intf.ZUGFeRDDocumentationSweep.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRDDocumentationSweep.UnitTests.pas
@@ -21,8 +21,12 @@ unit intf.ZUGFeRDDocumentationSweep.UnitTests;
 /// Lädt sämtliche Beispielrechnungen aus documentation\ und prüft, dass die
 /// Bibliothek sie einlesen, das Profil erkennen und wieder herausschreiben kann.
 ///
-/// Das ist ein Regressionsnetz, kein fachlicher Test: Geprüft wird nur, dass
-/// nichts ausfällt. Konkrete Feldwerte prüfen die übrigen Testunits.
+/// Das ist ein Regressionsnetz, kein fachlicher Test: Konkrete Feldwerte prüfen
+/// die übrigen Testunits. Geprüft wird hier, dass das Lesen überhaupt Daten
+/// liefert und dass diese Daten einen Schreib-/Lesezyklus überstehen. Ein reiner
+/// Ausfalltest wäre wirkungslos: ein Reader, der sämtliche Positionen verliert,
+/// liest die Guideline weiterhin und der Writer schreibt das leere Dokument
+/// anstandslos heraus.
 ///
 /// Jeder registrierte Dokumentationsstand benötigt eingecheckte Beispieldateien.
 /// Fehlende Verzeichnisse oder XML-Beispiele lassen den Test fehlschlagen, damit
@@ -71,6 +75,8 @@ implementation
 uses
   System.SysUtils, System.StrUtils, System.Classes, System.IOUtils, System.Types,
   intf.ZUGFeRDInvoiceDescriptor,
+  intf.ZUGFeRDCurrencyCodes,
+  intf.ZUGFeRDHelper,
   intf.ZUGFeRDProfile,
   intf.ZUGFeRDVersion,
   intf.ZUGFeRDFormats;
@@ -118,7 +124,7 @@ procedure TZUGFeRDDocumentationSweepTests.SweepDocumentationVersion(
 var
   files: TArray<string>;
   root, fn, rel: string;
-  desc: TZUGFeRDInvoiceDescriptor;
+  desc, reloaded: TZUGFeRDInvoiceDescriptor;
   ms: TMemoryStream;
   errors: TStringList;
   checked: Integer;
@@ -157,14 +163,79 @@ begin
           Continue;
         end;
 
-        // Zurückschreiben im erkannten Profil muss ohne Fehler durchlaufen
+        // BT-1 ist in jedem Profil eine Pflichtangabe. Eine leere Rechnungsnummer
+        // ist der deutlichste Hinweis darauf, dass gar nichts gelesen wurde.
+        if desc.InvoiceNo.Trim = '' then
+        begin
+          errors.Add(Format('%s: Keine Rechnungsnummer gelesen', [rel]));
+          Continue;
+        end;
+
+        // MINIMUM und BASIC-WL fuehren keine Positionen, alle uebrigen Profile schon.
+        if not (desc.Profile in [TZUGFeRDProfile.Minimum, TZUGFeRDProfile.BasicWL]) and
+           (desc.TradeLineItems.Count = 0) then
+        begin
+          errors.Add(Format('%s: Keine Rechnungspositionen gelesen (Profil %s)',
+            [rel, TZUGFeRDProfileExtensions.EnumToString(desc.Profile, TZUGFeRDVersion.Version23)]));
+          Continue;
+        end;
+
+        // Zurückschreiben im erkannten Profil muss ohne Fehler durchlaufen und ein
+        // wieder lesbares Dokument mit denselben Kerndaten ergeben.
         ms := TMemoryStream.Create;
         try
           try
             desc.Save(ms, TZUGFeRDVersion.Version23, desc.Profile, TZUGFeRDFormats.CII);
           except
             on E: Exception do
+            begin
               errors.Add(Format('%s: Schreiben fehlgeschlagen - %s: %s', [rel, E.ClassName, E.Message]));
+              Continue;
+            end;
+          end;
+
+          if ms.Size = 0 then
+          begin
+            errors.Add(Format('%s: Schreiben liefert ein leeres Dokument', [rel]));
+            Continue;
+          end;
+
+          ms.Position := 0;
+          try
+            reloaded := TZUGFeRDInvoiceDescriptor.Load(ms);
+          except
+            on E: Exception do
+            begin
+              errors.Add(Format('%s: Erneutes Lesen fehlgeschlagen - %s: %s', [rel, E.ClassName, E.Message]));
+              Continue;
+            end;
+          end;
+
+          try
+            if reloaded.InvoiceNo <> desc.InvoiceNo then
+              errors.Add(Format('%s: Rechnungsnummer nach Roundtrip [%s] statt [%s]',
+                [rel, reloaded.InvoiceNo, desc.InvoiceNo]));
+
+            if reloaded.TradeLineItems.Count <> desc.TradeLineItems.Count then
+              errors.Add(Format('%s: %d statt %d Rechnungspositionen nach Roundtrip',
+                [rel, reloaded.TradeLineItems.Count, desc.TradeLineItems.Count]));
+
+            if reloaded.Currency <> desc.Currency then
+              errors.Add(Format('%s: Waehrung nach Roundtrip [%s] statt [%s]',
+                [rel,
+                 TEnumExtensions<TZUGFeRDCurrencyCodes>.EnumToString(reloaded.Currency),
+                 TEnumExtensions<TZUGFeRDCurrencyCodes>.EnumToString(desc.Currency)]));
+
+            if desc.GrandTotalAmount.HasValue then
+            begin
+              if not reloaded.GrandTotalAmount.HasValue then
+                errors.Add(Format('%s: BT-112 nach Roundtrip nicht mehr vorhanden', [rel]))
+              else if reloaded.GrandTotalAmount.Value <> desc.GrandTotalAmount.Value then
+                errors.Add(Format('%s: BT-112 nach Roundtrip [%s] statt [%s]',
+                  [rel, CurrToStr(reloaded.GrandTotalAmount.Value), CurrToStr(desc.GrandTotalAmount.Value)]));
+            end;
+          finally
+            reloaded.Free;
           end;
         finally
           ms.Free;

--- a/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
@@ -92,6 +92,14 @@ type
     [Test]
     procedure TestInvalidTaxBasisAmountIsReported;
     [Test]
+    procedure TestConsistentlyWrongTaxBasisIsReported;
+    [Test]
+    procedure TestDeclaredAllowanceTotalDeviationIsReported;
+    [Test]
+    procedure TestDeclaredChargeTotalDeviationIsReported;
+    [Test]
+    procedure TestMissingLineTotalAmountIsReported;
+    [Test]
     procedure TestValidationDoesNotRaiseOnDeviation;
   end;
 
@@ -679,6 +687,148 @@ begin
       'Der Validator wirft eine Exception, statt die Abweichung zu melden');
     try
       Assert.IsFalse(validationResult.IsValid);
+    finally
+      validationResult.Free;
+    end;
+  finally
+    desc.Free;
+  end;
+end;
+
+/// <summary>
+/// BR-CO-13: BT-109 muss sich aus BT-106 - BT-107 + BT-108 ergeben. Stimmen BT-109
+/// und die Steueraufschluesselung (BT-116) untereinander ueberein, weichen aber
+/// gemeinsam vom Positionsnetto ab, greift keine der uebrigen Pruefungen: die
+/// Bruttosumme wird aus dem nachgerechneten Positionsnetto gebildet und passt
+/// dann ebenfalls.
+/// </summary>
+procedure TZUGFeRDInvoiceValidatorTests.TestConsistentlyWrongTaxBasisIsReported;
+var
+  desc: TZUGFeRDInvoiceDescriptor;
+  validationResult: TZUGFeRDValidationResult;
+begin
+  desc := TZUGFeRDInvoiceDescriptor.CreateInvoice('RE-4711', EncodeDate(2026, 1, 15),
+    TZUGFeRDCurrencyCodes.EUR);
+  try
+    desc.AddTradeLineItem(
+      {name=}            'Testartikel',
+      {netUnitPrice=}    TZUGFeRDNullableParam<Currency>.Create(100),
+      {description=}     '',
+      {unitCode=}        TZUGFeRDNullableParam<TZUGFeRDQuantityCodes>.Create(TZUGFeRDQuantityCodes.H87),
+      {unitQuantity=}    nil,
+      {grossUnitPrice=}  nil,
+      {billedQuantity=}  2,
+      {lineTotalAmount=} 200,
+      {taxType=}         TZUGFeRDNullableParam<TZUGFeRDTaxTypes>.Create(TZUGFeRDTaxTypes.VAT),
+      {categoryCode=}    TZUGFeRDNullableParam<TZUGFeRDTaxCategoryCodes>.Create(TZUGFeRDTaxCategoryCodes.S),
+      {taxPercent=}      19.0);
+
+    // BT-116 und BT-109 sind zueinander konsistent, aber um 10,00 zu niedrig.
+    desc.AddApplicableTradeTax({calculatedAmount=} 36.10, {basisAmount=} 190,
+      {percent=} 19.0, TZUGFeRDTaxTypes.VAT, TZUGFeRDTaxCategoryCodes.S);
+
+    // BT-112 passt zur Nachrechnung aus BT-106 und BT-110, nicht zu BT-109.
+    desc.SetTotals(
+      {aLineTotalAmount=}      200,
+      {aChargeTotalAmount=}    0,
+      {aAllowanceTotalAmount=} 0,
+      {aTaxBasisAmount=}       190,
+      {aTaxTotalAmount=}       36.10,
+      {aGrandTotalAmount=}     236.10,
+      {aTotalPrepaidAmount=}   0,
+      {aDuePayableAmount=}     236.10);
+
+    validationResult := TZUGFeRDInvoiceValidator.Validate(desc, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsFalse(validationResult.IsValid,
+        'Ein von BT-106 abweichendes BT-109 wurde nicht beanstandet:'#13#10 +
+        validationResult.Messages.Text);
+      Assert.IsTrue(Pos('BR-CO-13', validationResult.Messages.Text) > 0,
+        'Es fehlt die Meldung zu BR-CO-13:'#13#10 + validationResult.Messages.Text);
+    finally
+      validationResult.Free;
+    end;
+  finally
+    desc.Free;
+  end;
+end;
+
+/// <summary>
+/// BR-CO-11: BT-107 muss der Summe der einzelnen Kopfabschlaege (BT-92) entsprechen.
+/// </summary>
+procedure TZUGFeRDInvoiceValidatorTests.TestDeclaredAllowanceTotalDeviationIsReported;
+var
+  desc: TZUGFeRDInvoiceDescriptor;
+  validationResult: TZUGFeRDValidationResult;
+begin
+  desc := CreateBalancedInvoice(False);
+  try
+    // Kopfabschlaege gibt es keine, BT-107 behauptet aber 15,00.
+    desc.AllowanceTotalAmount := 15;
+
+    validationResult := TZUGFeRDInvoiceValidator.Validate(desc, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsFalse(validationResult.IsValid,
+        'Ein BT-107 ohne zugehoerige Kopfabschlaege wurde nicht beanstandet:'#13#10 +
+        validationResult.Messages.Text);
+      Assert.IsTrue(Pos('BR-CO-11', validationResult.Messages.Text) > 0,
+        'Es fehlt die Meldung zu BR-CO-11:'#13#10 + validationResult.Messages.Text);
+    finally
+      validationResult.Free;
+    end;
+  finally
+    desc.Free;
+  end;
+end;
+
+/// <summary>
+/// BR-CO-12: BT-108 muss der Summe der einzelnen Kopfzuschlaege (BT-99) entsprechen.
+/// </summary>
+procedure TZUGFeRDInvoiceValidatorTests.TestDeclaredChargeTotalDeviationIsReported;
+var
+  desc: TZUGFeRDInvoiceDescriptor;
+  validationResult: TZUGFeRDValidationResult;
+begin
+  desc := CreateBalancedInvoice(True);
+  try
+    // Der einzige Kopfzuschlag betraegt 10,00, BT-108 behauptet 20,00.
+    desc.ChargeTotalAmount := 20;
+
+    validationResult := TZUGFeRDInvoiceValidator.Validate(desc, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsFalse(validationResult.IsValid,
+        'Ein von den Kopfzuschlaegen abweichendes BT-108 wurde nicht beanstandet:'#13#10 +
+        validationResult.Messages.Text);
+      Assert.IsTrue(Pos('BR-CO-12', validationResult.Messages.Text) > 0,
+        'Es fehlt die Meldung zu BR-CO-12:'#13#10 + validationResult.Messages.Text);
+    finally
+      validationResult.Free;
+    end;
+  finally
+    desc.Free;
+  end;
+end;
+
+/// <summary>
+/// Ein fehlendes BT-106 darf nicht stillschweigend als 0 gegen die Nachrechnung
+/// gestellt werden, sondern muss als fehlende Pflichtangabe gemeldet werden.
+/// </summary>
+procedure TZUGFeRDInvoiceValidatorTests.TestMissingLineTotalAmountIsReported;
+var
+  desc: TZUGFeRDInvoiceDescriptor;
+  validationResult: TZUGFeRDValidationResult;
+begin
+  desc := CreateBalancedInvoice(False);
+  try
+    desc.LineTotalAmount := nil;
+
+    validationResult := TZUGFeRDInvoiceValidator.Validate(desc, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsFalse(validationResult.IsValid,
+        'Ein fehlendes BT-106 wurde nicht beanstandet:'#13#10 +
+        validationResult.Messages.Text);
+      Assert.IsTrue(Pos('Kein LineTotalAmount vorhanden', validationResult.Messages.Text) > 0,
+        'Es fehlt die Meldung zum fehlenden BT-106:'#13#10 + validationResult.Messages.Text);
     finally
       validationResult.Free;
     end;

--- a/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
@@ -42,6 +42,11 @@ type
     /// Zu- und Abschlägen, Vorauszahlung und Rundung. Die Summen im Descriptor
     /// sind passend gesetzt, der Validator muss die Rechnung also als gueltig ansehen.
     /// </summary>
+    /// <summary>
+    /// Baut eine Rechnung, deren Nettoeinzelpreis sich auf eine Preisbasismenge
+    /// bezieht (BT-149).
+    /// </summary>
+    function CreateInvoiceWithPriceBaseQuantity(const unitQuantity: Currency): TZUGFeRDInvoiceDescriptor;
     function CreateBalancedInvoice(const withCharge: Boolean;
       const lineAllowance: Currency = 0; const lineCharge: Currency = 0;
       const prepaidAmount: Currency = 0; const roundingAmount: Currency = 0): TZUGFeRDInvoiceDescriptor;
@@ -91,6 +96,10 @@ type
     procedure TestMissingTaxBasisAmountIsReported;
     [Test]
     procedure TestInvalidTaxBasisAmountIsReported;
+    [Test]
+    procedure TestPriceBaseQuantityIsApplied;
+    [Test]
+    procedure TestZeroPriceBaseQuantityIsReported;
     [Test]
     procedure TestConsistentlyWrongTaxBasisIsReported;
     [Test]
@@ -829,6 +838,94 @@ begin
         validationResult.Messages.Text);
       Assert.IsTrue(Pos('Kein LineTotalAmount vorhanden', validationResult.Messages.Text) > 0,
         'Es fehlt die Meldung zum fehlenden BT-106:'#13#10 + validationResult.Messages.Text);
+    finally
+      validationResult.Free;
+    end;
+  finally
+    desc.Free;
+  end;
+end;
+
+/// <summary>
+/// Baut eine ausgeglichene Rechnung, deren Nettoeinzelpreis BT-146 sich auf eine
+/// Preisbasismenge BT-149 bezieht: 100,00 je 10 Stueck bei 2 berechneten Stueck
+/// ergibt einen Positionsnettobetrag BT-131 von 20,00.
+/// </summary>
+function TZUGFeRDInvoiceValidatorTests.CreateInvoiceWithPriceBaseQuantity(
+  const unitQuantity: Currency): TZUGFeRDInvoiceDescriptor;
+begin
+  Result := TZUGFeRDInvoiceDescriptor.CreateInvoice('RE-4711', EncodeDate(2026, 1, 15),
+    TZUGFeRDCurrencyCodes.EUR);
+
+  Result.AddTradeLineItem(
+    {name=}            'Testartikel',
+    {netUnitPrice=}    TZUGFeRDNullableParam<Currency>.Create(100),
+    {description=}     '',
+    {unitCode=}        TZUGFeRDNullableParam<TZUGFeRDQuantityCodes>.Create(TZUGFeRDQuantityCodes.H87),
+    {unitQuantity=}    TZUGFeRDNullableParam<Currency>.Create(unitQuantity),
+    {grossUnitPrice=}  nil,
+    {billedQuantity=}  2,
+    {lineTotalAmount=} 20,
+    {taxType=}         TZUGFeRDNullableParam<TZUGFeRDTaxTypes>.Create(TZUGFeRDTaxTypes.VAT),
+    {categoryCode=}    TZUGFeRDNullableParam<TZUGFeRDTaxCategoryCodes>.Create(TZUGFeRDTaxCategoryCodes.S),
+    {taxPercent=}      19.0);
+
+  Result.AddApplicableTradeTax({calculatedAmount=} 3.80, {basisAmount=} 20,
+    {percent=} 19.0, TZUGFeRDTaxTypes.VAT, TZUGFeRDTaxCategoryCodes.S);
+
+  Result.SetTotals(
+    {aLineTotalAmount=}      20,
+    {aChargeTotalAmount=}    0,
+    {aAllowanceTotalAmount=} 0,
+    {aTaxBasisAmount=}       20,
+    {aTaxTotalAmount=}       3.80,
+    {aGrandTotalAmount=}     23.80,
+    {aTotalPrepaidAmount=}   0,
+    {aDuePayableAmount=}     23.80);
+end;
+
+/// <summary>
+/// BT-146 gilt je Preisbasismenge BT-149. Wird BT-149 ignoriert, rechnet der
+/// Validator das Zehnfache und verwirft eine gueltige Rechnung.
+/// </summary>
+procedure TZUGFeRDInvoiceValidatorTests.TestPriceBaseQuantityIsApplied;
+var
+  desc: TZUGFeRDInvoiceDescriptor;
+  validationResult: TZUGFeRDValidationResult;
+begin
+  desc := CreateInvoiceWithPriceBaseQuantity(10);
+  try
+    validationResult := TZUGFeRDInvoiceValidator.Validate(desc, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsTrue(validationResult.IsValid,
+        'Rechnung mit Preisbasismenge wurde als ungueltig gemeldet:'#13#10 +
+        validationResult.Messages.Text);
+    finally
+      validationResult.Free;
+    end;
+  finally
+    desc.Free;
+  end;
+end;
+
+/// <summary>
+/// Eine Preisbasismenge von 0 ist fachlich unzulaessig und darf nicht still
+/// uebergangen werden.
+/// </summary>
+procedure TZUGFeRDInvoiceValidatorTests.TestZeroPriceBaseQuantityIsReported;
+var
+  desc: TZUGFeRDInvoiceDescriptor;
+  validationResult: TZUGFeRDValidationResult;
+begin
+  desc := CreateInvoiceWithPriceBaseQuantity(0);
+  try
+    validationResult := TZUGFeRDInvoiceValidator.Validate(desc, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsFalse(validationResult.IsValid,
+        'Eine Preisbasismenge von 0 wurde nicht beanstandet:'#13#10 +
+        validationResult.Messages.Text);
+      Assert.IsTrue(Pos('BT-149', validationResult.Messages.Text) > 0,
+        'Es fehlt die Meldung zu BT-149:'#13#10 + validationResult.Messages.Text);
     finally
       validationResult.Free;
     end;

--- a/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
@@ -522,7 +522,7 @@ begin
     try
       Assert.IsFalse(ValidationResult.IsValid, 'Unrounded tax amount was not reported');
       // 0,0057 liegt innerhalb der BR-CO-17-Toleranz; beanstandet wird die
-      // unzulaessige Zahl der Nachkommastellen.
+      // unzulässige Zahl der Nachkommastellen.
       Assert.IsTrue(ValidationResult.Messages.Text.Contains('BR-DEC-20'),
         'Validation messages do not identify BR-DEC-20');
     finally
@@ -543,7 +543,7 @@ begin
   Descriptor := TZUGFeRDInvoiceDescriptor.CreateInvoice('RE-ROUND-CATEGORY', EncodeDate(2026, 1, 15), TZUGFeRDCurrencyCodes.EUR);
   try
     // Gegensätzliche Abweichungen dürfen sich bei gleichem Steuersatz nicht gegenseitig
-    // aufheben. Beide liegen ausserhalb der BR-CO-17-Toleranz, ihre Summe ergibt aber
+    // aufheben. Beide liegen außerhalb der BR-CO-17-Toleranz, ihre Summe ergibt aber
     // exakt den korrekten Gesamtbetrag von 14,00.
     AddTaxGroup(Descriptor, 'Standard rate', 100, 7, 9.00, TZUGFeRDTaxCategoryCodes.S);
     AddTaxGroup(Descriptor, 'Lower rate', 100, 7, 5.00, TZUGFeRDTaxCategoryCodes.AA);
@@ -714,8 +714,8 @@ end;
 
 /// <summary>
 /// BR-CO-13: BT-109 muss sich aus BT-106 - BT-107 + BT-108 ergeben. Stimmen BT-109
-/// und die Steueraufschluesselung (BT-116) untereinander ueberein, weichen aber
-/// gemeinsam vom Positionsnetto ab, greift keine der uebrigen Pruefungen: die
+/// und die Steueraufschlüsselung (BT-116) untereinander überein, weichen aber
+/// gemeinsam vom Positionsnetto ab, greift keine der übrigen Prüfungen: die
 /// Bruttosumme wird aus dem nachgerechneten Positionsnetto gebildet und passt
 /// dann ebenfalls.
 /// </summary>
@@ -771,7 +771,7 @@ begin
 end;
 
 /// <summary>
-/// BR-CO-11: BT-107 muss der Summe der einzelnen Kopfabschlaege (BT-92) entsprechen.
+/// BR-CO-11: BT-107 muss der Summe der einzelnen Kopfabschläge (BT-92) entsprechen.
 /// </summary>
 procedure TZUGFeRDInvoiceValidatorTests.TestDeclaredAllowanceTotalDeviationIsReported;
 var
@@ -780,13 +780,13 @@ var
 begin
   desc := CreateBalancedInvoice(False);
   try
-    // Kopfabschlaege gibt es keine, BT-107 behauptet aber 15,00.
+    // Kopfabschläge gibt es keine, BT-107 behauptet aber 15,00.
     desc.AllowanceTotalAmount := 15;
 
     validationResult := TZUGFeRDInvoiceValidator.Validate(desc, TZUGFeRDVersion.Version23);
     try
       Assert.IsFalse(validationResult.IsValid,
-        'Ein BT-107 ohne zugehoerige Kopfabschlaege wurde nicht beanstandet:'#13#10 +
+        'Ein BT-107 ohne zugehörige Kopfabschläge wurde nicht beanstandet:'#13#10 +
         validationResult.Messages.Text);
       Assert.IsTrue(Pos('BR-CO-11', validationResult.Messages.Text) > 0,
         'Es fehlt die Meldung zu BR-CO-11:'#13#10 + validationResult.Messages.Text);
@@ -799,7 +799,7 @@ begin
 end;
 
 /// <summary>
-/// BR-CO-12: BT-108 muss der Summe der einzelnen Kopfzuschlaege (BT-99) entsprechen.
+/// BR-CO-12: BT-108 muss der Summe der einzelnen Kopfzuschläge (BT-99) entsprechen.
 /// </summary>
 procedure TZUGFeRDInvoiceValidatorTests.TestDeclaredChargeTotalDeviationIsReported;
 var
@@ -808,13 +808,13 @@ var
 begin
   desc := CreateBalancedInvoice(True);
   try
-    // Der einzige Kopfzuschlag betraegt 10,00, BT-108 behauptet 20,00.
+    // Der einzige Kopfzuschlag beträgt 10,00, BT-108 behauptet 20,00.
     desc.ChargeTotalAmount := 20;
 
     validationResult := TZUGFeRDInvoiceValidator.Validate(desc, TZUGFeRDVersion.Version23);
     try
       Assert.IsFalse(validationResult.IsValid,
-        'Ein von den Kopfzuschlaegen abweichendes BT-108 wurde nicht beanstandet:'#13#10 +
+        'Ein von den Kopfzuschlägen abweichendes BT-108 wurde nicht beanstandet:'#13#10 +
         validationResult.Messages.Text);
       Assert.IsTrue(Pos('BR-CO-12', validationResult.Messages.Text) > 0,
         'Es fehlt die Meldung zu BR-CO-12:'#13#10 + validationResult.Messages.Text);
@@ -856,7 +856,7 @@ end;
 
 /// <summary>
 /// Baut eine ausgeglichene Rechnung, deren Nettoeinzelpreis BT-146 sich auf eine
-/// Preisbasismenge BT-149 bezieht: 100,00 je 10 Stueck bei 2 berechneten Stueck
+/// Preisbasismenge BT-149 bezieht: 100,00 je 10 Stück bei 2 berechneten Stück
 /// ergibt einen Positionsnettobetrag BT-131 von 20,00.
 /// </summary>
 function TZUGFeRDInvoiceValidatorTests.CreateInvoiceWithPriceBaseQuantity(
@@ -894,7 +894,7 @@ end;
 
 /// <summary>
 /// BT-146 gilt je Preisbasismenge BT-149. Wird BT-149 ignoriert, rechnet der
-/// Validator das Zehnfache und verwirft eine gueltige Rechnung.
+/// Validator das Zehnfache und verwirft eine gültige Rechnung.
 /// </summary>
 procedure TZUGFeRDInvoiceValidatorTests.TestPriceBaseQuantityIsApplied;
 var
@@ -906,7 +906,7 @@ begin
     validationResult := TZUGFeRDInvoiceValidator.Validate(desc, TZUGFeRDVersion.Version23);
     try
       Assert.IsTrue(validationResult.IsValid,
-        'Rechnung mit Preisbasismenge wurde als ungueltig gemeldet:'#13#10 +
+        'Rechnung mit Preisbasismenge wurde als ungültig gemeldet:'#13#10 +
         validationResult.Messages.Text);
     finally
       validationResult.Free;
@@ -917,8 +917,8 @@ begin
 end;
 
 /// <summary>
-/// Eine Preisbasismenge von 0 ist fachlich unzulaessig und darf nicht still
-/// uebergangen werden.
+/// Eine Preisbasismenge von 0 ist fachlich unzulässig und darf nicht still
+/// übergangen werden.
 /// </summary>
 procedure TZUGFeRDInvoiceValidatorTests.TestZeroPriceBaseQuantityIsReported;
 var
@@ -943,10 +943,10 @@ begin
 end;
 
 /// <summary>
-/// BR-CO-17 laesst laut EN-16931-Schematron eine Abweichung von einer
-/// Waehrungseinheit je Steueraufschluesselung zu. BT-110 ist dabei nach BR-CO-14
+/// BR-CO-17 lässt laut EN-16931-Schematron eine Abweichung von einer
+/// Währungseinheit je Steueraufschlüsselung zu. BT-110 ist dabei nach BR-CO-14
 /// die Summe der angegebenen BT-117, nicht die der nachgerechneten Sollwerte -
-/// sonst waere eine normkonforme Rechnung allein an der Steuersumme ungueltig.
+/// sonst wäre eine normkonforme Rechnung allein an der Steuersumme ungültig.
 /// </summary>
 procedure TZUGFeRDInvoiceValidatorTests.TestTaxAmountWithinBRCO17ToleranceIsAccepted;
 var
@@ -955,7 +955,7 @@ var
 begin
   Descriptor := TZUGFeRDInvoiceDescriptor.CreateInvoice('RE-TOLERANCE-OK', EncodeDate(2026, 1, 15), TZUGFeRDCurrencyCodes.EUR);
   try
-    // Sollwert 19,00, angegeben 19,50: Abweichung 0,50 und damit zulaessig.
+    // Sollwert 19,00, angegeben 19,50: Abweichung 0,50 und damit zulässig.
     AddTaxGroup(Descriptor, 'Standard rate', 100, 19, 19.50, TZUGFeRDTaxCategoryCodes.S);
     Descriptor.SetTotals(100, 0, 0, 100, 19.50, 119.50, 0, 119.50);
 
@@ -965,18 +965,18 @@ begin
         'Eine Abweichung innerhalb der BR-CO-17-Toleranz wurde als Fehler gemeldet:'#13#10 +
         ValidationResult.Messages.Text);
       Assert.IsTrue(ValidationResult.Messages.Text.Contains('BR-CO-17-Toleranz'),
-        'Die zulaessige Abweichung wurde nicht protokolliert:'#13#10 +
+        'Die zulässige Abweichung wurde nicht protokolliert:'#13#10 +
         ValidationResult.Messages.Text);
     finally
-      FreeAndNil(ValidationResult);
+      ValidationResult.Free;
     end;
   finally
-    FreeAndNil(Descriptor);
+    Descriptor.Free;
   end;
 end;
 
 /// <summary>
-/// Jenseits einer Waehrungseinheit ist BR-CO-17 verletzt.
+/// Jenseits einer Währungseinheit ist BR-CO-17 verletzt.
 /// </summary>
 procedure TZUGFeRDInvoiceValidatorTests.TestTaxAmountBeyondBRCO17ToleranceIsReported;
 var
@@ -985,7 +985,7 @@ var
 begin
   Descriptor := TZUGFeRDInvoiceDescriptor.CreateInvoice('RE-TOLERANCE-FAIL', EncodeDate(2026, 1, 15), TZUGFeRDCurrencyCodes.EUR);
   try
-    // Sollwert 19,00, angegeben 20,50: Abweichung 1,50 und damit unzulaessig.
+    // Sollwert 19,00, angegeben 20,50: Abweichung 1,50 und damit unzulässig.
     AddTaxGroup(Descriptor, 'Standard rate', 100, 19, 20.50, TZUGFeRDTaxCategoryCodes.S);
     Descriptor.SetTotals(100, 0, 0, 100, 20.50, 120.50, 0, 120.50);
 
@@ -997,10 +997,10 @@ begin
       Assert.IsTrue(ValidationResult.Messages.Text.Contains('BR-CO-17:'),
         'Es fehlt die Meldung zu BR-CO-17:'#13#10 + ValidationResult.Messages.Text);
     finally
-      FreeAndNil(ValidationResult);
+      ValidationResult.Free;
     end;
   finally
-    FreeAndNil(Descriptor);
+    Descriptor.Free;
   end;
 end;
 

--- a/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
@@ -85,6 +85,10 @@ type
     [Test]
     procedure TestUnroundedTaxAmountIsReported;
     [Test]
+    procedure TestTaxAmountWithinBRCO17ToleranceIsAccepted;
+    [Test]
+    procedure TestTaxAmountBeyondBRCO17ToleranceIsReported;
+    [Test]
     procedure TestTaxAmountDeviationsWithinSameRateAreReported;
     [Test]
     procedure TestNegativeMidpointTaxAmountIsRoundedAwayFromZero;
@@ -517,8 +521,10 @@ begin
     ValidationResult := TZUGFeRDInvoiceValidator.Validate(Descriptor, TZUGFeRDVersion.Version23);
     try
       Assert.IsFalse(ValidationResult.IsValid, 'Unrounded tax amount was not reported');
-      Assert.IsTrue(ValidationResult.Messages.Text.Contains('BR-CO-17'),
-        'Validation messages do not identify BR-CO-17');
+      // 0,0057 liegt innerhalb der BR-CO-17-Toleranz; beanstandet wird die
+      // unzulaessige Zahl der Nachkommastellen.
+      Assert.IsTrue(ValidationResult.Messages.Text.Contains('BR-DEC-20'),
+        'Validation messages do not identify BR-DEC-20');
     finally
       FreeAndNil(ValidationResult);
     end;
@@ -536,10 +542,12 @@ var
 begin
   Descriptor := TZUGFeRDInvoiceDescriptor.CreateInvoice('RE-ROUND-CATEGORY', EncodeDate(2026, 1, 15), TZUGFeRDCurrencyCodes.EUR);
   try
-    // Gegensätzliche Abweichungen dürfen sich bei gleichem Steuersatz nicht gegenseitig aufheben.
-    AddTaxGroup(Descriptor, 'Standard rate', 1, 7, 0.08, TZUGFeRDTaxCategoryCodes.S);
-    AddTaxGroup(Descriptor, 'Lower rate', 1, 7, 0.06, TZUGFeRDTaxCategoryCodes.AA);
-    Descriptor.SetTotals(2, 0, 0, 2, 0.14, 2.14, 0, 2.14);
+    // Gegensätzliche Abweichungen dürfen sich bei gleichem Steuersatz nicht gegenseitig
+    // aufheben. Beide liegen ausserhalb der BR-CO-17-Toleranz, ihre Summe ergibt aber
+    // exakt den korrekten Gesamtbetrag von 14,00.
+    AddTaxGroup(Descriptor, 'Standard rate', 100, 7, 9.00, TZUGFeRDTaxCategoryCodes.S);
+    AddTaxGroup(Descriptor, 'Lower rate', 100, 7, 5.00, TZUGFeRDTaxCategoryCodes.AA);
+    Descriptor.SetTotals(200, 0, 0, 200, 14, 214, 0, 214);
 
     ValidationResult := TZUGFeRDInvoiceValidator.Validate(Descriptor, TZUGFeRDVersion.Version23);
     try
@@ -931,6 +939,68 @@ begin
     end;
   finally
     desc.Free;
+  end;
+end;
+
+/// <summary>
+/// BR-CO-17 laesst laut EN-16931-Schematron eine Abweichung von einer
+/// Waehrungseinheit je Steueraufschluesselung zu. BT-110 ist dabei nach BR-CO-14
+/// die Summe der angegebenen BT-117, nicht die der nachgerechneten Sollwerte -
+/// sonst waere eine normkonforme Rechnung allein an der Steuersumme ungueltig.
+/// </summary>
+procedure TZUGFeRDInvoiceValidatorTests.TestTaxAmountWithinBRCO17ToleranceIsAccepted;
+var
+  Descriptor: TZUGFeRDInvoiceDescriptor;
+  ValidationResult: TZUGFeRDValidationResult;
+begin
+  Descriptor := TZUGFeRDInvoiceDescriptor.CreateInvoice('RE-TOLERANCE-OK', EncodeDate(2026, 1, 15), TZUGFeRDCurrencyCodes.EUR);
+  try
+    // Sollwert 19,00, angegeben 19,50: Abweichung 0,50 und damit zulaessig.
+    AddTaxGroup(Descriptor, 'Standard rate', 100, 19, 19.50, TZUGFeRDTaxCategoryCodes.S);
+    Descriptor.SetTotals(100, 0, 0, 100, 19.50, 119.50, 0, 119.50);
+
+    ValidationResult := TZUGFeRDInvoiceValidator.Validate(Descriptor, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsTrue(ValidationResult.IsValid,
+        'Eine Abweichung innerhalb der BR-CO-17-Toleranz wurde als Fehler gemeldet:'#13#10 +
+        ValidationResult.Messages.Text);
+      Assert.IsTrue(ValidationResult.Messages.Text.Contains('BR-CO-17-Toleranz'),
+        'Die zulaessige Abweichung wurde nicht protokolliert:'#13#10 +
+        ValidationResult.Messages.Text);
+    finally
+      FreeAndNil(ValidationResult);
+    end;
+  finally
+    FreeAndNil(Descriptor);
+  end;
+end;
+
+/// <summary>
+/// Jenseits einer Waehrungseinheit ist BR-CO-17 verletzt.
+/// </summary>
+procedure TZUGFeRDInvoiceValidatorTests.TestTaxAmountBeyondBRCO17ToleranceIsReported;
+var
+  Descriptor: TZUGFeRDInvoiceDescriptor;
+  ValidationResult: TZUGFeRDValidationResult;
+begin
+  Descriptor := TZUGFeRDInvoiceDescriptor.CreateInvoice('RE-TOLERANCE-FAIL', EncodeDate(2026, 1, 15), TZUGFeRDCurrencyCodes.EUR);
+  try
+    // Sollwert 19,00, angegeben 20,50: Abweichung 1,50 und damit unzulaessig.
+    AddTaxGroup(Descriptor, 'Standard rate', 100, 19, 20.50, TZUGFeRDTaxCategoryCodes.S);
+    Descriptor.SetTotals(100, 0, 0, 100, 20.50, 120.50, 0, 120.50);
+
+    ValidationResult := TZUGFeRDInvoiceValidator.Validate(Descriptor, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsFalse(ValidationResult.IsValid,
+        'Eine Abweichung jenseits der BR-CO-17-Toleranz wurde nicht beanstandet:'#13#10 +
+        ValidationResult.Messages.Text);
+      Assert.IsTrue(ValidationResult.Messages.Text.Contains('BR-CO-17:'),
+        'Es fehlt die Meldung zu BR-CO-17:'#13#10 + ValidationResult.Messages.Text);
+    finally
+      FreeAndNil(ValidationResult);
+    end;
+  finally
+    FreeAndNil(Descriptor);
   end;
 end;
 

--- a/intf.ZUGFeRDInvoiceDescriptor20Writer.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor20Writer.pas
@@ -673,7 +673,9 @@ if (Descriptor.Profile = TZUGFeRDProfile.Extended) then
 
   //   3. TaxCurrencyCode (optional)
   //   BT-6
-	if Descriptor.TaxCurrency.HasValue then
+  // BT-6 nur bei abweichender Abrechnungswaehrung, siehe BR-53: ohne BT-111 darf
+  // kein Steuerwaehrungscode stehen.
+	if Descriptor.TaxCurrency.HasValue and (Descriptor.TaxCurrency.Value <> Descriptor.Currency) then
   	Writer.WriteElementString('ram:TaxCurrencyCode', TEnumExtensions<TZUGFeRDCurrencyCodes>.EnumToString(Descriptor.TaxCurrency), [TZUGFeRDProfile.Comfort,TZUGFeRDProfile.Extended,TZUGFeRDProfile.XRechnung,TZUGFeRDProfile.XRechnung1]);
 
   //   4. InvoiceCurrencyCode (optional)

--- a/intf.ZUGFeRDInvoiceDescriptor20Writer.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor20Writer.pas
@@ -673,8 +673,8 @@ if (Descriptor.Profile = TZUGFeRDProfile.Extended) then
 
   //   3. TaxCurrencyCode (optional)
   //   BT-6
-  // BT-6 nur bei abweichender Abrechnungswaehrung, siehe BR-53: ohne BT-111 darf
-  // kein Steuerwaehrungscode stehen.
+  // BT-6 nur bei abweichender Abrechnungswährung, siehe BR-53: ohne BT-111 darf
+  // kein Steuerwährungscode stehen.
 	if Descriptor.TaxCurrency.HasValue and (Descriptor.TaxCurrency.Value <> Descriptor.Currency) then
   	Writer.WriteElementString('ram:TaxCurrencyCode', TEnumExtensions<TZUGFeRDCurrencyCodes>.EnumToString(Descriptor.TaxCurrency), [TZUGFeRDProfile.Comfort,TZUGFeRDProfile.Extended,TZUGFeRDProfile.XRechnung,TZUGFeRDProfile.XRechnung1]);
 

--- a/intf.ZUGFeRDInvoiceDescriptor22UBLWriter.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor22UBLWriter.pas
@@ -213,9 +213,9 @@ begin
 
   Writer.WriteElementString('cbc:DocumentCurrencyCode', TEnumExtensions<TZUGFeRDCurrencyCodes>.EnumToString(Descriptor.Currency));
 
-  // BT-6 nur bei einer von der Rechnungswaehrung abweichenden Abrechnungswaehrung:
+  // BT-6 nur bei einer von der Rechnungswährung abweichenden Abrechnungswährung:
   // BR-53 verlangt zu einem vorhandenen BT-6 zwingend ein BT-111, und das wird weiter
-  // unten ebenfalls nur bei abweichender Waehrung geschrieben.
+  // unten ebenfalls nur bei abweichender Währung geschrieben.
   if Descriptor.TaxCurrency.HasValue and (Descriptor.TaxCurrency.Value <> Descriptor.Currency) then
     Writer.WriteElementString('cbc:TaxCurrencyCode', TEnumExtensions<TZUGFeRDCurrencyCodes>.EnumToString(Descriptor.TaxCurrency.Value));
 

--- a/intf.ZUGFeRDInvoiceDescriptor22UBLWriter.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor22UBLWriter.pas
@@ -213,8 +213,10 @@ begin
 
   Writer.WriteElementString('cbc:DocumentCurrencyCode', TEnumExtensions<TZUGFeRDCurrencyCodes>.EnumToString(Descriptor.Currency));
 
-  // BT-6
-  if Descriptor.TaxCurrency.HasValue then
+  // BT-6 nur bei einer von der Rechnungswaehrung abweichenden Abrechnungswaehrung:
+  // BR-53 verlangt zu einem vorhandenen BT-6 zwingend ein BT-111, und das wird weiter
+  // unten ebenfalls nur bei abweichender Waehrung geschrieben.
+  if Descriptor.TaxCurrency.HasValue and (Descriptor.TaxCurrency.Value <> Descriptor.Currency) then
     Writer.WriteElementString('cbc:TaxCurrencyCode', TEnumExtensions<TZUGFeRDCurrencyCodes>.EnumToString(Descriptor.TaxCurrency.Value));
 
   // BT-19

--- a/intf.ZUGFeRDInvoiceDescriptor23CIIWriter.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor23CIIWriter.pas
@@ -920,7 +920,9 @@ begin
 
   //   3. TaxCurrencyCode (optional)
   //   BT-6
-	if Descriptor.TaxCurrency.HasValue then
+  // BT-6 nur bei abweichender Abrechnungswaehrung, siehe BR-53: ohne BT-111 darf
+  // kein Steuerwaehrungscode stehen.
+	if Descriptor.TaxCurrency.HasValue and (Descriptor.TaxCurrency.Value <> Descriptor.Currency) then
   	Writer.WriteElementString('ram:TaxCurrencyCode', TEnumExtensions<TZUGFeRDCurrencyCodes>.EnumToString(Descriptor.TaxCurrency), [TZUGFeRDProfile.Comfort,TZUGFeRDProfile.Extended,TZUGFeRDProfile.XRechnung,TZUGFeRDProfile.XRechnung1]);
 
   //   4. InvoiceCurrencyCode (optional), BT-5

--- a/intf.ZUGFeRDInvoiceDescriptor23CIIWriter.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor23CIIWriter.pas
@@ -920,8 +920,8 @@ begin
 
   //   3. TaxCurrencyCode (optional)
   //   BT-6
-  // BT-6 nur bei abweichender Abrechnungswaehrung, siehe BR-53: ohne BT-111 darf
-  // kein Steuerwaehrungscode stehen.
+  // BT-6 nur bei abweichender Abrechnungswährung, siehe BR-53: ohne BT-111 darf
+  // kein Steuerwährungscode stehen.
 	if Descriptor.TaxCurrency.HasValue and (Descriptor.TaxCurrency.Value <> Descriptor.Currency) then
   	Writer.WriteElementString('ram:TaxCurrencyCode', TEnumExtensions<TZUGFeRDCurrencyCodes>.EnumToString(Descriptor.TaxCurrency), [TZUGFeRDProfile.Comfort,TZUGFeRDProfile.Extended,TZUGFeRDProfile.XRechnung,TZUGFeRDProfile.XRechnung1]);
 

--- a/intf.ZUGFeRDInvoiceValidator.pas
+++ b/intf.ZUGFeRDInvoiceValidator.pas
@@ -133,7 +133,7 @@ begin
             _total := _total / item.NetQuantity.Value
           else
           begin
-            Result.Messages.Add(Format('BT-149: Die Preisbasismenge der Position [%s] muss groesser als 0 sein', [item.Name]));
+            Result.Messages.Add(Format('BT-149: Die Preisbasismenge der Position [%s] muss größer als 0 sein', [item.Name]));
             Result.IsValid := false;
           end;
         end;
@@ -201,13 +201,13 @@ begin
       expectedTaxAmount := SimpleRoundTo(tax.BasisAmount * tax.Percent / 100, -2);
 
       // BR-CO-14 bildet BT-110 aus den angegebenen BT-117, nicht aus den
-      // nachgerechneten Sollwerten. Beides faellt nur zusammen, solange BR-CO-17
-      // exakt erzwungen wird - die Regel laesst aber eine Abweichung zu.
+      // nachgerechneten Sollwerten. Beides fällt nur zusammen, solange BR-CO-17
+      // exakt erzwungen wird - die Regel lässt aber eine Abweichung zu.
       taxTotal := taxTotal + tax.TaxAmount;
 
       Result.Messages.Add(Format('===> %f x %f%% = %f', [tax.BasisAmount, tax.Percent, expectedTaxAmount]));
 
-      // BR-DEC-20: BT-117 darf hoechstens zwei Nachkommastellen haben.
+      // BR-DEC-20: BT-117 darf höchstens zwei Nachkommastellen haben.
       if tax.TaxAmount <> SimpleRoundTo(tax.TaxAmount, -2) then
       begin
         Result.Messages.Add(Format(
@@ -215,9 +215,9 @@ begin
         Result.IsValid := false;
       end;
 
-      // BR-CO-17 laesst laut EN-16931-Schematron eine Abweichung von einer
-      // Waehrungseinheit je Steueraufschluesselung zu. Was darueber liegt, ist ein
-      // Verstoss; was darunter liegt, wird protokolliert, damit es nicht untergeht.
+      // BR-CO-17 lässt laut EN-16931-Schematron eine Abweichung von einer
+      // Währungseinheit je Steueraufschlüsselung zu. Was darüber liegt, ist ein
+      // Verstoß; was darunter liegt, wird protokolliert, damit es nicht untergeht.
       taxDeviation := tax.TaxAmount - expectedTaxAmount;
       if Abs(taxDeviation) > 1 then
       begin
@@ -229,7 +229,7 @@ begin
       else if taxDeviation <> 0 then
       begin
         Result.Messages.Add(Format(
-          'Hinweis: Der Steuerbetrag[%4f] weicht um [%4f] vom berechneten Wert[%4f] ab, bleibt aber innerhalb der BR-CO-17-Toleranz von einer Waehrungseinheit',
+          'Hinweis: Der Steuerbetrag[%4f] weicht um [%4f] vom berechneten Wert[%4f] ab, bleibt aber innerhalb der BR-CO-17-Toleranz von einer Währungseinheit',
           [tax.TaxAmount, taxDeviation, expectedTaxAmount]));
       end;
     end;
@@ -359,9 +359,9 @@ begin
       Result.IsValid := false;
     end;
 
-    // BR-CO-11: Die Summe der Abschlaege auf Dokumentenebene (BT-107) muss der
-    // Summe der einzelnen Kopfabschlaege (BT-92) entsprechen. BR-CO-12 verlangt
-    // dasselbe fuer die Zuschlaege (BT-108 gegen BT-99). Beide Kopfsummen sind
+    // BR-CO-11: Die Summe der Abschläge auf Dokumentenebene (BT-107) muss der
+    // Summe der einzelnen Kopfabschläge (BT-92) entsprechen. BR-CO-12 verlangt
+    // dasselbe für die Zuschläge (BT-108 gegen BT-99). Beide Kopfsummen sind
     // optional; fehlen sie, gelten sie als 0.
     if Abs(allowanceTotal - declaredAllowanceTotal) < 0.01 then
     begin
@@ -383,8 +383,8 @@ begin
       Result.IsValid := false;
     end;
 
-    // BR-CO-13: BT-109 ergibt sich aus BT-106 abzueglich BT-107 zuzueglich BT-108.
-    // Ohne diese Pruefung koennen sich BT-109 und die Steueraufschluesselung
+    // BR-CO-13: BT-109 ergibt sich aus BT-106 abzüglich BT-107 zuzüglich BT-108.
+    // Ohne diese Prüfung können sich BT-109 und die Steueraufschlüsselung
     // gemeinsam vom Positionsnetto entfernen, ohne beanstandet zu werden: der
     // Abgleich weiter oben vergleicht BT-109 nur gegen die Summe der BT-116.
     if descriptor.LineTotalAmount.HasValue and descriptor.TaxBasisAmount.HasValue then

--- a/intf.ZUGFeRDInvoiceValidator.pas
+++ b/intf.ZUGFeRDInvoiceValidator.pas
@@ -93,6 +93,7 @@ var
   lineTotal, allowanceTotal, chargeTotal, taxTotal, grandTotal, prepaid,
     rounding, duePayable, expectedDuePayable, expectedTaxAmount: Currency;
   declaredAllowanceTotal, declaredChargeTotal, expectedTaxBasis: Currency;
+  taxDeviation: Currency;
   item: TZUGFeRDTradeLineItem;
   tax: TZUGFeRDTax;
 begin
@@ -197,19 +198,44 @@ begin
       if tax.TypeCode.Value <> TZUGFeRDTaxTypes.VAT then
         Continue;
 
-      // BR-CO-17 verlangt die Rundung jeder Steuergruppe vor der Summierung zu BT-110.
       expectedTaxAmount := SimpleRoundTo(tax.BasisAmount * tax.Percent / 100, -2);
-      taxTotal := taxTotal + expectedTaxAmount;
+
+      // BR-CO-14 bildet BT-110 aus den angegebenen BT-117, nicht aus den
+      // nachgerechneten Sollwerten. Beides faellt nur zusammen, solange BR-CO-17
+      // exakt erzwungen wird - die Regel laesst aber eine Abweichung zu.
+      taxTotal := taxTotal + tax.TaxAmount;
+
       Result.Messages.Add(Format('===> %f x %f%% = %f', [tax.BasisAmount, tax.Percent, expectedTaxAmount]));
 
-      if tax.TaxAmount <> expectedTaxAmount then
+      // BR-DEC-20: BT-117 darf hoechstens zwei Nachkommastellen haben.
+      if tax.TaxAmount <> SimpleRoundTo(tax.TaxAmount, -2) then
+      begin
+        Result.Messages.Add(Format(
+          'BR-DEC-20: Der Steuerbetrag[%4f] hat mehr als zwei Nachkommastellen', [tax.TaxAmount]));
+        Result.IsValid := false;
+      end;
+
+      // BR-CO-17 laesst laut EN-16931-Schematron eine Abweichung von einer
+      // Waehrungseinheit je Steueraufschluesselung zu. Was darueber liegt, ist ein
+      // Verstoss; was darunter liegt, wird protokolliert, damit es nicht untergeht.
+      taxDeviation := tax.TaxAmount - expectedTaxAmount;
+      if Abs(taxDeviation) > 1 then
       begin
         Result.Messages.Add(Format(
           'BR-CO-17: Berechneter Steuerbetrag ist[%4f] aber vorhandener Steuerbetrag ist[%4f] bei Bemessungsgrundlage[%4f] und Steuersatz[%4f]',
           [expectedTaxAmount, tax.TaxAmount, tax.BasisAmount, tax.Percent]));
         Result.IsValid := false;
+      end
+      else if taxDeviation <> 0 then
+      begin
+        Result.Messages.Add(Format(
+          'Hinweis: Der Steuerbetrag[%4f] weicht um [%4f] vom berechneten Wert[%4f] ab, bleibt aber innerhalb der BR-CO-17-Toleranz von einer Waehrungseinheit',
+          [tax.TaxAmount, taxDeviation, expectedTaxAmount]));
       end;
     end;
+
+    // BR-CO-14 rundet die Summe der BT-117 auf zwei Nachkommastellen.
+    taxTotal := SimpleRoundTo(taxTotal, -2);
 
     grandTotal := lineTotal - allowanceTotal + taxTotal + chargeTotal;
     prepaid := descriptor.TotalPrepaidAmount.GetValueOrDefault;

--- a/intf.ZUGFeRDInvoiceValidator.pas
+++ b/intf.ZUGFeRDInvoiceValidator.pas
@@ -92,6 +92,7 @@ var
   lineCounter: Integer;
   lineTotal, allowanceTotal, chargeTotal, taxTotal, grandTotal, prepaid,
     rounding, duePayable, expectedDuePayable, expectedTaxAmount: Currency;
+  declaredAllowanceTotal, declaredChargeTotal, expectedTaxBasis: Currency;
   item: TZUGFeRDTradeLineItem;
   tax: TZUGFeRDTax;
 begin
@@ -226,12 +227,8 @@ begin
           _taxBasisTotal := _taxBasisTotal + tax.BasisAmount;
     end;
 
-    var _allowanceTotal : Currency := 0;
-    var _chargeTotal : Currency := 0;
-    for var allowance in descriptor.GetTradeAllowances do
-      _allowanceTotal := _allowanceTotal + allowance.ActualAmount;
-    for var charge in descriptor.GetTradeCharges do
-        _chargeTotal := _chargeTotal + charge.ActualAmount;
+    declaredAllowanceTotal := descriptor.AllowanceTotalAmount.GetValueOrDefault;
+    declaredChargeTotal := descriptor.ChargeTotalAmount.GetValueOrDefault;
 
     if not descriptor.TaxTotalAmount.HasValue then
     begin
@@ -248,7 +245,12 @@ begin
       Result.IsValid := false;
     end;
 
-    if Abs(lineTotal - descriptor.LineTotalAmount.Value) < 0.01 then
+    if not descriptor.LineTotalAmount.HasValue then
+    begin
+      Result.Messages.Add('trade.settlement.monetarySummation.lineTotal Message: Kein LineTotalAmount vorhanden');
+      Result.IsValid := false;
+    end
+    else if Abs(lineTotal - descriptor.LineTotalAmount.Value) < 0.01 then
     begin
       Result.Messages.Add(Format('trade.settlement.monetarySummation.lineTotal Message: Berechneter Wert ist wie vorhanden:[%4f]', [lineTotal]));
     end
@@ -318,24 +320,47 @@ begin
       Result.IsValid := false;
     end;
 
-    if Abs(allowanceTotal - _allowanceTotal) < 0.01 then
+    // BR-CO-11: Die Summe der Abschlaege auf Dokumentenebene (BT-107) muss der
+    // Summe der einzelnen Kopfabschlaege (BT-92) entsprechen. BR-CO-12 verlangt
+    // dasselbe fuer die Zuschlaege (BT-108 gegen BT-99). Beide Kopfsummen sind
+    // optional; fehlen sie, gelten sie als 0.
+    if Abs(allowanceTotal - declaredAllowanceTotal) < 0.01 then
     begin
-      Result.Messages.Add(Format('trade.settlement.monetarySummation.allowanceTotal  Message: Berechneter Wert ist wie vorhanden:[%4f]', [_allowanceTotal]));
+      Result.Messages.Add(Format('trade.settlement.monetarySummation.allowanceTotal  Message: Berechneter Wert ist wie vorhanden:[%4f]', [declaredAllowanceTotal]));
     end
     else
     begin
-      Result.Messages.Add(Format('trade.settlement.monetarySummation.allowanceTotal  Message: Berechneter Wert ist[%4f] aber tatsächliche vorhander Wert ist[%4f]', [allowanceTotal, _allowanceTotal]));
+      Result.Messages.Add(Format('BR-CO-11: trade.settlement.monetarySummation.allowanceTotal  Message: Berechneter Wert ist[%4f] aber tatsächlich vorhandener Wert ist[%4f]', [allowanceTotal, declaredAllowanceTotal]));
       Result.IsValid := false;
     end;
 
-    if Abs(chargeTotal - _chargeTotal) < 0.01 then
+    if Abs(chargeTotal - declaredChargeTotal) < 0.01 then
     begin
-      Result.Messages.Add(Format('trade.settlement.monetarySummation.chargeTotal  Message: Berechneter Wert ist wie vorhanden:[%4f]', [_chargeTotal]));
+      Result.Messages.Add(Format('trade.settlement.monetarySummation.chargeTotal  Message: Berechneter Wert ist wie vorhanden:[%4f]', [declaredChargeTotal]));
     end
     else
     begin
-      Result.Messages.Add(Format('trade.settlement.monetarySummation.chargeTotal  Message: Berechneter Wert ist[%4f] aber tatsächliche vorhander Wert ist[%4f]', [chargeTotal, _chargeTotal]));
+      Result.Messages.Add(Format('BR-CO-12: trade.settlement.monetarySummation.chargeTotal  Message: Berechneter Wert ist[%4f] aber tatsächlich vorhandener Wert ist[%4f]', [chargeTotal, declaredChargeTotal]));
       Result.IsValid := false;
+    end;
+
+    // BR-CO-13: BT-109 ergibt sich aus BT-106 abzueglich BT-107 zuzueglich BT-108.
+    // Ohne diese Pruefung koennen sich BT-109 und die Steueraufschluesselung
+    // gemeinsam vom Positionsnetto entfernen, ohne beanstandet zu werden: der
+    // Abgleich weiter oben vergleicht BT-109 nur gegen die Summe der BT-116.
+    if descriptor.LineTotalAmount.HasValue and descriptor.TaxBasisAmount.HasValue then
+    begin
+      expectedTaxBasis := descriptor.LineTotalAmount.Value - declaredAllowanceTotal + declaredChargeTotal;
+      if Abs(expectedTaxBasis - descriptor.TaxBasisAmount.Value) < 0.01 then
+      begin
+        Result.Messages.Add(Format('BR-CO-13: Steuerbemessungsgrundlage aus BT-106 - BT-107 + BT-108 ist wie vorhanden:[%4f]', [expectedTaxBasis]));
+      end
+      else
+      begin
+        Result.Messages.Add(Format('BR-CO-13: Steuerbemessungsgrundlage aus BT-106 - BT-107 + BT-108 ist[%4f] aber tatsächlich vorhandener Wert ist[%4f]',
+          [expectedTaxBasis, descriptor.TaxBasisAmount.Value]));
+        Result.IsValid := false;
+      end;
     end;
 
     // version-specific validation

--- a/intf.ZUGFeRDInvoiceValidator.pas
+++ b/intf.ZUGFeRDInvoiceValidator.pas
@@ -124,6 +124,19 @@ begin
       begin
         _total := (item.NetUnitPrice.Value * item.BilledQuantity);
 
+        // BT-146 gilt je Preisbasismenge BT-149, nicht je Einheit. Fehlt BT-149,
+        // ist die Basismenge 1. Der CII-Writer rechnet bei fehlendem BT-131 genauso.
+        if item.NetQuantity.HasValue then
+        begin
+          if item.NetQuantity.Value > 0 then
+            _total := _total / item.NetQuantity.Value
+          else
+          begin
+            Result.Messages.Add(Format('BT-149: Die Preisbasismenge der Position [%s] muss groesser als 0 sein', [item.Name]));
+            Result.IsValid := false;
+          end;
+        end;
+
         // BT-131 enthält BG-28-Positionszuschläge und vermindert sich um BG-27-Positionsabschläge.
         for var lineAllowance in item.GetSpecifiedTradeAllowances do
           _total := _total - lineAllowance.ActualAmount;


### PR DESCRIPTION
## Zusammenfassung

Führt Svens Review-Korrekturen aus `LandrixSoftware:fix/validator-review-findings` über den bei MGGM geprüften Stand nach Landrix `main` zurück.

- BR-CO-11, BR-CO-12 und BR-CO-13 prüfen die deklarierten Kopfsummen.
- BT-149 wird bei der Nachrechnung von BT-131 berücksichtigt.
- BR-CO-17 verwendet die normative Toleranz; BR-DEC-20 prüft die Nachkommastellen.
- BT-110 wird aus den deklarierten BT-117 gebildet.
- BT-6 wird nur gemeinsam mit BT-111 geschrieben.
- Der Documentation-Sweep vergleicht Kerndaten nach einem vollständigen Roundtrip.
- Die Cross-Version-Tests kompilieren mit Delphi 13.

Der zusätzliche MGGM-Commit ersetzt Ersatzschreibweisen in den neuen deutschen Kommentaren und Meldungstexten durch echte Umlaute. Die neu hinzugefügten Tests verwenden entsprechend der Library-Konvention `Free` statt `FreeAndNil`.

## Verifikation

Für den fachlichen Stand sind ein vollständiger Delphi-13-Win64-Rebuild sowie 343 von 343 erfolgreiche DUnitX-Tests dokumentiert. Die nachfolgende Textkorrektur wurde per Diff-, UTF-8- und Whitespace-Prüfung kontrolliert; ein eigener Delphi-Lauf war in der aktuellen Umgebung nicht möglich.
