### PR TITLE
Validate BR-CO-10 against declared line totals

### DIFF
--- a/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
@@ -81,6 +81,10 @@ type
     [Test]
     procedure TestInvalidTaxTotalIsReported;
     [Test]
+    procedure TestDeclaredLineAmountsAreUsedForBRCO10;
+    [Test]
+    procedure TestDeclaredLineAmountDeviationIsReportedByBRCO10;
+    [Test]
     procedure TestTaxAmountsAreRoundedPerTaxGroup;
     [Test]
     procedure TestUnroundedTaxAmountIsReported;
@@ -90,6 +94,8 @@ type
     procedure TestTaxAmountWithinBRCO17ToleranceIsAccepted;
     [Test]
     procedure TestTaxAmountAtFacturXBRCO17ToleranceBoundaryIsAccepted;
+    [Test]
+    procedure TestTaxAmountJustBeyondBRCO17ToleranceIsReported;
     [Test]
     procedure TestTaxAmountBeyondBRCO17ToleranceIsReported;
     [Test]
@@ -128,6 +134,8 @@ type
     procedure TestMissingChargeTotalWithChargeIsReported;
     [Test]
     procedure TestMissingLineTotalAmountIsReported;
+    [Test]
+    procedure TestMissingLineItemLineTotalAmountIsReported;
     [Test]
     procedure TestValidationDoesNotRaiseOnDeviation;
   end;
@@ -499,6 +507,64 @@ begin
   end;
 end;
 
+/// <summary>
+/// BR-CO-10 bildet BT-106 aus den deklarierten Positionsnettobeträgen BT-131.
+/// Eine davon abweichende Nachrechnung aus Preis und Menge darf eine nach
+/// BR-CO-10 konsistente Rechnung nicht verwerfen.
+/// </summary>
+procedure TZUGFeRDInvoiceValidatorTests.TestDeclaredLineAmountsAreUsedForBRCO10;
+var
+  Descriptor: TZUGFeRDInvoiceDescriptor;
+  ValidationResult: TZUGFeRDValidationResult;
+begin
+  Descriptor := CreateBalancedInvoice(False);
+  try
+    Descriptor.TradeLineItems[0].LineTotalAmount := 199;
+    Descriptor.Taxes[0].BasisAmount := 199;
+    Descriptor.Taxes[0].TaxAmount := 37.81;
+    Descriptor.SetTotals(199, 0, 0, 199, 37.81, 236.81, 0, 236.81);
+
+    ValidationResult := TZUGFeRDInvoiceValidator.Validate(Descriptor, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsTrue(ValidationResult.IsValid,
+        'Eine nach BR-CO-10 konsistente Rechnung wurde anhand von Preis und Menge verworfen:'#13#10 +
+        ValidationResult.Messages.Text);
+    finally
+      ValidationResult.Free;
+    end;
+  finally
+    Descriptor.Free;
+  end;
+end;
+
+/// <summary>
+/// Stimmen die deklarierten BT-131 nicht mit BT-106 überein, muss BR-CO-10
+/// auch dann anschlagen, wenn die Nachrechnung aus Preis und Menge BT-106 ergibt.
+/// </summary>
+procedure TZUGFeRDInvoiceValidatorTests.TestDeclaredLineAmountDeviationIsReportedByBRCO10;
+var
+  Descriptor: TZUGFeRDInvoiceDescriptor;
+  ValidationResult: TZUGFeRDValidationResult;
+begin
+  Descriptor := CreateBalancedInvoice(False);
+  try
+    Descriptor.TradeLineItems[0].LineTotalAmount := 199.99;
+
+    ValidationResult := TZUGFeRDInvoiceValidator.Validate(Descriptor, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsFalse(ValidationResult.IsValid,
+        'Eine Abweichung zwischen der Summe der BT-131 und BT-106 wurde nicht beanstandet:'#13#10 +
+        ValidationResult.Messages.Text);
+      Assert.IsTrue(ValidationResult.Messages.Text.Contains('BR-CO-10'),
+        'Es fehlt die Meldung zu BR-CO-10:'#13#10 + ValidationResult.Messages.Text);
+    finally
+      ValidationResult.Free;
+    end;
+  finally
+    Descriptor.Free;
+  end;
+end;
+
 procedure TZUGFeRDInvoiceValidatorTests.TestTaxAmountsAreRoundedPerTaxGroup;
 var
   Descriptor: TZUGFeRDInvoiceDescriptor;
@@ -516,11 +582,14 @@ begin
     try
       Assert.IsTrue(ValidationResult.IsValid,
         'Tax amounts rounded per group were rejected:'#13#10 + ValidationResult.Messages.Text);
+      Assert.IsFalse(ValidationResult.Messages.Text.Contains('BR-CO-17-Toleranz'),
+        'Die korrekt gerundeten Steuerbeträge wurden nur durch die BR-CO-17-Toleranz akzeptiert:'#13#10 +
+        ValidationResult.Messages.Text);
     finally
-      FreeAndNil(ValidationResult);
+      ValidationResult.Free;
     end;
   finally
-    FreeAndNil(Descriptor);
+    Descriptor.Free;
   end;
 end;
 
@@ -589,18 +658,21 @@ begin
   Descriptor := TZUGFeRDInvoiceDescriptor.CreateInvoice('RE-ROUND-NEGATIVE', EncodeDate(2026, 1, 15), TZUGFeRDCurrencyCodes.EUR);
   try
     // Der Rundungsmodus entspricht der Betragsformatierung der Writer und rundet Mittelpunkte von null weg.
-    AddTaxGroup(Descriptor, 'Negative midpoint', -0.025, 20, -0.01, TZUGFeRDTaxCategoryCodes.S);
-    Descriptor.SetTotals(-0.025, 0, 0, -0.025, -0.01, -0.035, 0, -0.035);
+    AddTaxGroup(Descriptor, 'Negative midpoint', -0.05, 10, -0.01, TZUGFeRDTaxCategoryCodes.S);
+    Descriptor.SetTotals(-0.05, 0, 0, -0.05, -0.01, -0.06, 0, -0.06);
 
     ValidationResult := TZUGFeRDInvoiceValidator.Validate(Descriptor, TZUGFeRDVersion.Version23);
     try
       Assert.IsTrue(ValidationResult.IsValid,
         'Negative midpoint tax amount was not rounded away from zero:'#13#10 + ValidationResult.Messages.Text);
+      Assert.IsFalse(ValidationResult.Messages.Text.Contains('BR-CO-17-Toleranz'),
+        'Der negative Mittelpunkt wurde nur durch die BR-CO-17-Toleranz akzeptiert:'#13#10 +
+        ValidationResult.Messages.Text);
     finally
-      FreeAndNil(ValidationResult);
+      ValidationResult.Free;
     end;
   finally
-    FreeAndNil(Descriptor);
+    Descriptor.Free;
   end;
 end;
 
@@ -871,6 +943,33 @@ begin
 end;
 
 /// <summary>
+/// BR-24 verlangt für jede Rechnungsposition einen Positionsnettobetrag BT-131.
+/// Ohne diesen Wert darf BR-CO-10 die Position nicht still als null summieren.
+/// </summary>
+procedure TZUGFeRDInvoiceValidatorTests.TestMissingLineItemLineTotalAmountIsReported;
+var
+  Descriptor: TZUGFeRDInvoiceDescriptor;
+  ValidationResult: TZUGFeRDValidationResult;
+begin
+  Descriptor := CreateBalancedInvoice(False);
+  try
+    Descriptor.TradeLineItems[0].LineTotalAmount := nil;
+
+    ValidationResult := TZUGFeRDInvoiceValidator.Validate(Descriptor, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsFalse(ValidationResult.IsValid,
+        'Ein fehlendes BT-131 wurde nicht beanstandet:'#13#10 + ValidationResult.Messages.Text);
+      Assert.IsTrue(ValidationResult.Messages.Text.Contains('BR-24'),
+        'Es fehlt die Meldung zu BR-24:'#13#10 + ValidationResult.Messages.Text);
+    finally
+      ValidationResult.Free;
+    end;
+  finally
+    Descriptor.Free;
+  end;
+end;
+
+/// <summary>
 /// Baut eine ausgeglichene Rechnung, deren Nettoeinzelpreis BT-146 sich auf eine
 /// Preisbasismenge BT-149 bezieht: 100,00 je 10 Stück bei 2 berechneten Stück
 /// ergibt einen Positionsnettobetrag BT-131 von 20,00.
@@ -1025,6 +1124,35 @@ begin
 end;
 
 /// <summary>
+/// Bereits 1,01 Währungseinheiten Abweichung liegen jenseits der in Factur-X
+/// einschließlich verwendeten BR-CO-17-Grenze von einer Währungseinheit.
+/// </summary>
+procedure TZUGFeRDInvoiceValidatorTests.TestTaxAmountJustBeyondBRCO17ToleranceIsReported;
+var
+  Descriptor: TZUGFeRDInvoiceDescriptor;
+  ValidationResult: TZUGFeRDValidationResult;
+begin
+  Descriptor := TZUGFeRDInvoiceDescriptor.CreateInvoice('RE-TOLERANCE-JUST-OVER', EncodeDate(2026, 1, 15), TZUGFeRDCurrencyCodes.EUR);
+  try
+    AddTaxGroup(Descriptor, 'Standard rate', 100, 19, 20.01, TZUGFeRDTaxCategoryCodes.S);
+    Descriptor.SetTotals(100, 0, 0, 100, 20.01, 120.01, 0, 120.01);
+
+    ValidationResult := TZUGFeRDInvoiceValidator.Validate(Descriptor, TZUGFeRDVersion.Version23);
+    try
+      Assert.IsFalse(ValidationResult.IsValid,
+        'Eine Abweichung von 1,01 Währungseinheiten wurde nicht beanstandet:'#13#10 +
+        ValidationResult.Messages.Text);
+      Assert.IsTrue(ValidationResult.Messages.Text.Contains('BR-CO-17:'),
+        'Es fehlt die Meldung zu BR-CO-17:'#13#10 + ValidationResult.Messages.Text);
+    finally
+      ValidationResult.Free;
+    end;
+  finally
+    Descriptor.Free;
+  end;
+end;
+
+/// <summary>
 /// Jenseits einer Währungseinheit ist BR-CO-17 verletzt.
 /// </summary>
 procedure TZUGFeRDInvoiceValidatorTests.TestTaxAmountBeyondBRCO17ToleranceIsReported;
@@ -1088,11 +1216,9 @@ begin
 end;
 
 /// <summary>
-/// Geht die Preisbasismenge nicht glatt auf, muss der Positionsnettobetrag je
-/// Position auf zwei Nachkommastellen gerundet werden, bevor er in BT-106
-/// einfliesst: BR-DEC-23 laesst fuer BT-131 nicht mehr Stellen zu, und BR-CO-10
-/// summiert genau diese gerundeten Werte. Ohne die Rundung summieren sich die
-/// Reste ueber die Positionen auf und sprengen die Toleranz des Vergleichs.
+/// Geht die Preisbasismenge nicht glatt auf, bleibt die Nachrechnung aus Preis
+/// und Menge eine gerundete Diagnose. BR-CO-10 summiert dagegen die deklarierten
+/// BT-131, die nach BR-DEC-23 höchstens zwei Nachkommastellen besitzen.
 /// </summary>
 procedure TZUGFeRDInvoiceValidatorTests.TestPriceBaseQuantityRemaindersAreRoundedPerLine;
 var
@@ -1134,13 +1260,16 @@ begin
     ValidationResult := TZUGFeRDInvoiceValidator.Validate(Descriptor, TZUGFeRDVersion.Version23);
     try
       Assert.IsTrue(ValidationResult.IsValid,
-        'Eine gueltige Rechnung mit nicht aufgehender Preisbasismenge wurde verworfen:'#13#10 +
+        'Eine gültige Rechnung mit nicht aufgehender Preisbasismenge wurde verworfen:'#13#10 +
+        ValidationResult.Messages.Text);
+      Assert.IsTrue(ValidationResult.Messages.Text.Contains(Format(';Testartikel 1;%f', [33.33])),
+        'Die Diagnose rundet den nachgerechneten Positionsbetrag nicht auf zwei Stellen:'#13#10 +
         ValidationResult.Messages.Text);
     finally
-      FreeAndNil(ValidationResult);
+      ValidationResult.Free;
     end;
   finally
-    FreeAndNil(Descriptor);
+    Descriptor.Free;
   end;
 end;
 

--- a/intf.ZUGFeRDInvoiceValidator.pas
+++ b/intf.ZUGFeRDInvoiceValidator.pas
@@ -95,7 +95,8 @@ class function TZUGFeRDInvoiceValidator.Validate(descriptor: TZUGFeRDInvoiceDesc
 var
   lineCounter: Integer;
   lineTotal, allowanceTotal, chargeTotal, taxTotal, grandTotal, prepaid,
-    rounding, duePayable, expectedDuePayable, expectedTaxAmount: Currency;
+    rounding, duePayable, expectedDuePayable, expectedTaxAmount,
+    recalculatedLineAmount: Currency;
   declaredAllowanceTotal, declaredChargeTotal, expectedTaxBasis: Currency;
   taxDeviation: Currency;
   item: TZUGFeRDTradeLineItem;
@@ -120,21 +121,21 @@ begin
   //grandTotal := 0;
   // line item summation
     Result.Messages.Add('Validating invoice monetary summation');
-    Result.Messages.Add(Format('Starting recalculating line total from %d items...', [descriptor.TradeLineItems.Count]));
+    Result.Messages.Add(Format('Starting summing declared line total from %d items...', [descriptor.TradeLineItems.Count]));
 
     for item in descriptor.TradeLineItems do
     begin
-      var _total : Currency := 0;
+      recalculatedLineAmount := 0;
       if item.NetUnitPrice.HasValue then
       begin
-        _total := (item.NetUnitPrice.Value * item.BilledQuantity);
+        recalculatedLineAmount := item.NetUnitPrice.Value * item.BilledQuantity;
 
         // BT-146 gilt je Preisbasismenge BT-149, nicht je Einheit. Fehlt BT-149,
         // ist die Basismenge 1. Der CII-Writer rechnet bei fehlendem BT-131 genauso.
         if item.NetQuantity.HasValue then
         begin
           if item.NetQuantity.Value > 0 then
-            _total := _total / item.NetQuantity.Value
+            recalculatedLineAmount := recalculatedLineAmount / item.NetQuantity.Value
           else
           begin
             Result.Messages.Add(Format('BT-149: Die Preisbasismenge der Position [%s] muss größer als 0 sein', [item.Name]));
@@ -144,35 +145,43 @@ begin
 
         // BT-131 enthält BG-28-Positionszuschläge und vermindert sich um BG-27-Positionsabschläge.
         for var lineAllowance in item.GetSpecifiedTradeAllowances do
-          _total := _total - lineAllowance.ActualAmount;
+          recalculatedLineAmount := recalculatedLineAmount - lineAllowance.ActualAmount;
         for var lineCharge in item.GetSpecifiedTradeCharges do
-          _total := _total + lineCharge.ActualAmount;
+          recalculatedLineAmount := recalculatedLineAmount + lineCharge.ActualAmount;
 
-        // BT-131 hat nach BR-DEC-23 höchstens zwei Nachkommastellen, und BR-CO-10
-        // bildet BT-106 aus der Summe dieser gerundeten Positionsbeträge. Ohne die
-        // Rundung je Position summieren sich die Reste einer Preisbasismenge auf:
-        // vier Positionen zu 100,00 je 3 Stück ergeben 133,3332 statt 133,32 und
-        // sprengen die Toleranz des Vergleichs gegen BT-106. Der CII-Writer schreibt
-        // BT-131 an dieser Stelle ebenfalls zweistellig.
-        _total := SimpleRoundTo(_total, -2);
+        // BR-CO-10 selbst vergleicht BT-131 nicht mit Preis und Menge. Diese
+        // Nachrechnung bleibt daher eine getrennte, auf zwei Stellen gerundete
+        // Diagnose; profilspezifische Regeln sind nicht Aufgabe dieses Validators.
+        recalculatedLineAmount := SimpleRoundTo(recalculatedLineAmount, -2);
+      end;
 
-        lineTotal := lineTotal + _total;
+      // BR-24 verlangt BT-131 je Position. BR-CO-10 bildet BT-106 ausschließlich
+      // aus diesen deklarierten Positionsnettobeträgen, nicht aus Preis und Menge.
+      if item.LineTotalAmount.HasValue then
+        lineTotal := lineTotal + item.LineTotalAmount.Value
+      else
+      begin
+        Result.Messages.Add(Format('BR-24: Kein Positionsnettobetrag BT-131 für Position [%s] vorhanden', [item.Name]));
+        Result.IsValid := false;
       end;
 
       //retval.Add(String.Format("==> {0}:", ++lineCounter));
       //retval.Add(String.Format("Recalculating item: [{0}]", item.Name));
       //retval.Add(String.Format("Line total formula: {0:0.0000} EUR (net price) x {1:0.0000} (quantity)", item.NetUnitPrice, item.BilledQuantity));
 
-      //retval.Add(String.Format("Recalculated item line total = {0:0.0000} EUR", _total));
+      //retval.Add(String.Format("Recalculated item line total = {0:0.0000} EUR", recalculatedLineAmount));
       //retval.Add(String.Format("Recalculated item tax = {0:0.00} %", item.TaxPercent));
       //retval.Add(String.Format("Current monetarySummation.lineTotal = {0:0.0000} EUR(the sum of all line totals)", lineTotal));
 
       Inc(lineCounter);
-      Result.Messages.Add(Format('%d;%s;%f', [lineCounter, item.Name, _total]));
+      Result.Messages.Add(Format('%d;%s;%f', [lineCounter, item.Name, recalculatedLineAmount]));
     end;
 
+    // Das Schematron rundet die Summe der BT-131 für BR-CO-10 auf zwei Stellen.
+    lineTotal := SimpleRoundTo(lineTotal, -2);
+
     Result.Messages.Add('==> DONE!');
-    Result.Messages.Add('Finished recalculating monetarySummation.lineTotal...');
+    Result.Messages.Add('Finished summing declared monetarySummation.lineTotal...');
     Result.Messages.Add('Adding tax amounts from invoice allowance charge...');
 
     for var charge in descriptor.GetTradeCharges do
@@ -341,13 +350,13 @@ begin
       Result.Messages.Add('trade.settlement.monetarySummation.lineTotal Message: Kein LineTotalAmount vorhanden');
       Result.IsValid := false;
     end
-    else if Abs(lineTotal - descriptor.LineTotalAmount.Value) < 0.01 then
+    else if lineTotal = descriptor.LineTotalAmount.Value then
     begin
-      Result.Messages.Add(Format('trade.settlement.monetarySummation.lineTotal Message: Berechneter Wert ist wie vorhanden:[%4f]', [lineTotal]));
+      Result.Messages.Add(Format('BR-CO-10: Summe der deklarierten BT-131 ist wie BT-106:[%4f]', [lineTotal]));
     end
     else
     begin
-      Result.Messages.Add(Format('trade.settlement.monetarySummation.lineTotal Message: Berechneter Wert ist[%4f] aber tatsächliche vorhander Wert ist[%4f]', [lineTotal, descriptor.LineTotalAmount.GetValueOrDefault]));
+      Result.Messages.Add(Format('BR-CO-10: Summe der deklarierten BT-131 ist[%4f] aber BT-106 ist[%4f]', [lineTotal, descriptor.LineTotalAmount.GetValueOrDefault]));
       Result.IsValid := false;
     end;
 


### PR DESCRIPTION
## Summary

- validate BT-106 against the rounded sum of the declared BT-131 amounts, as required by BR-CO-10
- keep the price/quantity calculation as a separate rounded diagnostic instead of using it as the BR-CO-10 value
- report a missing BT-131 per invoice line as BR-24
- strengthen the existing tax-rounding tests so BR-CO-17 tolerance cannot hide a wrong rounding mode
- add the missing BR-CO-17 boundary test for a deviation of 1.01 currency units

## Rule reference

The implementation was checked against the official Factur-X 1.09.2 EN16931 Schematron included in `documentation/zugferd25-facturx1009-02/zugferd252de/Schema/Schema.zip`:

- BR-CO-10 defines BT-106 as the rounded sum of the declared BT-131 values
- BR-24 requires BT-131 on every invoice line
- BR-DEC-23 limits BT-131 to two decimal places

## Verification

- DUnitX: 384/384 tests passed
- Delphi 11 Win64 Debug build: 0 errors, 0 warnings, 0 hints
