### PR TITLE
Report nil advance payment entries accurately

### DIFF
--- a/Unittest/intf.ZUGFeRD22Tests.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRD22Tests.UnitTests.pas
@@ -40,6 +40,8 @@ type
     [Test]
     procedure TestAdvancePaymentMandatoryDataValidation;
     [Test]
+    procedure TestNilAdvancePaymentValidation;
+    [Test]
     procedure TestAdvancePaymentReaderRejectsMissingMandatoryData;
     [Test]
     procedure TestReferenceAdvancePaymentFromDocumentation;
@@ -743,6 +745,43 @@ begin
     AssertSaveRaisesMissingData;
   finally
     desc.Free;
+  end;
+end;
+
+/// <summary>
+/// Verifies that a nil BG-X-45 list entry is reported separately from a
+/// missing paid amount.
+/// </summary>
+procedure TZUGFeRD22Tests.TestNilAdvancePaymentValidation;
+var
+  Descriptor: TZUGFeRDInvoiceDescriptor;
+  Stream: TMemoryStream;
+  Raised: Boolean;
+begin
+  Descriptor := TZUGFeRDInvoiceDescriptor.Load(DemodataPath('zugferd21\zugferd_2p1_EXTENDED_Warenrechnung-factur-x.xml'));
+  try
+    Descriptor.AdvancePayments.Clear;
+    Descriptor.AdvancePayments.Add(nil);
+
+    Stream := TMemoryStream.Create;
+    try
+      Raised := False;
+      try
+        Descriptor.Save(Stream, TZUGFeRDVersion.Version23, TZUGFeRDProfile.Extended);
+      except
+        on E: TZUGFeRDMissingDataException do
+        begin
+          Raised := True;
+          Assert.IsTrue(E.Message.Contains('entry must not be nil'),
+            'The validation message does not identify the nil advance payment entry: ' + E.Message);
+        end;
+      end;
+      Assert.IsTrue(Raised, 'A nil advance payment entry was not rejected');
+    finally
+      Stream.Free;
+    end;
+  finally
+    Descriptor.Free;
   end;
 end;
 

--- a/intf.ZUGFeRDInvoiceDescriptor23CIIWriter.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor23CIIWriter.pas
@@ -134,7 +134,7 @@ begin
 end;
 
 /// <summary>
-/// Prüft die Pflichtangaben der nur im EXTENDED-Profil ausgegebenen Vorauszahlungen.
+/// Validates mandatory data for advance payments written only in the EXTENDED profile.
 /// </summary>
 procedure TZUGFeRDInvoiceDescriptor23CIIWriter._validateAdvancePayments;
 begin
@@ -144,7 +144,7 @@ begin
   for var advancePayment: TZUGFeRDAdvancePayment in Descriptor.AdvancePayments do
   begin
     if not Assigned(advancePayment) then
-      raise TZUGFeRDMissingDataException.Create('Advance payment paid amount is required (BG-X-45).');
+      raise TZUGFeRDMissingDataException.Create('Advance payment entry must not be nil (BG-X-45).');
     if not advancePayment.PaidAmount.HasValue then
       raise TZUGFeRDMissingDataException.Create('Advance payment paid amount is required (BG-X-45).');
 


### PR DESCRIPTION
## Summary
- report a nil entry in the BG-X-45 advance-payment list separately from a missing paid amount
- retain `TZUGFeRDMissingDataException` while making the diagnostic identify the actual invalid state
- add a regression test that distinguishes both cases

## Verification
- countercheck before the message change: 381 tests executed, only the new nil-entry regression test failed
- Win64 Debug DUnitX: 381/381 tests passed, 0 leaks
- Win64 Debug build: 0 errors, 0 warnings, 0 hints