### PR TITLE
Free CII reader descriptor after parsing errors

### DIFF
--- a/Unittest/intf.ZUGFeRD22Tests.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRD22Tests.UnitTests.pas
@@ -42,6 +42,8 @@ type
     [Test]
     procedure TestAdvancePaymentReaderRejectsMissingMandatoryData;
     [Test]
+    procedure TestCIIReaderReleasesDescriptorAfterParsingError;
+    [Test]
     procedure TestReferenceAdvancePaymentFromDocumentation;
     [Test]
     procedure TestExtendedInvoiceWithIncludedItems;
@@ -818,6 +820,86 @@ begin
     AssertRemovalRaisesMissingData('<ram:IssuerAssignedID>R202506-01</ram:IssuerAssignedID>');
   finally
     desc.Free;
+  end;
+end;
+
+/// <summary>
+/// Prüft, dass der CII-2.3-Reader einen teilweise aufgebauten Descriptor bei
+/// einer Ausnahme vor dem Advance-Payment-Block freigibt.
+/// </summary>
+procedure TZUGFeRD22Tests.TestCIIReaderReleasesDescriptorAfterParsingError;
+const
+  validIssueDateXml = '<udt:DateTimeString format="102">20251001</udt:DateTimeString>';
+  invalidIssueDateXml = '<udt:DateTimeString format="102">2025100</udt:DateTimeString>';
+  measuredLoadCount = 10;
+var
+  xmlContent: string;
+  invalidXml: string;
+  invalidStream: TStringStream;
+  firstBatchMemory: NativeUInt;
+  secondBatchMemory: NativeUInt;
+  loadIndex: Integer;
+  allLoadsFailed: Boolean;
+
+  function GetAllocatedMemory: NativeUInt;
+  var
+    memoryManagerState: TMemoryManagerState;
+    smallBlockTypeState: TSmallBlockTypeState;
+  begin
+    {$WARN SYMBOL_PLATFORM OFF}
+    GetMemoryManagerState(memoryManagerState);
+    {$WARN SYMBOL_PLATFORM DEFAULT}
+    Result := memoryManagerState.TotalAllocatedMediumBlockSize +
+      memoryManagerState.TotalAllocatedLargeBlockSize;
+    for smallBlockTypeState in memoryManagerState.SmallBlockTypeStates do
+      Inc(Result, NativeUInt(smallBlockTypeState.UseableBlockSize) *
+        smallBlockTypeState.AllocatedBlockCount);
+  end;
+
+  function LoadRaisesParsingError: Boolean;
+  var
+    loadedInvoice: TZUGFeRDInvoiceDescriptor;
+  begin
+    Result := False;
+    loadedInvoice := nil;
+    try
+      try
+        invalidStream.Position := 0;
+        loadedInvoice := TZUGFeRDInvoiceDescriptor.Load(invalidStream);
+      except
+        Result := True;
+      end;
+    finally
+      loadedInvoice.Free;
+    end;
+  end;
+
+begin
+  xmlContent := TFile.ReadAllText(DocumentationPath(
+    'zugferd24-facturx1008\de\Beispiele\4. EXTENDED\EXTENDED_Warenrechnung\EXTENDED_Warenrechnung.xml'),
+    TEncoding.UTF8);
+  invalidXml := StringReplace(xmlContent, validIssueDateXml, invalidIssueDateXml, []);
+  Assert.AreNotEqual(xmlContent, invalidXml, 'Das zu ersetzende Rechnungsdatum wurde nicht gefunden.');
+
+  invalidStream := TStringStream.Create(invalidXml, TEncoding.UTF8);
+  try
+    Assert.IsTrue(LoadRaisesParsingError, 'Das ungültige Rechnungsdatum wurde nicht abgelehnt.');
+
+    for loadIndex := 1 to measuredLoadCount do
+      LoadRaisesParsingError;
+    firstBatchMemory := GetAllocatedMemory;
+
+    allLoadsFailed := True;
+    for loadIndex := 1 to measuredLoadCount do
+      allLoadsFailed := LoadRaisesParsingError and allLoadsFailed;
+    secondBatchMemory := GetAllocatedMemory;
+
+    Assert.IsTrue(allLoadsFailed, 'Mindestens ein ungültiges Rechnungsdatum wurde nicht abgelehnt.');
+    Assert.IsTrue(secondBatchMemory <= firstBatchMemory,
+      Format('Wiederholte Parser-Ausnahmen erhöhten den belegten Speicher von %s auf %s Bytes.',
+        [UIntToStr(firstBatchMemory), UIntToStr(secondBatchMemory)]));
+  finally
+    invalidStream.Free;
   end;
 end;
 

--- a/intf.ZUGFeRDInvoiceDescriptor23CIIReader.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor23CIIReader.pas
@@ -258,6 +258,7 @@ begin
   //   nsmgr.AddNamespace('rsm', nsmgr.DefaultNamespace);
 
   Result := TZUGFeRDInvoiceDescriptor.Create;
+  try
 
   Result.IsTest := TZUGFeRDXmlUtils.NodeAsBool(doc.documentElement,'//*[local-name()="ExchangedDocumentContext"]/ram:TestIndicator/udt:Indicator',false);
   Result.BusinessProcess := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//*[local-name()="BusinessProcessSpecifiedDocumentContextParameter"]/ram:ID');//, nsmgr),
@@ -622,75 +623,70 @@ begin
       TEnumExtensions<TZUGFeRDAccountingAccountTypeCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:TypeCode')));
 
   // Vorauszahlungen / Anzahlungen, BG-X-45 (nur EXTENDED)
-  try
-    nodes := doc.SelectNodes('//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedAdvancePayment');
-    for i := 0 to nodes.length-1 do
-    begin
-      var advancePayment: TZUGFeRDAdvancePayment := TZUGFeRDAdvancePayment.Create;
-      try
-        advancePayment.PaidAmount := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './ram:PaidAmount');
-        if not advancePayment.PaidAmount.HasValue then
-          raise TZUGFeRDMissingDataException.Create('Advance payment paid amount is required (BG-X-45).');
+  nodes := doc.SelectNodes('//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedAdvancePayment');
+  for i := 0 to nodes.length-1 do
+  begin
+    var advancePayment: TZUGFeRDAdvancePayment := TZUGFeRDAdvancePayment.Create;
+    try
+      advancePayment.PaidAmount := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './ram:PaidAmount');
+      if not advancePayment.PaidAmount.HasValue then
+        raise TZUGFeRDMissingDataException.Create('Advance payment paid amount is required (BG-X-45).');
 
-        advancePayment.FormattedReceivedDateTime := TZUGFeRDXmlUtils.NodeAsDateTime(nodes[i],
-          './ram:FormattedReceivedDateTime/qdt:DateTimeString');
+      advancePayment.FormattedReceivedDateTime := TZUGFeRDXmlUtils.NodeAsDateTime(nodes[i],
+        './ram:FormattedReceivedDateTime/qdt:DateTimeString');
 
-        var taxNodes: IXMLDOMNodeList := nodes[i].selectNodes('./ram:IncludedTradeTax');
-        if taxNodes.length = 0 then
-          raise TZUGFeRDMissingDataException.Create('At least one included trade tax is required for an advance payment (BG-X-45).');
+      var taxNodes: IXMLDOMNodeList := nodes[i].selectNodes('./ram:IncludedTradeTax');
+      if taxNodes.length = 0 then
+        raise TZUGFeRDMissingDataException.Create('At least one included trade tax is required for an advance payment (BG-X-45).');
 
-        for var taxIndex: Integer := 0 to taxNodes.length-1 do
-        begin
-          var taxAmount: ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(
-            taxNodes[taxIndex], './ram:CalculatedAmount');
-          var taxTypeCode: ZUGFeRDNullable<TZUGFeRDTaxTypes> :=
-            TEnumExtensions<TZUGFeRDTaxTypes>.StringToNullableEnum(
-              TZUGFeRDXmlUtils.NodeAsString(taxNodes[taxIndex], './ram:TypeCode'));
-          var taxCategoryCode: ZUGFeRDNullable<TZUGFeRDTaxCategoryCodes> :=
-            TEnumExtensions<TZUGFeRDTaxCategoryCodes>.StringToNullableEnum(
-              TZUGFeRDXmlUtils.NodeAsString(taxNodes[taxIndex], './ram:CategoryCode'));
-          if not taxAmount.HasValue or not taxTypeCode.HasValue or not taxCategoryCode.HasValue then
-            raise TZUGFeRDMissingDataException.Create('Advance payment tax amount, type and category are required (BG-X-45).');
+      for var taxIndex: Integer := 0 to taxNodes.length-1 do
+      begin
+        var taxAmount: ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(
+          taxNodes[taxIndex], './ram:CalculatedAmount');
+        var taxTypeCode: ZUGFeRDNullable<TZUGFeRDTaxTypes> :=
+          TEnumExtensions<TZUGFeRDTaxTypes>.StringToNullableEnum(
+            TZUGFeRDXmlUtils.NodeAsString(taxNodes[taxIndex], './ram:TypeCode'));
+        var taxCategoryCode: ZUGFeRDNullable<TZUGFeRDTaxCategoryCodes> :=
+          TEnumExtensions<TZUGFeRDTaxCategoryCodes>.StringToNullableEnum(
+            TZUGFeRDXmlUtils.NodeAsString(taxNodes[taxIndex], './ram:CategoryCode'));
+        if not taxAmount.HasValue or not taxTypeCode.HasValue or not taxCategoryCode.HasValue then
+          raise TZUGFeRDMissingDataException.Create('Advance payment tax amount, type and category are required (BG-X-45).');
 
-          var includedTax: TZUGFeRDTax := TZUGFeRDTax.Create;
-          try
-            includedTax.TaxAmount := taxAmount.Value;
-            includedTax.TypeCode := taxTypeCode;
-            includedTax.CategoryCode := taxCategoryCode;
-            includedTax.Percent := TZUGFeRDXmlUtils.NodeAsDecimal(
-              taxNodes[taxIndex], './ram:RateApplicablePercent', 0).Value;
-            advancePayment.IncludedTradeTaxes.Add(includedTax);
-            includedTax := nil;
-          finally
-            includedTax.Free;
-          end;
+        var includedTax: TZUGFeRDTax := TZUGFeRDTax.Create;
+        try
+          includedTax.TaxAmount := taxAmount.Value;
+          includedTax.TypeCode := taxTypeCode;
+          includedTax.CategoryCode := taxCategoryCode;
+          includedTax.Percent := TZUGFeRDXmlUtils.NodeAsDecimal(
+            taxNodes[taxIndex], './ram:RateApplicablePercent', 0).Value;
+          advancePayment.IncludedTradeTaxes.Add(includedTax);
+          includedTax := nil;
+        finally
+          includedTax.Free;
         end;
-
-        if nodes[i].selectSingleNode('./ram:InvoiceSpecifiedReferencedDocument') <> nil then
-        begin
-          var invoiceReferenceID: string := TZUGFeRDXmlUtils.NodeAsString(nodes[i],
-            './ram:InvoiceSpecifiedReferencedDocument/ram:IssuerAssignedID');
-          if Trim(invoiceReferenceID) = '' then
-            raise TZUGFeRDMissingDataException.Create('Advance payment invoice reference ID is required when a reference is specified (BG-X-45).');
-
-          advancePayment.SetInvoiceReferencedDocument(
-            invoiceReferenceID,
-            TZUGFeRDXmlUtils.NodeAsDateTime(nodes[i],
-              './ram:InvoiceSpecifiedReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString'),
-            TEnumExtensions<TZUGFeRDInvoiceType>.StringToNullableEnum(
-              TZUGFeRDXmlUtils.NodeAsString(nodes[i],
-                './ram:InvoiceSpecifiedReferencedDocument/ram:TypeCode')));
-        end;
-
-        Result.AdvancePayments.Add(advancePayment);
-        advancePayment := nil;
-      finally
-        advancePayment.Free;
       end;
+
+      if nodes[i].selectSingleNode('./ram:InvoiceSpecifiedReferencedDocument') <> nil then
+      begin
+        var invoiceReferenceID: string := TZUGFeRDXmlUtils.NodeAsString(nodes[i],
+          './ram:InvoiceSpecifiedReferencedDocument/ram:IssuerAssignedID');
+        if Trim(invoiceReferenceID) = '' then
+          raise TZUGFeRDMissingDataException.Create('Advance payment invoice reference ID is required when a reference is specified (BG-X-45).');
+
+        advancePayment.SetInvoiceReferencedDocument(
+          invoiceReferenceID,
+          TZUGFeRDXmlUtils.NodeAsDateTime(nodes[i],
+            './ram:InvoiceSpecifiedReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString'),
+          TEnumExtensions<TZUGFeRDInvoiceType>.StringToNullableEnum(
+            TZUGFeRDXmlUtils.NodeAsString(nodes[i],
+              './ram:InvoiceSpecifiedReferencedDocument/ram:TypeCode')));
+      end;
+
+      Result.AdvancePayments.Add(advancePayment);
+      advancePayment := nil;
+    finally
+      advancePayment.Free;
     end;
-  except
-    Result.Free;
-    raise;
   end;
 
   Result.OrderDate:= TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableHeaderTradeAgreement/ram:BuyerOrderReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString');
@@ -722,6 +718,10 @@ begin
   nodes := doc.SelectNodes('//ram:IncludedSupplyChainTradeLineItem');
   for i := 0 to nodes.length-1 do
     Result.TradeLineItems.Add(_parseTradeLineItem(nodes[i]));
+  except
+    Result.Free;
+    raise;
+  end;
 end;
 
 function TZUGFeRDInvoiceDescriptor23CIIReader._parseTradeLineItem(tradeLineItem: IXmlDomNode): TZUGFeRDTradeLineItem;


### PR DESCRIPTION
## Summary
- free a partially populated `TZUGFeRDInvoiceDescriptor` when any exception escapes the ZUGFeRD 2.3 CII reader
- retain the existing ownership handling for temporary advance-payment and tax objects
- add a regression test that triggers a header parsing error before the former advance-payment-specific exception handler

## Regression evidence
Before the reader change, ten additional failing loads increased the allocated heap from 6,521,832 to 6,550,232 bytes. The new test detected this 28,400-byte increase. With the reader change applied, the same test passes.

## Verification
- Delphi 11 Win64 Debug build: 0 errors, 0 warnings, 0 hints
- DUnitX: 381 tests passed, 0 failed, 0 errors
