### PR TITLE
Validate calculated UBL line totals

### DIFF
--- a/Unittest/intf.XRechnungUBLTests.UnitTests.pas
+++ b/Unittest/intf.XRechnungUBLTests.UnitTests.pas
@@ -21,16 +21,35 @@ interface
 
 uses
   DUnitX.TestFramework,
-  intf.ZUGFeRDTestBase;
+  intf.ZUGFeRDTestBase,
+  intf.ZUGFeRDInvoiceDescriptor;
 
 type
   [TestFixture]
   TXRechnungUBLTests = class(TZUGFeRDTestBase)
+  private
+    /// <summary>
+    /// Writes an XRechnung invoice to UBL and returns the UTF-8 XML.
+    /// </summary>
+    function SaveAsUBL(Descriptor: TZUGFeRDInvoiceDescriptor): string;
+    /// <summary>
+    /// Verifies that a non-positive BT-149 is rejected before a calculated
+    /// BT-131 can be written.
+    /// </summary>
+    procedure AssertLineExtensionAmountCalculationRejectsBaseQuantity(const UnitQuantity: Currency);
   public
     [Test]
     procedure TestParentLineId;
     [Test]
     procedure TestLineExtensionAmountIsCalculatedWhenMissing;
+    [Test]
+    procedure TestCalculatedLineExtensionAmountIncludesLineLevelAdjustments;
+    [Test]
+    procedure TestLineExtensionAmountCalculationRequiresNetUnitPrice;
+    [Test]
+    procedure TestLineExtensionAmountCalculationRejectsZeroBaseQuantity;
+    [Test]
+    procedure TestLineExtensionAmountCalculationRejectsNegativeBaseQuantity;
     [Test]
     procedure TestTaxRepresentativePartyNoNestedPartyElement;
     [Test]
@@ -116,8 +135,8 @@ implementation
 uses
   System.SysUtils, System.Classes, System.Math, System.RegularExpressions,
   System.Generics.Collections,
-  intf.ZUGFeRDInvoiceDescriptor,
   intf.ZUGFeRDInvoiceProvider,
+  intf.ZUGFeRDExceptions,
   intf.ZUGFeRDProfile,
   intf.ZUGFeRDInvoiceTypes,
   intf.ZUGFeRDVersion,
@@ -156,6 +175,67 @@ uses
   intf.ZUGFeRDApplicableProductCharacteristic;
 
 { TXRechnungUBLTests }
+
+procedure TXRechnungUBLTests.AssertLineExtensionAmountCalculationRejectsBaseQuantity(
+  const UnitQuantity: Currency);
+var
+  Descriptor: TZUGFeRDInvoiceDescriptor;
+  LineItem: TZUGFeRDTradeLineItem;
+  Raised: Boolean;
+begin
+  Descriptor := TZUGFeRDInvoiceProvider.CreateInvoice;
+  try
+    Descriptor.TradeLineItems.Clear;
+    LineItem := Descriptor.AddTradeLineItem(
+      {name=}            'Invalid price base quantity',
+      {netUnitPrice=}    TZUGFeRDNullableParam<Currency>.Create(100),
+      {description=}     '',
+      {unitCode=}        TZUGFeRDNullableParam<TZUGFeRDQuantityCodes>.Create(TZUGFeRDQuantityCodes.H87),
+      {unitQuantity=}    TZUGFeRDNullableParam<Currency>.Create(UnitQuantity),
+      {grossUnitPrice=}  nil,
+      {billedQuantity=}  2,
+      {lineTotalAmount=} 0,
+      {taxType=}         TZUGFeRDNullableParam<TZUGFeRDTaxTypes>.Create(TZUGFeRDTaxTypes.VAT),
+      {categoryCode=}    TZUGFeRDNullableParam<TZUGFeRDTaxCategoryCodes>.Create(TZUGFeRDTaxCategoryCodes.S),
+      {taxPercent=}      19.0);
+    LineItem.LineTotalAmount := nil;
+
+    Raised := False;
+    try
+      SaveAsUBL(Descriptor);
+    except
+      on E: TZUGFeRDArgumentException do
+      begin
+        Raised := True;
+        Assert.IsTrue(E.Message.Contains('BT-149'),
+          'The validation message does not identify BT-149: ' + E.Message);
+        Assert.IsTrue(E.Message.Contains('PEPPOL-EN16931-R121'),
+          'The validation message does not identify PEPPOL-EN16931-R121: ' + E.Message);
+      end;
+    end;
+    Assert.IsTrue(Raised, 'A non-positive price base quantity was not rejected');
+  finally
+    Descriptor.Free;
+  end;
+end;
+
+function TXRechnungUBLTests.SaveAsUBL(Descriptor: TZUGFeRDInvoiceDescriptor): string;
+var
+  Stream: TMemoryStream;
+  Bytes: TBytes;
+begin
+  Stream := TMemoryStream.Create;
+  try
+    Descriptor.Save(Stream, TZUGFeRDVersion.Version23, TZUGFeRDProfile.XRechnung, TZUGFeRDFormats.UBL);
+    Stream.Position := 0;
+    SetLength(Bytes, Stream.Size);
+    if Stream.Size > 0 then
+      Stream.ReadBuffer(Bytes[0], Stream.Size);
+    Result := TEncoding.UTF8.GetString(Bytes);
+  finally
+    Stream.Free;
+  end;
+end;
 
 procedure TXRechnungUBLTests.TestParentLineId;
 var
@@ -2113,10 +2193,9 @@ begin
 end;
 
 /// <summary>
-/// BT-131 ist in cac:InvoiceLine eine Pflichtangabe. Fehlt der Positionsbetrag im
-/// Descriptor, muss der Writer ihn aus Nettoeinzelpreis, berechneter Menge und
-/// Preisbasismenge bilden, statt das Element wegzulassen und ein schema-ungueltiges
-/// Dokument zu erzeugen.
+/// BT-131 is mandatory in cac:InvoiceLine. If it is missing from the descriptor,
+/// the writer calculates it from the net price, invoiced quantity and price base
+/// quantity instead of omitting the element.
 /// </summary>
 procedure TXRechnungUBLTests.TestLineExtensionAmountIsCalculatedWhenMissing;
 var
@@ -2163,6 +2242,109 @@ begin
   finally
     desc.Free;
   end;
+end;
+
+/// <summary>
+/// PEPPOL-EN16931-R120 includes BG-27 allowances and BG-28 charges in BT-131.
+/// A BG-29 price allowance is already reflected in BT-146 and must not be
+/// subtracted a second time.
+/// </summary>
+procedure TXRechnungUBLTests.TestCalculatedLineExtensionAmountIncludesLineLevelAdjustments;
+var
+  Descriptor: TZUGFeRDInvoiceDescriptor;
+  LineItem: TZUGFeRDTradeLineItem;
+  XmlContent: string;
+begin
+  Descriptor := TZUGFeRDInvoiceProvider.CreateInvoice;
+  try
+    Descriptor.TradeLineItems.Clear;
+    LineItem := Descriptor.AddTradeLineItem(
+      {name=}            'Line adjustments',
+      {netUnitPrice=}    TZUGFeRDNullableParam<Currency>.Create(100),
+      {description=}     '',
+      {unitCode=}        TZUGFeRDNullableParam<TZUGFeRDQuantityCodes>.Create(TZUGFeRDQuantityCodes.H87),
+      {unitQuantity=}    TZUGFeRDNullableParam<Currency>.Create(10),
+      {grossUnitPrice=}  TZUGFeRDNullableParam<Currency>.Create(110),
+      {billedQuantity=}  2,
+      {lineTotalAmount=} 0,
+      {taxType=}         TZUGFeRDNullableParam<TZUGFeRDTaxTypes>.Create(TZUGFeRDTaxTypes.VAT),
+      {categoryCode=}    TZUGFeRDNullableParam<TZUGFeRDTaxCategoryCodes>.Create(TZUGFeRDTaxCategoryCodes.S),
+      {taxPercent=}      19.0);
+    LineItem.LineTotalAmount := nil;
+    LineItem.AddTradeAllowance(TZUGFeRDCurrencyCodes.EUR,
+      TZUGFeRDNullableParam<Currency>.Create(110), 10, 'Price allowance');
+    LineItem.AddSpecifiedTradeAllowance(TZUGFeRDCurrencyCodes.EUR,
+      TZUGFeRDNullableParam<Currency>.Create(20), 3, 'Line allowance');
+    LineItem.AddSpecifiedTradeCharge(TZUGFeRDCurrencyCodes.EUR,
+      TZUGFeRDNullableParam<Currency>.Create(20), 1, 'Line charge');
+
+    XmlContent := SaveAsUBL(Descriptor);
+
+    Assert.IsTrue(XmlContent.Contains('<cbc:LineExtensionAmount currencyID="EUR">18.00</cbc:LineExtensionAmount>'),
+      'BT-131 does not include the BG-27 allowance and BG-28 charge exactly once:'#13#10 + XmlContent);
+  finally
+    Descriptor.Free;
+  end;
+end;
+
+/// <summary>
+/// BT-146 is mandatory and is required to calculate a missing BT-131. Writing
+/// 0.00 would hide the missing source value and change the invoice semantics.
+/// </summary>
+procedure TXRechnungUBLTests.TestLineExtensionAmountCalculationRequiresNetUnitPrice;
+var
+  Descriptor: TZUGFeRDInvoiceDescriptor;
+  LineItem: TZUGFeRDTradeLineItem;
+  Raised: Boolean;
+begin
+  Descriptor := TZUGFeRDInvoiceProvider.CreateInvoice;
+  try
+    Descriptor.TradeLineItems.Clear;
+    LineItem := Descriptor.AddTradeLineItem(
+      {name=}            'Missing net price',
+      {netUnitPrice=}    nil,
+      {description=}     '',
+      {unitCode=}        TZUGFeRDNullableParam<TZUGFeRDQuantityCodes>.Create(TZUGFeRDQuantityCodes.H87),
+      {unitQuantity=}    nil,
+      {grossUnitPrice=}  nil,
+      {billedQuantity=}  2,
+      {lineTotalAmount=} 0,
+      {taxType=}         TZUGFeRDNullableParam<TZUGFeRDTaxTypes>.Create(TZUGFeRDTaxTypes.VAT),
+      {categoryCode=}    TZUGFeRDNullableParam<TZUGFeRDTaxCategoryCodes>.Create(TZUGFeRDTaxCategoryCodes.S),
+      {taxPercent=}      19.0);
+    LineItem.LineTotalAmount := nil;
+
+    Raised := False;
+    try
+      SaveAsUBL(Descriptor);
+    except
+      on E: TZUGFeRDMissingDataException do
+      begin
+        Raised := True;
+        Assert.IsTrue(E.Message.Contains('BT-146'),
+          'The validation message does not identify BT-146: ' + E.Message);
+      end;
+    end;
+    Assert.IsTrue(Raised, 'A missing net unit price was silently written as 0.00');
+  finally
+    Descriptor.Free;
+  end;
+end;
+
+/// <summary>
+/// PEPPOL-EN16931-R121 requires a positive price base quantity.
+/// </summary>
+procedure TXRechnungUBLTests.TestLineExtensionAmountCalculationRejectsZeroBaseQuantity;
+begin
+  AssertLineExtensionAmountCalculationRejectsBaseQuantity(0);
+end;
+
+/// <summary>
+/// PEPPOL-EN16931-R121 also excludes negative price base quantities.
+/// </summary>
+procedure TXRechnungUBLTests.TestLineExtensionAmountCalculationRejectsNegativeBaseQuantity;
+begin
+  AssertLineExtensionAmountCalculationRejectsBaseQuantity(-1);
 end;
 
 

--- a/intf.ZUGFeRDInvoiceDescriptor22UBLWriter.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor22UBLWriter.pas
@@ -87,6 +87,7 @@ type
     procedure _writeOptionalParty(_writer: TZUGFeRDProfileAwareXmlTextWriter; partyType : TZUGFeRDPartyTypes; party : TZUGFeRDParty; contact : TZUGFeRDContact = nil; electronicAddress : TZUGFeRDElectronicAddress = nil; taxRegistrations : TObjectList<TZUGFeRDTaxRegistration> = nil);
     procedure _writeApplicableProductCharacteristics(_writer: TZUGFeRDProfileAwareXmlTextWriter; productCharacteristics : TObjectList<TZUGFeRDApplicableProductCharacteristic>);
     procedure _writeIncludedReferencedProducts(_writer: TZUGFeRDProfileAwareXmlTextWriter; includedReferencedProducts : TObjectList<TZUGFeRDIncludedReferencedProduct>);
+    function _CalculateLineTotalAmount(tradeLineItem: TZUGFeRDTradeLineItem): Currency;
     procedure _WriteDocumentLevelAllowanceCharges(tradeAllowanceCharge: TZUGFeRDAbstractTradeAllowanceCharge);
     procedure _WriteTradeLineItem(tradeLineItem: TZUGFeRDTradeLineItem; isInvoice: Boolean; options: TZUGFeRDInvoiceFormatOptions);
     procedure _WriteItemLevelSpecifiedTradeAllowanceCharge(specifiedTradeAllowanceCharge: TZUGFeRDAbstractTradeAllowanceCharge);
@@ -683,6 +684,36 @@ begin
 end;
 
 
+/// <summary>
+/// Returns BT-131, calculating a missing value according to
+/// PEPPOL-EN16931-R120 from BT-146, BT-129, BT-149, BG-27 and BG-28.
+/// </summary>
+function TZUGFeRDInvoiceDescriptor22UBLWriter._CalculateLineTotalAmount(
+  tradeLineItem: TZUGFeRDTradeLineItem): Currency;
+var
+  SpecifiedTradeAllowance: TZUGFeRDTradeAllowance;
+  SpecifiedTradeCharge: TZUGFeRDTradeCharge;
+begin
+  if not tradeLineItem.NetUnitPrice.HasValue then
+    raise TZUGFeRDMissingDataException.Create('Net unit price (BT-146) is required for UBL lines.');
+
+  if tradeLineItem.NetQuantity.HasValue and (tradeLineItem.NetQuantity.Value <= 0) then
+    raise TZUGFeRDArgumentException.Create('Price base quantity (BT-149) must be greater than zero (PEPPOL-EN16931-R121).');
+
+  if tradeLineItem.LineTotalAmount.HasValue then
+    Exit(tradeLineItem.LineTotalAmount.Value);
+
+  Result := tradeLineItem.NetUnitPrice.Value * tradeLineItem.BilledQuantity;
+  if tradeLineItem.NetQuantity.HasValue then
+    Result := Result / tradeLineItem.NetQuantity.Value;
+
+  for SpecifiedTradeAllowance in tradeLineItem.GetSpecifiedTradeAllowances do
+    Result := Result - SpecifiedTradeAllowance.ActualAmount;
+  for SpecifiedTradeCharge in tradeLineItem.GetSpecifiedTradeCharges do
+    Result := Result + SpecifiedTradeCharge.ActualAmount;
+end;
+
+
 procedure TZUGFeRDInvoiceDescriptor22UBLWriter._WriteTradeLineItem(
   tradeLineItem: TZUGFeRDTradeLineItem; isInvoice: Boolean;
   options: TZUGFeRDInvoiceFormatOptions);
@@ -692,6 +723,7 @@ var
   specifiedTradeCharge : TZUGFeRDTradeCharge;
   subTradeLineItem : TZUGFeRDTradeLineItem;
   charges : TObjectList<TZUGFeRDAbstractTradeAllowanceCharge>;
+  lineTotalAmount: Currency;
 begin
   if tradeLineItem.AssociatedDocument.ParentLineID = '' then
   begin
@@ -737,18 +769,7 @@ begin
 
   WriteComment(Writer, options, TZUGFeRDInvoiceCommentConstants.SpecifiedTradeSettlementLineMonetarySummationComment);
 
-  // BT-131 ist in cac:InvoiceLine eine Pflichtangabe. Fehlt der Positionsbetrag im
-  // Descriptor, wird er wie im CII-Writer aus Nettoeinzelpreis, berechneter Menge
-  // und Preisbasismenge gebildet, statt das Element wegzulassen.
-  var lineTotalAmount: Currency := 0;
-  if tradeLineItem.LineTotalAmount.HasValue then
-    lineTotalAmount := tradeLineItem.LineTotalAmount.Value
-  else if tradeLineItem.NetUnitPrice.HasValue then
-  begin
-    lineTotalAmount := tradeLineItem.NetUnitPrice.Value * tradeLineItem.BilledQuantity;
-    if tradeLineItem.NetQuantity.HasValue and (tradeLineItem.NetQuantity.Value <> 0) then
-      lineTotalAmount := lineTotalAmount / tradeLineItem.NetQuantity.Value;
-  end;
+  lineTotalAmount := _CalculateLineTotalAmount(tradeLineItem);
 
   Writer.WriteStartElement('cbc:LineExtensionAmount');
   Writer.WriteAttributeString('currencyID', TEnumExtensions<TZUGFeRDCurrencyCodes>.EnumToString(Descriptor.Currency));


### PR DESCRIPTION
## Summary
- calculate a missing UBL invoice line net amount (BT-131) from BT-146, BT-129, BT-149, BG-27 and BG-28
- reject a missing item net price (BT-146) and a non-positive price base quantity (BT-149) instead of silently writing an incorrect amount
- keep an explicitly supplied BT-131 unchanged and do not apply the BG-29 price allowance a second time

## Specification basis
- PEPPOL-EN16931-R120 defines the BT-131 calculation including invoice-line allowances and charges
- PEPPOL-EN16931-R121 requires BT-149 to be greater than zero
- both rules are also contained in the bundled XRechnung 3.0.1 UBL Schematron at `documentation/xRechnung/XRechnung 3.0.1/xrechnung-3.0.1-schematron-2.0.1.zip`

## Verification
- countercheck before the writer change: 384 tests executed, the four new regression cases failed
- Win64 Debug DUnitX: 384/384 tests passed, 0 leaks
- Win64 Debug build: 0 errors, 0 warnings, 0 hints