### PR TITLE
Document BR-CO-17 tolerance boundary in validator

### DIFF
--- a/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
@@ -87,6 +87,8 @@ type
     [Test]
     procedure TestTaxAmountWithinBRCO17ToleranceIsAccepted;
     [Test]
+    procedure TestTaxAmountAtFacturXBRCO17ToleranceBoundaryIsAccepted;
+    [Test]
     procedure TestTaxAmountBeyondBRCO17ToleranceIsReported;
     [Test]
     procedure TestTaxAmountDeviationsWithinSameRateAreReported;
@@ -943,10 +945,10 @@ begin
 end;
 
 /// <summary>
-/// BR-CO-17 lässt laut EN-16931-Schematron eine Abweichung von einer
-/// Währungseinheit je Steueraufschlüsselung zu. BT-110 ist dabei nach BR-CO-14
-/// die Summe der angegebenen BT-117, nicht die der nachgerechneten Sollwerte -
-/// sonst wäre eine normkonforme Rechnung allein an der Steuersumme ungültig.
+/// Die Factur-X-Schematrons 1.08 und 1.09 setzen BR-CO-17 mit einer Toleranz von
+/// einer Währungseinheit je Steueraufschlüsselung um. BT-110 ist dabei nach
+/// BR-CO-14 die Summe der angegebenen BT-117, nicht die der nachgerechneten
+/// Sollwerte, sonst wäre eine zulässige Rechnung allein an der Steuersumme ungültig.
 /// </summary>
 procedure TZUGFeRDInvoiceValidatorTests.TestTaxAmountWithinBRCO17ToleranceIsAccepted;
 var
@@ -966,6 +968,39 @@ begin
         ValidationResult.Messages.Text);
       Assert.IsTrue(ValidationResult.Messages.Text.Contains('BR-CO-17-Toleranz'),
         'Die zulässige Abweichung wurde nicht protokolliert:'#13#10 +
+        ValidationResult.Messages.Text);
+    finally
+      ValidationResult.Free;
+    end;
+  finally
+    Descriptor.Free;
+  end;
+end;
+
+/// <summary>
+/// Factur-X verwendet in FX-SCH-A-000052 inklusive Grenzen und akzeptiert deshalb
+/// genau eine Währungseinheit Abweichung. Aktuelle CEN- und Peppol-Artefakte
+/// verlangen dagegen eine strikt kleinere Abweichung. Da der Validator insgesamt
+/// kein Profil oder Ausgabeformat berücksichtigt, dokumentiert dieser Test bewusst
+/// die derzeit für alle Profile verwendete Factur-X-Grenze.
+/// </summary>
+procedure TZUGFeRDInvoiceValidatorTests.TestTaxAmountAtFacturXBRCO17ToleranceBoundaryIsAccepted;
+var
+  Descriptor: TZUGFeRDInvoiceDescriptor;
+  ValidationResult: TZUGFeRDValidationResult;
+begin
+  Descriptor := TZUGFeRDInvoiceDescriptor.CreateInvoice('RE-TOLERANCE-BOUNDARY', EncodeDate(2026, 1, 15), TZUGFeRDCurrencyCodes.EUR);
+  try
+    AddTaxGroup(Descriptor, 'Standard rate', 100, 19, 20, TZUGFeRDTaxCategoryCodes.S);
+    Descriptor.SetTotals(100, 0, 0, 100, 20, 120, 0, 120);
+
+    ValidationResult := TZUGFeRDInvoiceValidator.Validate(Descriptor, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsTrue(ValidationResult.IsValid,
+        'Die inklusive Factur-X-Grenze von einer Währungseinheit wurde als Fehler gemeldet:'#13#10 +
+        ValidationResult.Messages.Text);
+      Assert.IsTrue(ValidationResult.Messages.Text.Contains('BR-CO-17-Toleranz'),
+        'Die Abweichung an der Factur-X-Grenze wurde nicht protokolliert:'#13#10 +
         ValidationResult.Messages.Text);
     finally
       ValidationResult.Free;

--- a/intf.ZUGFeRDInvoiceValidator.pas
+++ b/intf.ZUGFeRDInvoiceValidator.pas
@@ -46,6 +46,10 @@ type
   ///
   /// Currently limited to summarizing line totals
   ///
+  /// Die Validierung ist derzeit unabhängig von Profil und Ausgabeformat. Regeln,
+  /// die sich zwischen Factur-X und XRechnung unterscheiden, können deshalb nicht
+  /// profilspezifisch ausgewählt werden.
+  ///
   /// Output syntax copied from Konik library (https://konik.io/)
   /// </summary>
   TZUGFeRDInvoiceValidator = class
@@ -215,9 +219,12 @@ begin
         Result.IsValid := false;
       end;
 
-      // BR-CO-17 lässt laut EN-16931-Schematron eine Abweichung von einer
-      // Währungseinheit je Steueraufschlüsselung zu. Was darüber liegt, ist ein
-      // Verstoß; was darunter liegt, wird protokolliert, damit es nicht untergeht.
+      // Der Validator ist insgesamt nicht profil- oder formatspezifisch. Factur-X
+      // 1.08/1.09 setzt BR-CO-17 in FX-SCH-A-000052 mit einer inklusiven Abweichung
+      // von einer Währungseinheit um, während die aktuellen CEN- und Peppol-
+      // Artefakte eine strikt kleinere Abweichung verlangen. Bis der Validator das
+      // konkrete Regelwerk kennt, bleibt die Factur-X-Grenze für alle Profile
+      // erhalten. Abweichungen werden protokolliert, damit sie nicht untergehen.
       taxDeviation := tax.TaxAmount - expectedTaxAmount;
       if Abs(taxDeviation) > 1 then
       begin


### PR DESCRIPTION
## Summary

- document that `TZUGFeRDInvoiceValidator` currently validates independently of profile and output format
- document the intentional inclusive BR-CO-17 tolerance used by Factur-X 1.08/1.09 rule `FX-SCH-A-000052`
- add a regression test showing that an exact deviation of 1.00 is accepted

## Background

Factur-X 1.08/1.09 accepts the inclusive 1.00 boundary in `FX-SCH-A-000052`. The current CEN and Peppol BR-CO-17 expressions use strict bounds and therefore require a deviation below 1.00.

Because the generic Delphi validator does not currently select a concrete rule set by profile or output format, this change keeps its existing Factur-X boundary and makes that decision explicit in source and test documentation.

References:

- [CEN EN16931 CII schematron](https://github.com/ConnectingEurope/eInvoicing-EN16931/blob/master/cii/schematron/CII/EN16931-CII-model.sch)
- [Peppol BR-CO-17](https://docs.peppol.eu/poacc/billing/3.0/rules/ubl-tc434/BR-CO-17/)

## Verification

- `ZfDUnitTest.dproj`, Win64 Debug: compilation successful with 0 errors, 0 warnings and 0 hints
