### PR TITLE
Release nested CII reader objects on parsing errors

### DIFF
--- a/Unittest/intf.ZUGFeRD22Tests.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRD22Tests.UnitTests.pas
@@ -45,6 +45,23 @@ type
     procedure TestAdvancePaymentReaderRejectsMissingMandatoryData;
     [Test]
     procedure TestCIIReaderReleasesDescriptorAfterParsingError;
+    /// <summary>Checks ownership before and after nested CII objects are handed to their parent.</summary>
+    [Test]
+    [TestCase('ValidLinePeriod', 'line-period,False')]
+    [TestCase('InvalidLinePeriod', 'line-period,True')]
+    [TestCase('ValidLineOrder', 'line-order,False')]
+    [TestCase('InvalidLineOrder', 'line-order,True')]
+    [TestCase('ValidHeaderReference', 'header-reference,False')]
+    [TestCase('InvalidHeaderReference', 'header-reference,True')]
+    [TestCase('ValidLineReference', 'line-reference,False')]
+    [TestCase('InvalidLineReference', 'line-reference,True')]
+    [TestCase('ValidHeaderAfterAttachment', 'header-after-attachment,False')]
+    [TestCase('InvalidHeaderAfterAttachment', 'header-after-attachment,True')]
+    [TestCase('ValidLineAfterAttachment', 'line-after-attachment,False')]
+    [TestCase('InvalidLineAfterAttachment', 'line-after-attachment,True')]
+    [TestCase('ValidLineDelivery', 'line-delivery,False')]
+    [TestCase('InvalidLineDelivery', 'line-delivery,True')]
+    procedure TestCIIReaderNestedObjectOwnership(const failurePoint: string; invalidData: Boolean);
     [Test]
     procedure TestReferenceAdvancePaymentFromDocumentation;
     [Test]
@@ -922,6 +939,147 @@ begin
     AssertNoMemoryGrowth(firstBatchMemory, secondBatchMemory);
   finally
     invalidStream.Free;
+  end;
+end;
+
+/// <summary>
+/// Exercises late failures with both unowned children and already attached documents and streams.
+/// </summary>
+procedure TZUGFeRD22Tests.TestCIIReaderNestedObjectOwnership(const failurePoint: string; invalidData: Boolean);
+const
+  measuredLoadCount = 10;
+  validDate = '20251001';
+  invalidDate = '2025100';
+var
+  xmlContent: string;
+  inputStream: TStringStream;
+  expectedError: string;
+  firstBatchMemory, secondBatchMemory: NativeUInt;
+  allLoadsMatched: Boolean;
+
+  /// <summary>Checks that decoded attachments remain usable until their owning invoice is freed.</summary>
+  procedure CheckAttachment(attachment: TMemoryStream);
+  var
+    content: TBytes;
+  begin
+    Assert.IsNotNull(attachment);
+    Assert.AreEqual(Int64(5), attachment.Size);
+    SetLength(content, 5);
+    attachment.Position := 0;
+    attachment.ReadBuffer(content, Length(content));
+    Assert.AreEqual('Hello', TEncoding.UTF8.GetString(content));
+  end;
+
+  /// <summary>Preserves the expected parser exception; successful results are always released.</summary>
+  function LoadAndRelease(checkValues: Boolean): Boolean;
+  var
+    loadedInvoice: TZUGFeRDInvoiceDescriptor;
+  begin
+    loadedInvoice := nil;
+    try
+      try
+        inputStream.Position := 0;
+        loadedInvoice := TZUGFeRDInvoiceDescriptor.Load(inputStream);
+      except
+        on error: Exception do
+        begin
+          if not invalidData then
+            raise;
+          Exit(error.Message = expectedError);
+        end;
+      end;
+      Result := not invalidData and (loadedInvoice <> nil);
+      if checkValues and Result then
+      begin
+        Assert.AreEqual(1, loadedInvoice.TradeLineItems.Count);
+        Assert.AreEqual(2, loadedInvoice.AdditionalReferencedDocuments.Count);
+        Assert.AreEqual('HEADER-DOC', loadedInvoice.AdditionalReferencedDocuments[0].ID);
+        CheckAttachment(loadedInvoice.AdditionalReferencedDocuments[0].AttachmentBinaryObject);
+        Assert.AreEqual('HEADER-LATE', loadedInvoice.AdditionalReferencedDocuments[1].ID);
+        Assert.IsNull(loadedInvoice.AdditionalReferencedDocuments[1].AttachmentBinaryObject);
+        var lineItem := loadedInvoice.TradeLineItems[0];
+        Assert.AreEqual('1', lineItem.AssociatedDocument.LineID);
+        Assert.AreEqual(EncodeDate(2025, 10, 1), lineItem.BillingPeriodStart.Value);
+        Assert.AreEqual('ORDER', lineItem.BuyerOrderReferencedDocument.ID);
+        Assert.AreEqual(1, lineItem.ApplicableProductCharacteristics.Count);
+        Assert.AreEqual('blue', lineItem.ApplicableProductCharacteristics[0].Value);
+        Assert.AreEqual(1, lineItem.IncludedReferencedProducts.Count);
+        Assert.AreEqual('PART', lineItem.IncludedReferencedProducts[0].SellerAssignedID);
+        Assert.AreEqual(1, lineItem.ReceivableSpecifiedTradeAccountingAccounts.Count);
+        Assert.AreEqual('ACCOUNT', lineItem.ReceivableSpecifiedTradeAccountingAccounts[0].TradeAccountID);
+        Assert.AreEqual(2, lineItem.AdditionalReferencedDocuments.Count);
+        Assert.AreEqual('LINE-DOC', lineItem.AdditionalReferencedDocuments[0].ID);
+        CheckAttachment(lineItem.AdditionalReferencedDocuments[0].AttachmentBinaryObject);
+        Assert.AreEqual('LINE-LATE', lineItem.AdditionalReferencedDocuments[1].ID);
+        Assert.IsNull(lineItem.AdditionalReferencedDocuments[1].AttachmentBinaryObject);
+        Assert.AreEqual(EncodeDate(2025, 10, 1), lineItem.ActualDeliveryDate.Value);
+      end;
+    finally
+      loadedInvoice.Free;
+    end;
+  end;
+
+begin
+  // Self-contained parser fixture, not a schema-conformance test. Each token has one failure site.
+  xmlContent := '<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"' +
+    ' xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"' +
+    ' xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"' +
+    ' xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100">' +
+    '<rsm:ExchangedDocumentContext><ram:GuidelineSpecifiedDocumentContextParameter>' +
+    '<ram:ID>urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended</ram:ID>' +
+    '</ram:GuidelineSpecifiedDocumentContextParameter></rsm:ExchangedDocumentContext>' +
+    '<rsm:ExchangedDocument><ram:ID>OWNERSHIP</ram:ID><ram:TypeCode>380</ram:TypeCode></rsm:ExchangedDocument>' +
+    '<rsm:SupplyChainTradeTransaction><ram:IncludedSupplyChainTradeLineItem>' +
+    '<ram:AssociatedDocumentLineDocument><ram:LineID>1</ram:LineID></ram:AssociatedDocumentLineDocument>' +
+    '<ram:SpecifiedTradeProduct><ram:Name>Ownership test</ram:Name>' +
+    '<ram:ApplicableProductCharacteristic><ram:Description>Colour</ram:Description><ram:Value>blue</ram:Value></ram:ApplicableProductCharacteristic>' +
+    '<ram:IncludedReferencedProduct><ram:SellerAssignedID>PART</ram:SellerAssignedID></ram:IncludedReferencedProduct></ram:SpecifiedTradeProduct>' +
+    '<ram:SpecifiedLineTradeAgreement><ram:BuyerOrderReferencedDocument><ram:IssuerAssignedID>ORDER</ram:IssuerAssignedID>' +
+    '<ram:FormattedIssueDateTime><qdt:DateTimeString format="102">{line-order}</qdt:DateTimeString></ram:FormattedIssueDateTime>' +
+    '</ram:BuyerOrderReferencedDocument></ram:SpecifiedLineTradeAgreement>' +
+    '<ram:SpecifiedLineTradeDelivery><ram:ActualDeliverySupplyChainEvent><ram:OccurrenceDateTime>' +
+    '<udt:DateTimeString format="102">{line-delivery}</udt:DateTimeString></ram:OccurrenceDateTime>' +
+    '</ram:ActualDeliverySupplyChainEvent></ram:SpecifiedLineTradeDelivery>' +
+    '<ram:SpecifiedLineTradeSettlement><ram:BillingSpecifiedPeriod><ram:StartDateTime>' +
+    '<udt:DateTimeString format="102">{line-period}</udt:DateTimeString></ram:StartDateTime></ram:BillingSpecifiedPeriod>' +
+    '<ram:AdditionalReferencedDocument><ram:IssuerAssignedID>LINE-DOC</ram:IssuerAssignedID><ram:TypeCode>916</ram:TypeCode>' +
+    '<ram:AttachmentBinaryObject filename="line.txt">SGVsbG8=</ram:AttachmentBinaryObject>' +
+    '<ram:FormattedIssueDateTime><qdt:DateTimeString format="102">{line-reference}</qdt:DateTimeString></ram:FormattedIssueDateTime>' +
+    '</ram:AdditionalReferencedDocument><ram:AdditionalReferencedDocument><ram:IssuerAssignedID>LINE-LATE</ram:IssuerAssignedID>' +
+    '<ram:FormattedIssueDateTime><qdt:DateTimeString format="102">{line-after-attachment}</qdt:DateTimeString></ram:FormattedIssueDateTime>' +
+    '</ram:AdditionalReferencedDocument><ram:ReceivableSpecifiedTradeAccountingAccount><ram:ID>ACCOUNT</ram:ID>' +
+    '</ram:ReceivableSpecifiedTradeAccountingAccount></ram:SpecifiedLineTradeSettlement></ram:IncludedSupplyChainTradeLineItem>' +
+    '<ram:ApplicableHeaderTradeAgreement><ram:AdditionalReferencedDocument>' +
+    '<ram:IssuerAssignedID>HEADER-DOC</ram:IssuerAssignedID><ram:TypeCode>916</ram:TypeCode>' +
+    '<ram:AttachmentBinaryObject filename="header.txt">SGVsbG8=</ram:AttachmentBinaryObject>' +
+    '<ram:FormattedIssueDateTime><qdt:DateTimeString format="102">{header-reference}</qdt:DateTimeString></ram:FormattedIssueDateTime>' +
+    '</ram:AdditionalReferencedDocument><ram:AdditionalReferencedDocument><ram:IssuerAssignedID>HEADER-LATE</ram:IssuerAssignedID>' +
+    '<ram:FormattedIssueDateTime><qdt:DateTimeString format="102">{header-after-attachment}</qdt:DateTimeString></ram:FormattedIssueDateTime>' +
+    '</ram:AdditionalReferencedDocument></ram:ApplicableHeaderTradeAgreement>' +
+    '</rsm:SupplyChainTradeTransaction></rsm:CrossIndustryInvoice>';
+
+  Assert.IsTrue(xmlContent.Contains('{' + failurePoint + '}'), 'Unknown failure point.');
+  expectedError := 'Wrong length of datetime element (format 102)';
+  if invalidData then
+    xmlContent := xmlContent.Replace('{' + failurePoint + '}', invalidDate);
+  for var dateToken in TArray<string>.Create('line-period', 'line-order', 'line-delivery', 'header-reference', 'line-reference',
+    'header-after-attachment', 'line-after-attachment') do
+    xmlContent := xmlContent.Replace('{' + dateToken + '}', validDate);
+
+  inputStream := TStringStream.Create(xmlContent, TEncoding.UTF8);
+  try
+    Assert.IsTrue(LoadAndRelease(True), 'The reader did not produce the expected result or parser exception.');
+    for var warmupIndex := 1 to measuredLoadCount do
+      LoadAndRelease(False);
+    firstBatchMemory := GetAllocatedMemory;
+    allLoadsMatched := True;
+    for var loadIndex := 1 to measuredLoadCount do
+      allLoadsMatched := LoadAndRelease(False) and allLoadsMatched;
+    secondBatchMemory := GetAllocatedMemory;
+    Assert.IsTrue(allLoadsMatched, 'A repeated load did not produce the expected result or parser exception.');
+    AssertNoMemoryGrowth(firstBatchMemory, secondBatchMemory);
+  finally
+    inputStream.Free;
   end;
 end;
 

--- a/intf.ZUGFeRDInvoiceDescriptor23CIIReader.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor23CIIReader.pas
@@ -82,9 +82,11 @@ type
   TZUGFeRDInvoiceDescriptor23CIIReader = class(TZUGFeRDIInvoiceDescriptorReader)
   private
     function GetValidURIs : TArray<string>;
+    /// <summary>Returns a caller-owned line item and releases partial results if parsing fails.</summary>
     function _parseTradeLineItem(tradeLineItem : IXmlDomNode {nsmgr: XmlNamespaceManager = nil; }) : TZUGFeRDTradeLineItem;
     function _nodeAsContact(basenode: IXmlDomNode; const xpath: string) : TZUGFeRDContact;
     function _nodeAsParty(basenode: IXmlDomNode; const xpath: string) : TZUGFeRDParty;
+    /// <summary>Returns a caller-owned reference, including its attachment, only after successful parsing.</summary>
     function _getAdditionalReferencedDocument(a_oXmlNode : IXmlDomNode {nsmgr: XmlNamespaceManager = nil; }) : TZUGFeRDAdditionalReferencedDocument;
     function _nodeAsLegalOrganization(basenode: IXmlDomNode; const xpath: string) : TZUGFeRDLegalOrganization;
   public
@@ -742,7 +744,7 @@ begin
     TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:AssociatedDocumentLineDocument/ram:LineStatusReasonCode'));
 
   Result := TZUGFeRDTradeLineItem.Create(lineId);
-
+  try
   Result.GlobalID.SchemeID := TEnumExtensions<TZUGFeRDGlobalIDSchemeIdentifiers>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:GlobalID/@schemeID'));
   Result.GlobalID.ID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:GlobalID');
   Result.SellerAssignedID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:SellerAssignedID');
@@ -794,25 +796,36 @@ begin
   for i := 0 to nodes.length-1 do
   begin
     var apcItem : TZUGFeRDApplicableProductCharacteristic := TZUGFeRDApplicableProductCharacteristic.Create;
-    apcItem.Description := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Description');
-    apcItem.Value := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Value');
-    Result.ApplicableProductCharacteristics.Add(apcItem);
+    try
+      apcItem.Description := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Description');
+      apcItem.Value := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Value');
+      Result.ApplicableProductCharacteristics.Add(apcItem);
+    except
+      // Until Add succeeds, the partially parsed line item does not own this child.
+      apcItem.Free;
+      raise;
+    end;
   end;
 
   nodes := tradeLineItem.SelectNodes('.//ram:SpecifiedTradeProduct/ram:IncludedReferencedProduct');
   for i := 0 to nodes.length-1 do
   begin
     var irpItem: TZUGFeRDIncludedReferencedProduct := TZUGFeRDIncludedReferencedProduct.Create;
-    irpItem.GlobalID.SchemeID := TEnumExtensions<TZUGFeRDGlobalIDSchemeIdentifiers>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:GlobalID/@schemeID'));
-    irpItem.GlobalID.ID := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:GlobalID');
-    irpItem.SellerAssignedID := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:SellerAssignedID');
-    irpItem.BuyerAssignedID := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:BuyerAssignedID');
-    irpItem.IndustryAssignedID := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:IndustryAssignedID');
-    irpItem.Name := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Name');
-    irpItem.Description := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Description');
-    irpItem.UnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:UnitQuantity/@unitCode'));
-    irpItem.UnitQuantity:= TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:UnitQuantity');
-    Result.IncludedReferencedProducts.Add(irpItem);
+    try
+      irpItem.GlobalID.SchemeID := TEnumExtensions<TZUGFeRDGlobalIDSchemeIdentifiers>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:GlobalID/@schemeID'));
+      irpItem.GlobalID.ID := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:GlobalID');
+      irpItem.SellerAssignedID := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:SellerAssignedID');
+      irpItem.BuyerAssignedID := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:BuyerAssignedID');
+      irpItem.IndustryAssignedID := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:IndustryAssignedID');
+      irpItem.Name := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Name');
+      irpItem.Description := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Description');
+      irpItem.UnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:UnitQuantity/@unitCode'));
+      irpItem.UnitQuantity:= TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:UnitQuantity');
+      Result.IncludedReferencedProducts.Add(irpItem);
+    except
+      irpItem.Free;
+      raise;
+    end;
   end;
 
   if (tradeLineItem.SelectSingleNode('.//ram:SpecifiedLineTradeAgreement/ram:BuyerOrderReferencedDocument') <> nil) then
@@ -896,9 +909,14 @@ begin
   for i := 0 to nodes.length-1 do
   begin
     var rstaaItem : TZUGFeRDReceivableSpecifiedTradeAccountingAccount := TZUGFeRDReceivableSpecifiedTradeAccountingAccount.Create;
-    rstaaItem.TradeAccountID := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ID');
-    rstaaItem.TradeAccountTypeCode := TEnumExtensions<TZUGFeRDAccountingAccountTypeCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:TypeCode'));
-    Result.ReceivableSpecifiedTradeAccountingAccounts.Add(rstaaItem);
+    try
+      rstaaItem.TradeAccountID := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ID');
+      rstaaItem.TradeAccountTypeCode := TEnumExtensions<TZUGFeRDAccountingAccountTypeCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:TypeCode'));
+      Result.ReceivableSpecifiedTradeAccountingAccounts.Add(rstaaItem);
+    except
+      rstaaItem.Free;
+      raise;
+    end;
     break; // an if above would have done it also <g>
   end;
 
@@ -967,7 +985,11 @@ begin
 
   if tradeLineItem.SelectSingleNode('.//ram:OriginTradeCountry//ram:ID') <> nil then
     Result.OriginTradeCountry := TEnumExtensions<TZUGFeRDCountryCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:OriginTradeCountry//ram:ID'));
-
+  except
+    // Load cannot release this line until it has been returned and added to TradeLineItems.
+    Result.Free;
+    raise;
+  end;
 end;
 
 function TZUGFeRDInvoiceDescriptor23CIIReader._nodeAsLegalOrganization(
@@ -1050,6 +1072,7 @@ function TZUGFeRDInvoiceDescriptor23CIIReader._getAdditionalReferencedDocument(a
 begin
   var strBase64BinaryData : String := TZUGFeRDXmlUtils.NodeAsString(a_oXmlNode, 'ram:AttachmentBinaryObject');
   Result := TZUGFeRDAdditionalReferencedDocument.Create(false);
+  try
   Result.ID := TZUGFeRDXmlUtils.NodeAsString(a_oXmlNode, 'ram:IssuerAssignedID');
   Result.TypeCode := TEnumExtensions<TZUGFeRDAdditionalReferencedDocumentTypeCode>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(a_oXmlNode, 'ram:TypeCode'));
   Result.Name := TZUGFeRDXmlUtils.NodeAsString(a_oXmlNode, 'ram:Name');
@@ -1064,6 +1087,11 @@ begin
   Result.ReferenceTypeCode := TEnumExtensions<TZUGFeRDReferenceTypeCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(a_oXmlNode, 'ram:ReferenceTypeCode'));
   Result.URIID := TZUGFeRDXmlUtils.NodeAsString(a_oXmlNode, 'ram:URIID');
   Result.LineID := TZUGFeRDXmlUtils.NodeAsString(a_oXmlNode, 'ram:LineID');
+  except
+    // The reference owns the stream even if decoding or later field parsing fails.
+    Result.Free;
+    raise;
+  end;
 end;
 
 end.


### PR DESCRIPTION
Follow-up to #114: freeing the invoice descriptor does not release a line item or referenced document that throws before being returned to its parent. Repeatedly loading such input therefore retains memory.

This change:
- releases partial results in `_parseTradeLineItem` and `_getAdditionalReferencedDocument`, preserving the original exception;
- protects product characteristics, included products and accounting accounts until their owning collections accept them;
- keeps attachment streams owned by their referenced document. Public interfaces and parsing rules remain unchanged.

The regression test covers seven malformed-date locations, each paired with a successful load: line billing period, order reference, header and line document references, later references after an attachment was loaded, and actual delivery date. Successful loads also check parsed children and decoded attachment contents.

Verification with Delphi 11, Win64 Debug:
- Without the fix, all seven malformed-input cases fail the allocated-heap assertion; the seven valid cases pass.
- With the fix, all 14 ownership cases and the full suite of 409 tests pass.
- All 18 runner/process checks pass.
- Console and GUI projects compile with no errors, warnings or hints.

Updated to current `main` after the merge of #113. The PR diff remains limited to the CII reader and its ownership tests. The integration run also passes the targeted rounding diagnostic and documentation-fixture checks (present: exit 0; deliberately absent in an isolated copy: exit 1).

The heap checks cover these exercised paths, not every possible reader exception.
