### PR TITLE
Preserve unrounded tax amount in BR-DEC-20 message

### DIFF
--- a/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
@@ -541,11 +541,13 @@ begin
       // unzulässige Zahl der Nachkommastellen.
       Assert.IsTrue(ValidationResult.Messages.Text.Contains('BR-DEC-20'),
         'Validation messages do not identify BR-DEC-20');
+      Assert.IsTrue(ValidationResult.Messages.Text.Contains(Format('%.4f', [0.0057])),
+        'Validation messages do not preserve the unrounded tax amount:'#13#10 + ValidationResult.Messages.Text);
     finally
-      FreeAndNil(ValidationResult);
+      ValidationResult.Free;
     end;
   finally
-    FreeAndNil(Descriptor);
+    Descriptor.Free;
   end;
 end;
 

--- a/intf.ZUGFeRDInvoiceValidator.pas
+++ b/intf.ZUGFeRDInvoiceValidator.pas
@@ -238,7 +238,7 @@ begin
       if Frac(tax.TaxAmount * 100) <> 0 then
       begin
         Result.Messages.Add(Format(
-          'BR-DEC-20: Der Steuerbetrag[%4f] hat mehr als zwei Nachkommastellen', [tax.TaxAmount]));
+          'BR-DEC-20: Der Steuerbetrag[%.4f] hat mehr als zwei Nachkommastellen', [tax.TaxAmount]));
         Result.IsValid := false;
       end;
 


### PR DESCRIPTION
## Summary
- format the offending BT-117 value with four decimal places in the BR-DEC-20 validation message
- retain the value that caused the rule violation instead of rounding it to two decimal places in the diagnostic
- add a regression assertion for the reported amount

## Verification
- countercheck before the format change: 380 tests executed, the updated BR-DEC-20 regression test failed
- Win64 Debug DUnitX: 380/380 tests passed, 0 leaks
- Win64 Debug build: 0 errors, 0 warnings, 0 hints