### PR TITLE
Fix console test selection and verify heap assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,45 @@ attachments in pure Pascal.
 - [documentation/](documentation/) — the official specifications, schemas and example invoices from
   ZUGFeRD 1.0 up to 2.5.2 / Factur-X 1.09.2.
 
+### Console test execution
+
+Build `Unittest/ZfDUnitTest.dproj` with Delphi 11, Win64, Debug. The executable is written
+directly to `Unittest/`. From that directory, Windows PowerShell 5.1 can run the suite or
+select a fully qualified DUnitX test/fixture name:
+
+```powershell
+.\run-tests.ps1
+.\run-tests.ps1 -Filter 'intf.ZUGFeRD22Tests.UnitTests.TZUGFeRD22Tests.TestCIIReaderReleasesDescriptorAfterParsingError'
+.\Test-Runner.ps1
+```
+
+The native DUnitX syntax uses colons: `--run:<qualified-name>`, `--xmlfile:<path>` and
+`--exitbehavior:Continue`. `--filter` and `--option=value` are not supported by the
+DUnitX version shipped with Delphi 11. The helper passes `--run` and closes stdin, so
+non-interactive runs do not require a placeholder file or an Enter keypress.
+
+Exit codes: `0` for successful executed tests, `1` for test failures, `2` for runner
+exceptions or invalid command-line options, and `3` if no tests execute. The PowerShell
+helper returns `4` for infrastructure failures, including missing/invalid XML or a timeout.
+It parses a unique report for each invocation before publishing `dunitx-results.xml`;
+an existing report is not reused as evidence for a failed invocation. `-XmlPath` selects
+another report destination and `-TimeoutSeconds` controls the process timeout.
+
+`Test-Runner.ps1` verifies test names, counts and exit codes, including missing fixtures,
+invalid reports and an isolated executable path containing spaces. It requires the compiled
+console runner and retains its logs and generated fixtures in a unique temporary directory,
+or in a new directory specified by `-ResultsDirectory`.
+
+The documentation sweep includes long example paths. On Windows, invoke the executable
+through a short `subst` drive alias when the checkout path would exceed `MAX_PATH`.
+
+The default DUnitX memory monitor always reports zero: **`Tests Leaked: 0` does not prove
+that tests are leak-free**. Ownership regressions use explicit allocated-heap snapshots
+from `TZUGFeRDTestBase` around warmed-up, isolated operations. The infrastructure tests
+prove that the assertion rejects a retained object and accepts a released object, without
+leaving the counterexample allocated. These checks cover only the measured paths, not
+every test or possible reader exception. No replacement memory manager is installed.
+
 ## Relationship to the C# library
 
 Synchronization point:

--- a/Unittest/Test-Runner.ps1
+++ b/Unittest/Test-Runner.ps1
@@ -1,0 +1,159 @@
+# Black-box regression tests for the compiled console runner and run-tests.ps1.
+# Run with Windows PowerShell 5.1 after building ZfDUnitTest.dproj.
+# Logs and isolated fixtures remain in ResultsDirectory for inspection.
+param(
+    [string]$ExePath = "$PSScriptRoot\ZfDUnitTest.exe",
+    [string]$ResultsDirectory = (Join-Path ([IO.Path]::GetTempPath()) ('zfd-runner-' + [Guid]::NewGuid().ToString('N')))
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$completedChecks = 0
+$helper = Join-Path $PSScriptRoot 'run-tests.ps1'
+$powershell = Join-Path $PSHOME 'powershell.exe'
+$heapFixture = 'intf.ZUGFeRDTestInfrastructure.UnitTests.TZUGFeRDTestInfrastructureTests'
+$retainedTest = "$heapFixture.TestHeapAssertionDetectsRetainedObject"
+$releasedTest = "$heapFixture.TestHeapAssertionAcceptsReleasedObject"
+
+# Each process has separate logs and a timeout so a broken runner cannot hang the verification.
+function Invoke-CheckedProcess {
+    param([string]$Name, [string]$FileName, [string]$Arguments, [int]$ExpectedExit,
+        [string]$XmlFile = '', [int]$ExpectedCount = -1)
+
+    $process = New-Object System.Diagnostics.Process
+    try {
+        $process.StartInfo.FileName = $FileName
+        $process.StartInfo.Arguments = $Arguments
+        $process.StartInfo.UseShellExecute = $false
+        $process.StartInfo.RedirectStandardInput = $true
+        $process.StartInfo.RedirectStandardOutput = $true
+        $process.StartInfo.RedirectStandardError = $true
+        if (-not $process.Start()) { throw "$Name did not start." }
+        $process.StandardInput.Close()
+        $stdout = $process.StandardOutput.ReadToEndAsync()
+        $stderr = $process.StandardError.ReadToEndAsync()
+        if (-not $process.WaitForExit(150000)) {
+            $process.Kill()
+            $process.WaitForExit()
+            throw "$Name exceeded its timeout."
+        }
+        [IO.File]::WriteAllText((Join-Path $ResultsDirectory "$Name.log"), $stdout.GetAwaiter().GetResult())
+        [IO.File]::WriteAllText((Join-Path $ResultsDirectory "$Name.err"), $stderr.GetAwaiter().GetResult())
+        if ($process.ExitCode -ne $ExpectedExit) {
+            throw "$Name returned $($process.ExitCode), expected $ExpectedExit. See $ResultsDirectory."
+        }
+        if ($ExpectedCount -ge 0) {
+            [xml]$report = Get-Content -LiteralPath $XmlFile -Raw -Encoding UTF8
+            $cases = @($report.SelectNodes('/test-results//test-case[@executed="True"]'))
+            if ($cases.Count -ne $ExpectedCount -or [int]$report.DocumentElement.GetAttribute('total') -ne $ExpectedCount) {
+                throw "$Name executed $($cases.Count) tests, expected $ExpectedCount."
+            }
+        }
+        $script:completedChecks++
+        Write-Output "PASS: $Name"
+    } finally {
+        $process.Dispose()
+    }
+}
+
+# Test names are checked as well as counts; another passing test must not satisfy a selection probe.
+function Assert-TestNames {
+    param([string]$XmlFile, [string[]]$ExpectedNames)
+    [xml]$report = Get-Content -LiteralPath $XmlFile -Raw -Encoding UTF8
+    $names = @($report.SelectNodes('/test-results//test-case[@executed="True"]') |
+        ForEach-Object { $_.GetAttribute('name') })
+    if (@(Compare-Object ($ExpectedNames | Sort-Object) ($names | Sort-Object)).Count -ne 0) {
+        throw "Unexpected selected test names in $XmlFile."
+    }
+}
+
+try {
+    $ExePath = (Get-Item -LiteralPath $ExePath).FullName
+    if (Test-Path -LiteralPath $ResultsDirectory) { throw 'ResultsDirectory must not already exist.' }
+    $ResultsDirectory = (New-Item -ItemType Directory -Path $ResultsDirectory).FullName
+
+    $singleXml = Join-Path $ResultsDirectory 'single.xml'
+    Invoke-CheckedProcess 'direct-single' $ExePath "--run:$retainedTest --xmlfile:`"$singleXml`"" 0 $singleXml 1
+    Assert-TestNames $singleXml @('TestHeapAssertionDetectsRetainedObject')
+
+    $fixtureXml = Join-Path $ResultsDirectory 'fixture.xml'
+    Invoke-CheckedProcess 'direct-fixture' $ExePath "--run:$heapFixture --xmlfile:`"$fixtureXml`"" 0 $fixtureXml 2
+    Assert-TestNames $fixtureXml @('TestHeapAssertionDetectsRetainedObject', 'TestHeapAssertionAcceptsReleasedObject')
+
+    $emptyXml = Join-Path $ResultsDirectory 'empty.xml'
+    Invoke-CheckedProcess 'direct-no-match' $ExePath "--run:NoSuchZfDTest --xmlfile:`"$emptyXml`"" 3 $emptyXml 0
+    Invoke-CheckedProcess 'direct-invalid-option' $ExePath '--this-option-does-not-exist:42' 2
+
+    $fullXml = Join-Path $ResultsDirectory 'suite.xml'
+    Invoke-CheckedProcess 'helper-suite' $powershell "-NoProfile -ExecutionPolicy Bypass -File `"$helper`" -ExePath `"$ExePath`" -XmlPath `"$fullXml`"" 0
+    [xml]$fullReport = Get-Content -LiteralPath $fullXml -Raw -Encoding UTF8
+    $fullCount = @($fullReport.SelectNodes('/test-results//test-case[@executed="True"]')).Count
+    if ($fullCount -le 2) { throw 'The full suite was unexpectedly filtered.' }
+
+    $helperEmptyXml = Join-Path $ResultsDirectory 'helper-empty.xml'
+    Invoke-CheckedProcess 'helper-no-match' $powershell "-NoProfile -ExecutionPolicy Bypass -File `"$helper`" -ExePath `"$ExePath`" -XmlPath `"$helperEmptyXml`" -Filter NoSuchZfDTest" 3 $helperEmptyXml 0
+
+    # A clean copy tests default paths, spaces, and the absence of the old stdin placeholder.
+    $isolated = (New-Item -ItemType Directory -Path (Join-Path $ResultsDirectory 'clean copy with spaces')).FullName
+    $isolatedHelper = Join-Path $isolated 'run-tests.ps1'
+    Copy-Item -LiteralPath $helper -Destination $isolatedHelper
+    Copy-Item -LiteralPath $ExePath -Destination (Join-Path $isolated 'ZfDUnitTest.exe')
+    $isolatedXml = Join-Path $isolated 'dunitx-results.xml'
+    Invoke-CheckedProcess 'helper-clean-copy' $powershell "-NoProfile -ExecutionPolicy Bypass -File `"$isolatedHelper`" -Filter $releasedTest" 0 $isolatedXml 1
+    Assert-TestNames $isolatedXml @('TestHeapAssertionAcceptsReleasedObject')
+
+    $failingTest = 'intf.ZUGFeRD22Tests.UnitTests.TZUGFeRD22Tests.TestCIIReaderReleasesDescriptorAfterParsingError'
+    $readerXml = Join-Path $ResultsDirectory 'reader.xml'
+    Invoke-CheckedProcess 'direct-reader-heap' $ExePath "--run:$failingTest --xmlfile:`"$readerXml`"" 0 $readerXml 1
+    Assert-TestNames $readerXml @('TestCIIReaderReleasesDescriptorAfterParsingError')
+    Invoke-CheckedProcess 'helper-test-failure' $powershell "-NoProfile -ExecutionPolicy Bypass -File `"$isolatedHelper`" -Filter $failingTest" 1 $isolatedXml 1
+
+    # Controlled executables exercise report failures without changing production fixtures or source files.
+    $stubExe = Join-Path $isolated 'ReportProbe.exe'
+    Add-Type -OutputAssembly $stubExe -OutputType ConsoleApplication -TypeDefinition @'
+using System;
+using System.IO;
+using System.Threading;
+public static class ReportProbe
+{
+    public static int Main(string[] arguments)
+    {
+        string mode = File.ReadAllText(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "mode.txt"));
+        string output = null;
+        foreach (string argument in arguments)
+            if (argument.StartsWith("--xmlfile:", StringComparison.Ordinal)) output = argument.Substring(10);
+        if (mode == "timeout") { Thread.Sleep(10000); return 0; }
+        if (mode == "missing") return 0;
+        if (mode == "malformed") { File.WriteAllText(output, "<invalid"); return 0; }
+        if (mode == "wrong-root") { File.WriteAllText(output, "<wrong/>"); return 0; }
+        string count = mode == "wrong-count" ? "2" : "1";
+        string result = mode == "failure" ? "Failure" : "Success";
+        File.WriteAllText(output, "<test-results total=\"" + count + "\" failures=\"0\" errors=\"0\"><test-suite><test-case name=\"Probe\" executed=\"True\" result=\"" + result + "\"/></test-suite></test-results>");
+        return mode == "nonzero" ? 7 : 0;
+    }
+}
+'@
+    $modePath = Join-Path $isolated 'mode.txt'
+    $stubArguments = "-NoProfile -ExecutionPolicy Bypass -File `"$isolatedHelper`" -ExePath `"$stubExe`""
+    foreach ($mode in @('valid', 'failure', 'nonzero', 'missing', 'malformed', 'wrong-root', 'wrong-count', 'timeout')) {
+        [IO.File]::WriteAllText($modePath, $mode)
+        $previousReport = [IO.File]::ReadAllText($isolatedXml)
+        $expectedExit = 4
+        $arguments = $stubArguments
+        switch ($mode) {
+            'valid' { $expectedExit = 0 }
+            'failure' { $expectedExit = 1 }
+            'nonzero' { $expectedExit = 7 }
+            'timeout' { $arguments += ' -TimeoutSeconds 1' }
+        }
+        Invoke-CheckedProcess "report-$mode" $powershell $arguments $expectedExit
+        if ($expectedExit -eq 4 -and [IO.File]::ReadAllText($isolatedXml) -ne $previousReport) {
+            throw "The invalid $mode result replaced an existing report."
+        }
+    }
+    Invoke-CheckedProcess 'helper-missing-exe' $powershell "-NoProfile -ExecutionPolicy Bypass -File `"$isolatedHelper`" -ExePath `"$isolated\missing.exe`"" 4
+    Write-Output "$completedChecks process checks passed; full Delphi suite: $fullCount tests. Logs: $ResultsDirectory"
+} catch {
+    [Console]::Error.WriteLine($_.Exception.Message)
+    exit 1
+}

--- a/Unittest/ZfDUnitTest.dpr
+++ b/Unittest/ZfDUnitTest.dpr
@@ -14,6 +14,7 @@ program ZfDUnitTest;
 
 uses
   Winapi.ActiveX,
+  Winapi.Windows,
   SysUtils,
   DUnitX.ConsoleWriter.Base,
   DUnitX.DUnitCompatibility,
@@ -51,6 +52,7 @@ uses
   intf.ZUGFeRDInvoiceProvider in 'intf.ZUGFeRDInvoiceProvider.pas',
 
   // Test units
+  intf.ZUGFeRDTestInfrastructure.UnitTests in 'intf.ZUGFeRDTestInfrastructure.UnitTests.pas',
   intf.ZUGFeRD10Tests.UnitTests in 'intf.ZUGFeRD10Tests.UnitTests.pas',
   intf.ZUGFeRD20Tests.UnitTests in 'intf.ZUGFeRD20Tests.UnitTests.pas',
   intf.ZUGFeRD22Tests.UnitTests in 'intf.ZUGFeRD22Tests.UnitTests.pas',
@@ -67,9 +69,12 @@ var
   logger : ITestLogger;
   nunitLogger : ITestLogger;
   xmlOutputFile : string;
+  inputMode: DWORD;
 begin
   CoInitialize(nil);
   try
+    // Parse before creating the runner so selection and XML output options take effect.
+    TDUnitX.CheckCommandLine;
     // Warn when running under the Delphi debugger
     {$WARN SYMBOL_PLATFORM OFF}
     if DebugHook <> 0 then
@@ -111,11 +116,21 @@ begin
     results := runner.Execute;
 
     ExitCode := 0;
-    if not results.AllPassed then
+    if results.TestCount = results.IgnoredCount then
+    begin
+      System.Writeln('No tests executed. Check the fully qualified test or fixture name.');
+      ExitCode := 3;
+    end
+    else if not results.AllPassed then
       ExitCode := 1;
 
+    // The default DUnitX monitor always returns zero; only explicit heap assertions measure memory.
+    if TDUnitX.Options.ConsoleMode <> TDunitXConsoleMode.Off then
+      System.Writeln('Memory checks: explicit heap assertions only; "Tests Leaked" is not a leak check.');
+
     // Only wait for keypress when running interactively (stdin is a console)
-    if IsConsole then
+    if (TDUnitX.Options.ExitBehavior = TDUnitXExitBehavior.Pause) and
+      GetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), inputMode) then
     begin
       System.Write('Done.. press <Enter> key to quit.');
       System.Readln;

--- a/Unittest/ZfDUnitTest.dproj
+++ b/Unittest/ZfDUnitTest.dproj
@@ -97,6 +97,7 @@
             <MainSource>MainSource</MainSource>
         </DelphiCompile>
         <DCCReference Include="intf.ZUGFeRDTestBase.pas"/>
+        <DCCReference Include="intf.ZUGFeRDTestInfrastructure.UnitTests.pas"/>
         <DCCReference Include="intf.ZUGFeRDInvoiceProvider.pas"/>
         <DCCReference Include="intf.ZUGFeRD10Tests.UnitTests.pas"/>
         <DCCReference Include="intf.ZUGFeRD20Tests.UnitTests.pas"/>

--- a/Unittest/ZfDUnitTestGUI.dpr
+++ b/Unittest/ZfDUnitTestGUI.dpr
@@ -20,6 +20,7 @@ uses
   intf.ZUGFeRDInvoiceProvider in 'intf.ZUGFeRDInvoiceProvider.pas',
 
   // Test units
+  intf.ZUGFeRDTestInfrastructure.UnitTests in 'intf.ZUGFeRDTestInfrastructure.UnitTests.pas',
   intf.ZUGFeRD10Tests.UnitTests in 'intf.ZUGFeRD10Tests.UnitTests.pas',
   intf.ZUGFeRD20Tests.UnitTests in 'intf.ZUGFeRD20Tests.UnitTests.pas',
   intf.ZUGFeRD22Tests.UnitTests in 'intf.ZUGFeRD22Tests.UnitTests.pas',

--- a/Unittest/ZfDUnitTestGUI.dproj
+++ b/Unittest/ZfDUnitTestGUI.dproj
@@ -96,6 +96,7 @@
             <MainSource>MainSource</MainSource>
         </DelphiCompile>
         <DCCReference Include="intf.ZUGFeRDTestBase.pas"/>
+        <DCCReference Include="intf.ZUGFeRDTestInfrastructure.UnitTests.pas"/>
         <DCCReference Include="intf.ZUGFeRDInvoiceProvider.pas"/>
         <DCCReference Include="intf.ZUGFeRD10Tests.UnitTests.pas"/>
         <DCCReference Include="intf.ZUGFeRD20Tests.UnitTests.pas"/>

--- a/Unittest/intf.ZUGFeRD22Tests.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRD22Tests.UnitTests.pas
@@ -880,21 +880,6 @@ var
   loadIndex: Integer;
   allLoadsFailed: Boolean;
 
-  function GetAllocatedMemory: NativeUInt;
-  var
-    memoryManagerState: TMemoryManagerState;
-    smallBlockTypeState: TSmallBlockTypeState;
-  begin
-    {$WARN SYMBOL_PLATFORM OFF}
-    GetMemoryManagerState(memoryManagerState);
-    {$WARN SYMBOL_PLATFORM DEFAULT}
-    Result := memoryManagerState.TotalAllocatedMediumBlockSize +
-      memoryManagerState.TotalAllocatedLargeBlockSize;
-    for smallBlockTypeState in memoryManagerState.SmallBlockTypeStates do
-      Inc(Result, NativeUInt(smallBlockTypeState.UseableBlockSize) *
-        smallBlockTypeState.AllocatedBlockCount);
-  end;
-
   function LoadRaisesParsingError: Boolean;
   var
     loadedInvoice: TZUGFeRDInvoiceDescriptor;
@@ -934,9 +919,7 @@ begin
     secondBatchMemory := GetAllocatedMemory;
 
     Assert.IsTrue(allLoadsFailed, 'Mindestens ein ungültiges Rechnungsdatum wurde nicht abgelehnt.');
-    Assert.IsTrue(secondBatchMemory <= firstBatchMemory,
-      Format('Wiederholte Parser-Ausnahmen erhöhten den belegten Speicher von %s auf %s Bytes.',
-        [UIntToStr(firstBatchMemory), UIntToStr(secondBatchMemory)]));
+    AssertNoMemoryGrowth(firstBatchMemory, secondBatchMemory);
   finally
     invalidStream.Free;
   end;

--- a/Unittest/intf.ZUGFeRDTestBase.pas
+++ b/Unittest/intf.ZUGFeRDTestBase.pas
@@ -8,13 +8,39 @@ uses
 type
   TZUGFeRDTestBase = class
   protected
+    /// <summary>Measures allocated blocks, not reserved heap capacity, for isolated ownership checks.</summary>
+    class function GetAllocatedMemory: NativeUInt; static;
+    /// <summary>Requires a warmed-up operation to release its objects before the second measurement.</summary>
+    class procedure AssertNoMemoryGrowth(const beforeBytes, afterBytes: NativeUInt); static;
     function DemodataPath(const aRelativePath: string): string;
     function DocumentationPath(const aRelativePath: string): string;
   end;
 
 implementation
 
+uses
+  DUnitX.TestFramework;
+
 { TZUGFeRDTestBase }
+
+class function TZUGFeRDTestBase.GetAllocatedMemory: NativeUInt;
+var
+  memoryManagerState: TMemoryManagerState;
+  smallBlockTypeState: TSmallBlockTypeState;
+begin
+  {$WARN SYMBOL_PLATFORM OFF}
+  GetMemoryManagerState(memoryManagerState);
+  {$WARN SYMBOL_PLATFORM DEFAULT}
+  Result := memoryManagerState.TotalAllocatedMediumBlockSize + memoryManagerState.TotalAllocatedLargeBlockSize;
+  for smallBlockTypeState in memoryManagerState.SmallBlockTypeStates do
+    Inc(Result, NativeUInt(smallBlockTypeState.UseableBlockSize) * smallBlockTypeState.AllocatedBlockCount);
+end;
+
+class procedure TZUGFeRDTestBase.AssertNoMemoryGrowth(const beforeBytes, afterBytes: NativeUInt);
+begin
+  Assert.IsTrue(afterBytes <= beforeBytes,
+    Format('Allocated memory increased from %s to %s bytes.', [UIntToStr(beforeBytes), UIntToStr(afterBytes)]));
+end;
 
 function TZUGFeRDTestBase.DemodataPath(const aRelativePath: string): string;
 begin

--- a/Unittest/intf.ZUGFeRDTestInfrastructure.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRDTestInfrastructure.UnitTests.pas
@@ -1,0 +1,65 @@
+unit intf.ZUGFeRDTestInfrastructure.UnitTests;
+
+interface
+
+uses
+  DUnitX.TestFramework,
+  intf.ZUGFeRDTestBase;
+
+type
+  [TestFixture]
+  TZUGFeRDTestInfrastructureTests = class(TZUGFeRDTestBase)
+  public
+    /// <summary>Proves that the heap assertion detects an object retained across the measurement.</summary>
+    [Test]
+    procedure TestHeapAssertionDetectsRetainedObject;
+    /// <summary>Proves that releasing the measured object does not report a leak.</summary>
+    [Test]
+    procedure TestHeapAssertionAcceptsReleasedObject;
+  end;
+
+implementation
+
+procedure TZUGFeRDTestInfrastructureTests.TestHeapAssertionDetectsRetainedObject;
+var
+  beforeBytes: NativeUInt;
+  afterBytes: NativeUInt;
+  retainedObject: TObject;
+begin
+  beforeBytes := GetAllocatedMemory;
+  retainedObject := TObject.Create;
+  try
+    afterBytes := GetAllocatedMemory;
+    Assert.IsTrue(afterBytes > beforeBytes, 'The active memory manager did not report the retained object.');
+    Assert.WillRaiseAny(
+      procedure
+      begin
+        AssertNoMemoryGrowth(beforeBytes, afterBytes);
+      end,
+      'The heap assertion did not detect the retained object.');
+  finally
+    // Keep the counterexample isolated; the test itself must not leak.
+    retainedObject.Free;
+  end;
+end;
+
+procedure TZUGFeRDTestInfrastructureTests.TestHeapAssertionAcceptsReleasedObject;
+var
+  beforeBytes: NativeUInt;
+  retainedBytes: NativeUInt;
+  afterBytes: NativeUInt;
+  measuredObject: TObject;
+begin
+  beforeBytes := GetAllocatedMemory;
+  measuredObject := TObject.Create;
+  try
+    retainedBytes := GetAllocatedMemory;
+  finally
+    measuredObject.Free;
+  end;
+  afterBytes := GetAllocatedMemory;
+  Assert.IsTrue(retainedBytes > beforeBytes, 'The active memory manager did not report the measured object.');
+  AssertNoMemoryGrowth(beforeBytes, afterBytes);
+end;
+
+end.

--- a/Unittest/run-tests.ps1
+++ b/Unittest/run-tests.ps1
@@ -4,88 +4,117 @@
 #
 # Usage:
 #   .\run-tests.ps1                    # run all tests
-#   .\run-tests.ps1 -Filter "TestName" # run specific test(s)
+#   .\run-tests.ps1 -Filter "intf.ZUGFeRD22Tests.UnitTests.TZUGFeRD22Tests.TestComment"
 #   .\run-tests.ps1 -ShowXml           # also dump the raw XML
 
 param(
     [string]$Filter = '',
     [switch]$ShowXml,
-    [string]$ExePath = "$PSScriptRoot\Win64\Debug\ZfDUnitTest.exe"
+    [string]$ExePath = "$PSScriptRoot\ZfDUnitTest.exe",
+    [string]$XmlPath = "$PSScriptRoot\dunitx-results.xml",
+    [ValidateRange(1, 3600)]
+    [int]$TimeoutSeconds = 120
 )
 
-$xmlPath = "$PSScriptRoot\dunitx-results.xml"
-$exitCode = 0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$exitCode = 4
+$process = $null
+$runXmlPath = Join-Path ([IO.Path]::GetTempPath()) ('zfd-results-' + [Guid]::NewGuid().ToString('N') + '.xml')
 
-# Build argument list
-$args = @()
-if ($Filter -ne '') {
-    $args += "--filter=$Filter"
-}
-
-# Run tests (non-interactive: stdin is not a console)
-Write-Host "Running: $ExePath $args" -ForegroundColor Cyan
-$proc = Start-Process -FilePath $ExePath -ArgumentList $args `
-    -Wait -PassThru -NoNewWindow `
-    -RedirectStandardInput "$PSScriptRoot\nul_stdin.tmp"
-
-# Create empty stdin redirect file if it doesn't exist
-if (-not (Test-Path "$PSScriptRoot\nul_stdin.tmp")) {
-    "" | Out-File "$PSScriptRoot\nul_stdin.tmp" -Encoding ASCII
-    $proc = Start-Process -FilePath $ExePath -ArgumentList $args `
-        -Wait -PassThru -NoNewWindow `
-        -RedirectStandardInput "$PSScriptRoot\nul_stdin.tmp"
-}
-
-$exitCode = $proc.ExitCode
-
-# Parse NUnit XML results
-if (Test-Path $xmlPath) {
-    [xml]$xml = Get-Content $xmlPath -Encoding UTF8
-
-    $suite = $xml.'test-results'
-    if ($null -eq $suite) {
-        $suite = $xml.SelectSingleNode('//*[@total]')
+try {
+    $resolvedExe = Get-Item -LiteralPath $ExePath
+    if ($resolvedExe.PSIsContainer) {
+        throw "The executable path is a directory: $ExePath"
+    }
+    $XmlPath = [IO.Path]::GetFullPath($XmlPath)
+    if ($Filter.Contains('"') -or $Filter.Contains("`r") -or $Filter.Contains("`n")) {
+        throw 'The filter must not contain quotes or line breaks.'
     }
 
-    $total   = [int]($suite.total   ?? ($xml.SelectSingleNode('//*[@total]').'total'))
-    $passed  = [int]($suite.passed  ?? 0)
-    $failed  = [int]($suite.failures ?? ($suite.failed ?? 0))
-    $errors  = [int]($suite.errors  ?? 0)
-    $ignored = [int]($suite.ignored ?? ($suite.skipped ?? 0))
+    # DUnitX accepts qualified test/fixture names via --run, not --filter.
+    $runnerArguments = @('--exitbehavior:Continue', ('--xmlfile:"' + $runXmlPath + '"'))
+    if ($Filter -ne '') {
+        $runnerArguments += '--run:"' + $Filter + '"'
+    }
 
-    Write-Host ""
-    Write-Host "=== Test Results ===" -ForegroundColor White
-    Write-Host "Total:   $total" -ForegroundColor White
-    Write-Host "Passed:  $passed" -ForegroundColor Green
-    if ($failed -gt 0)  { Write-Host "Failed:  $failed"  -ForegroundColor Red   }
-    if ($errors -gt 0)  { Write-Host "Errors:  $errors"  -ForegroundColor Red   }
-    if ($ignored -gt 0) { Write-Host "Ignored: $ignored" -ForegroundColor Yellow }
+    # Close redirected stdin before waiting; no pre-existing placeholder file is required.
+    Write-Host "Running: $($resolvedExe.FullName) $($runnerArguments -join ' ')"
+    $process = New-Object System.Diagnostics.Process
+    $process.StartInfo.FileName = $resolvedExe.FullName
+    $process.StartInfo.WorkingDirectory = $resolvedExe.DirectoryName
+    $process.StartInfo.Arguments = $runnerArguments -join ' '
+    $process.StartInfo.UseShellExecute = $false
+    $process.StartInfo.RedirectStandardInput = $true
+    if (-not $process.Start()) {
+        throw 'The test process did not start.'
+    }
+    $process.StandardInput.Close()
+    if (-not $process.WaitForExit($TimeoutSeconds * 1000)) {
+        $process.Kill()
+        $process.WaitForExit()
+        throw "The test process exceeded the timeout of $TimeoutSeconds seconds."
+    }
+    $exitCode = $process.ExitCode
+
+    # A unique path prevents a failed launch from reusing a previous successful result.
+    if (-not (Test-Path -LiteralPath $runXmlPath -PathType Leaf)) {
+        throw "The test process produced no XML results (exit code $exitCode)."
+    }
+    [xml]$xml = Get-Content -LiteralPath $runXmlPath -Raw -Encoding UTF8
+    $suite = $xml.DocumentElement
+    if ($suite.LocalName -ne 'test-results') {
+        throw 'The result file is not a DUnitX NUnit report.'
+    }
+
+    # NUnit 2 does not provide a "passed" attribute on the root element.
+    $testCases = @($suite.SelectNodes('.//test-case'))
+    $executedCases = @($testCases | Where-Object { $_.GetAttribute('executed') -eq 'True' })
+    $passed = @($executedCases | Where-Object { $_.GetAttribute('result') -eq 'Success' }).Count
+    $failedCases = @($executedCases | Where-Object { $_.GetAttribute('result') -ne 'Success' })
+    $ignored = $testCases.Count - $executedCases.Count
+    $reportedTotal = 0
+    if (-not [int]::TryParse($suite.GetAttribute('total'), [ref]$reportedTotal) -or
+        $reportedTotal -ne $executedCases.Count) {
+        throw 'The reported total does not match the executed test cases.'
+    }
+
+    if ($exitCode -eq 0) {
+        if ($executedCases.Count -eq 0) {
+            $exitCode = 3
+        } elseif ($failedCases.Count -gt 0 -or $suite.GetAttribute('failures') -ne '0' -or
+            $suite.GetAttribute('errors') -ne '0') {
+            $exitCode = 1
+        }
+    }
+
+    Copy-Item -LiteralPath $runXmlPath -Destination $XmlPath
+    Write-Host "Executed: $($executedCases.Count); passed: $passed; failed/errors: $($failedCases.Count); ignored: $ignored"
+    Write-Host 'Memory checks: explicit heap assertions only; the default DUnitX leak counter is inactive.'
 
     # Show failing tests
-    $failedTests = $xml.SelectNodes('//*[local-name()="test-case" and (@result="Failure" or @result="Error" or @result="Failed")]')
-    if ($failedTests.Count -gt 0) {
-        Write-Host ""
-        Write-Host "=== Failing Tests ===" -ForegroundColor Red
-        foreach ($t in $failedTests) {
-            $name = $t.name ?? $t.fullname
-            $msg  = $t.SelectSingleNode('*[local-name()="failure"]/*[local-name()="message"]')
-            Write-Host "  FAIL: $name" -ForegroundColor Red
-            if ($null -ne $msg) {
-                Write-Host "        $($msg.InnerText.Trim())" -ForegroundColor Yellow
-            }
+    foreach ($testCase in $failedCases) {
+        Write-Host "FAIL: $($testCase.GetAttribute('name'))"
+        $message = $testCase.SelectSingleNode('failure/message')
+        if ($null -ne $message) {
+            Write-Host $message.InnerText.Trim()
         }
     }
 
     if ($ShowXml) {
-        Write-Host ""
-        Write-Host "=== Raw XML ===" -ForegroundColor Gray
-        Get-Content $xmlPath
+        Get-Content -LiteralPath $XmlPath
     }
-} else {
-    Write-Host "ERROR: XML output not found at $xmlPath" -ForegroundColor Red
-    $exitCode = 3
+    Write-Host "XML results: $XmlPath"
+} catch {
+    [Console]::Error.WriteLine($_.Exception.Message)
+    $exitCode = 4
+} finally {
+    if ($null -ne $process) {
+        $process.Dispose()
+    }
+    if (Test-Path -LiteralPath $runXmlPath -PathType Leaf) {
+        Remove-Item -LiteralPath $runXmlPath
+    }
 }
 
-Write-Host ""
-Write-Host "XML results: $xmlPath" -ForegroundColor Gray
 exit $exitCode


### PR DESCRIPTION
## Summary

Fix console test selection and make the test results verifiable:

- Parse the DUnitX command line before creating the runner. Qualified test/fixture selection and XML output paths now take effect; invalid options and runs without executed tests return a nonzero exit code.
- Correct the executable path and PowerShell 5.1 compatibility in `run-tests.ps1`. Close redirected stdin, enforce a timeout, count executed/passed NUnit test cases, and validate a fresh per-invocation XML report before publishing it. A previous report cannot turn a failed invocation into a successful result.
- Extract the existing reader heap measurement into a shared test helper. Add counterexamples proving that it rejects a retained object and accepts a released object. The console and README explicitly distinguish these assertions from the inactive default DUnitX leak counter. This does not claim leak coverage for unmeasured reader paths or install another memory manager.
- Add `Test-Runner.ps1` with black-box checks for selection, exit codes, missing fixtures, paths containing spaces, report failures, stale reports, and timeouts.

## Verification

- Delphi 11, Win64 Debug: console and GUI projects compile without errors, warnings, or hints.
- Two consecutive verification runs: 395/395 Delphi tests and 18/18 process checks each.
- Countercheck without command-line parsing: the selected single-test invocation ran all 395 tests and failed the verification because the requested XML output was ignored.
- Countercheck with a disabled heap assertion: `TestHeapAssertionDetectsRetainedObject` failed. Both intentional defects were removed before the successful repeated runs.

This PR is based directly on the current upstream `main` and does not depend on the open cleanup PR.
