### PR TITLE
Remove unused reader result assignment

### DIFF
--- a/intf.ZUGFeRDInvoiceDescriptor23CIIReader.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor23CIIReader.pas
@@ -680,7 +680,6 @@ begin
     end;
   except
     Result.Free;
-    Result := nil;
     raise;
   end;
 


### PR DESCRIPTION
## Zusammenfassung

Entfernt die ungenutzte Zuweisung des Reader-Ergebnisses in `TZUGFeRDInvoiceDescriptor23CIIReader.Load`.

Damit entfällt der Delphi-Compilerhinweis H2077:

`Value assigned to 'TZUGFeRDInvoiceDescriptor23CIIReader.Load' never used`

Die Änderung betrifft ausschließlich die überflüssige Zuweisung; das gelesene Ergebnis wird unverändert zurückgegeben.

## Verifikation

Der zugehörige Delphi-Win64-Build lief ohne Fehler, Warnungen und Hinweise durch. Der vollständige DUnitX-Lauf enthielt 350 von 350 erfolgreiche Tests.
