### PR TITLE
Fix reader ownership and strengthen regression-test evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ select a fully qualified DUnitX test/fixture name:
 ```powershell
 .\run-tests.ps1
 .\run-tests.ps1 -Filter 'intf.ZUGFeRD22Tests.UnitTests.TZUGFeRD22Tests.TestCIIReaderReleasesDescriptorAfterParsingError'
+.\run-tests.ps1 -Filter 'intf.ZUGFeRD22Tests.UnitTests.TZUGFeRD22Tests.TestCIIReaderNestedObjectOwnership.ValidDocument'
+.\Test-SourceEncoding.ps1
 .\Test-Runner.ps1
 ```
 
@@ -248,17 +250,32 @@ The native DUnitX syntax uses colons: `--run:<qualified-name>`, `--xmlfile:<path
 DUnitX version shipped with Delphi 11. The helper passes `--run` and closes stdin, so
 non-interactive runs do not require a placeholder file or an Enter keypress.
 
+Parameterized tests require the case suffix: `<unit>.<fixture>.<method>.<case>`.
+The bare parameterized method selects no executable cases and returns exit code `3`;
+selecting its fixture runs all of that fixture's cases. The helper does not broaden filters.
+
 Exit codes: `0` for successful executed tests, `1` for test failures, `2` for runner
 exceptions or invalid command-line options, and `3` if no tests execute. The PowerShell
 helper returns `4` for infrastructure failures, including missing/invalid XML or a timeout.
 It parses a unique report for each invocation before publishing `dunitx-results.xml`;
 an existing report is not reused as evidence for a failed invocation. `-XmlPath` selects
 another report destination and `-TimeoutSeconds` controls the process timeout.
+Always check the exit code and the current invocation's report together. An early native
+option error returns `2` before logger creation and can leave an earlier XML file untouched.
+The helper can likewise leave its published report unchanged when the current run fails
+before producing a valid report; that file is not a success result for the failed run.
 
 `Test-Runner.ps1` verifies test names, counts and exit codes, including missing fixtures,
 invalid reports and an isolated executable path containing spaces. It requires the compiled
 console runner and retains its logs and generated fixtures in a unique temporary directory,
 or in a new directory specified by `-ResultsDirectory`.
+
+Before committing changes to the eight reviewed non-ASCII units, run `Test-SourceEncoding.ps1`.
+It checks strict UTF-8 and requires a BOM for non-ASCII source so Delphi 11 does not interpret
+Unicode diagnostics using the system ANSI code page. `-Paths` selects explicit files for
+the same check. `Test-Runner.ps1` includes valid ASCII/UTF-8 cases and missing-BOM,
+invalid-UTF-8 and missing-file counterexamples. `TestDiagnosticEncoding` captures a real
+assertion diagnostic and checks its Unicode code point independently of source literals.
 
 The documentation sweep includes long example paths. On Windows, invoke the executable
 through a short `subst` drive alias when the checkout path would exceed `MAX_PATH`.
@@ -269,6 +286,13 @@ from `TZUGFeRDTestBase` around warmed-up, isolated operations. The infrastructur
 prove that the assertion rejects a retained object and accepts a released object, without
 leaving the counterexample allocated. These checks cover only the measured paths, not
 every test or possible reader exception. No replacement memory manager is installed.
+
+The reader ownership tests cover CII 1.0/2.0 and UBL Invoice/CreditNote via direct readers
+and automatic dispatch, including successful loads, early/late date errors and payment
+terms errors. The CII 2.3 nested-object test has one common valid case and seven distinct
+date failures. Its `AfterAttachment` cases verify parent cleanup after a second reference
+fails, not a decoder failure in that reference's own attachment. COM, allocation and list
+insertion failures are not exhaustively covered by the regular suite.
 
 ## Relationship to the C# library
 

--- a/Unittest/Test-Runner.ps1
+++ b/Unittest/Test-Runner.ps1
@@ -84,6 +84,49 @@ try {
     Invoke-CheckedProcess 'direct-no-match' $ExePath "--run:NoSuchZfDTest --xmlfile:`"$emptyXml`"" 3 $emptyXml 0
     Invoke-CheckedProcess 'direct-invalid-option' $ExePath '--this-option-does-not-exist:42' 2
 
+    # A bare parameterized method is not a case selector; never silently run the whole fixture.
+    $parameterMethod = 'intf.ZUGFeRD22Tests.UnitTests.TZUGFeRD22Tests.TestCIIReaderNestedObjectOwnership'
+    $parameterCase = "$parameterMethod.ValidDocument"
+    foreach ($viaHelper in @($false, $true)) {
+        $prefix = if ($viaHelper) { 'helper' } else { 'direct' }
+        foreach ($exactCase in @($false, $true)) {
+            $name = if ($exactCase) { "$prefix-parameter-case" } else { "$prefix-parameter-method" }
+            $filter = if ($exactCase) { $parameterCase } else { $parameterMethod }
+            $expectedExit = if ($exactCase) { 0 } else { 3 }
+            $expectedCount = if ($exactCase) { 1 } else { 0 }
+            $parameterXml = Join-Path $ResultsDirectory "$name.xml"
+            if ($viaHelper) {
+                Invoke-CheckedProcess $name $powershell "-NoProfile -ExecutionPolicy Bypass -File `"$helper`" -ExePath `"$ExePath`" -XmlPath `"$parameterXml`" -Filter $filter" $expectedExit $parameterXml $expectedCount
+            } else {
+                Invoke-CheckedProcess $name $ExePath "--run:$filter --xmlfile:`"$parameterXml`"" $expectedExit $parameterXml $expectedCount
+            }
+            if ($exactCase) { Assert-TestNames $parameterXml @('TestCIIReaderNestedObjectOwnership.ValidDocument') }
+        }
+    }
+
+    # An option error can precede logger creation. A surviving report does not belong to that run.
+    $previousSingleReport = [IO.File]::ReadAllBytes($singleXml)
+    Invoke-CheckedProcess 'direct-invalid-option-existing-report' $ExePath "--this-option-does-not-exist:42 --xmlfile:`"$singleXml`"" 2
+    if ([Convert]::ToBase64String([IO.File]::ReadAllBytes($singleXml)) -ne [Convert]::ToBase64String($previousSingleReport)) {
+        throw 'The early option error unexpectedly replaced the report.'
+    }
+
+    # Check the reviewed source list and prove detection of each encoding error in isolated fixtures.
+    $encodingCheck = Join-Path $PSScriptRoot 'Test-SourceEncoding.ps1'
+    Invoke-CheckedProcess 'source-encoding' $powershell "-NoProfile -ExecutionPolicy Bypass -File `"$encodingCheck`"" 0
+    $unicodeText = 'ung' + [char]252 + 'ltig'
+    foreach ($encodingCase in @('bom', 'ascii', 'missing-bom', 'invalid-utf8', 'missing-file')) {
+        $sourcePath = Join-Path $ResultsDirectory "$encodingCase.pas"
+        $expectedExit = 1
+        switch ($encodingCase) {
+            'bom' { [IO.File]::WriteAllText($sourcePath, $unicodeText, (New-Object Text.UTF8Encoding($true))); $expectedExit = 0 }
+            'ascii' { [IO.File]::WriteAllText($sourcePath, 'unit ASCII;', (New-Object Text.UTF8Encoding($false))); $expectedExit = 0 }
+            'missing-bom' { [IO.File]::WriteAllText($sourcePath, $unicodeText, (New-Object Text.UTF8Encoding($false))) }
+            'invalid-utf8' { [IO.File]::WriteAllBytes($sourcePath, [byte[]]@(239, 187, 191, 195, 40)) }
+        }
+        Invoke-CheckedProcess "encoding-$encodingCase" $powershell "-NoProfile -ExecutionPolicy Bypass -File `"$encodingCheck`" -Paths `"$sourcePath`"" $expectedExit
+    }
+
     $fullXml = Join-Path $ResultsDirectory 'suite.xml'
     Invoke-CheckedProcess 'helper-suite' $powershell "-NoProfile -ExecutionPolicy Bypass -File `"$helper`" -ExePath `"$ExePath`" -XmlPath `"$fullXml`"" 0
     [xml]$fullReport = Get-Content -LiteralPath $fullXml -Raw -Encoding UTF8

--- a/Unittest/Test-SourceEncoding.ps1
+++ b/Unittest/Test-SourceEncoding.ps1
@@ -1,0 +1,33 @@
+param([string[]]$Paths = @(
+    "$PSScriptRoot\intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas",
+    "$PSScriptRoot\intf.ZUGFeRDCrossVersionTests.UnitTests.pas",
+    "$PSScriptRoot\intf.XRechnungUBLTests.UnitTests.pas",
+    "$PSScriptRoot\intf.ZUGFeRDDocumentationSweep.UnitTests.pas",
+    "$PSScriptRoot\..\intf.ZUGFeRDInvoiceDescriptor22UBLWriter.pas",
+    "$PSScriptRoot\..\intf.ZUGFeRDInvoiceDescriptor22UblReader.pas",
+    "$PSScriptRoot\..\intf.ZUGFeRDProfileAwareXmlTextWriter.pas",
+    "$PSScriptRoot\..\intf.ZUGFeRDAdvancePayment.pas"
+))
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Delphi 11 needs an explicit UTF-8 signature for non-ASCII source on an ANSI system locale.
+try {
+    if ($Paths.Count -eq 0) { throw 'No source files selected.' }
+    $decoder = New-Object System.Text.UTF8Encoding($false, $true)
+    foreach ($path in $Paths) {
+        $bytes = [IO.File]::ReadAllBytes($path)
+        $hasBom = $bytes.Length -ge 3 -and $bytes[0] -eq 239 -and $bytes[1] -eq 187 -and $bytes[2] -eq 191
+        $offset = if ($hasBom) { 3 } else { 0 }
+        $content = $decoder.GetString($bytes, $offset, $bytes.Length - $offset)
+        if (-not $hasBom -and $content -match '[^\x00-\x7F]') {
+            throw "Non-ASCII Delphi source requires a UTF-8 BOM: $path"
+        }
+    }
+    Write-Output "Source encoding checked: $($Paths.Count) files."
+    exit 0
+} catch {
+    [Console]::Error.WriteLine($_.Exception.Message)
+    exit 1
+}

--- a/Unittest/intf.XRechnungUBLTests.UnitTests.pas
+++ b/Unittest/intf.XRechnungUBLTests.UnitTests.pas
@@ -1,4 +1,4 @@
-{* Licensed to the Apache Software Foundation (ASF) under one
+﻿{* Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/Unittest/intf.ZUGFeRD22Tests.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRD22Tests.UnitTests.pas
@@ -45,21 +45,15 @@ type
     procedure TestAdvancePaymentReaderRejectsMissingMandatoryData;
     [Test]
     procedure TestCIIReaderReleasesDescriptorAfterParsingError;
-    /// <summary>Checks ownership before and after nested CII objects are handed to their parent.</summary>
+    /// <summary>Checks one valid document and seven distinct date failures before and after ownership transfer.</summary>
     [Test]
-    [TestCase('ValidLinePeriod', 'line-period,False')]
+    [TestCase('ValidDocument', 'line-period,False')]
     [TestCase('InvalidLinePeriod', 'line-period,True')]
-    [TestCase('ValidLineOrder', 'line-order,False')]
     [TestCase('InvalidLineOrder', 'line-order,True')]
-    [TestCase('ValidHeaderReference', 'header-reference,False')]
     [TestCase('InvalidHeaderReference', 'header-reference,True')]
-    [TestCase('ValidLineReference', 'line-reference,False')]
     [TestCase('InvalidLineReference', 'line-reference,True')]
-    [TestCase('ValidHeaderAfterAttachment', 'header-after-attachment,False')]
     [TestCase('InvalidHeaderAfterAttachment', 'header-after-attachment,True')]
-    [TestCase('ValidLineAfterAttachment', 'line-after-attachment,False')]
     [TestCase('InvalidLineAfterAttachment', 'line-after-attachment,True')]
-    [TestCase('ValidLineDelivery', 'line-delivery,False')]
     [TestCase('InvalidLineDelivery', 'line-delivery,True')]
     procedure TestCIIReaderNestedObjectOwnership(const failurePoint: string; invalidData: Boolean);
     [Test]
@@ -944,6 +938,8 @@ end;
 
 /// <summary>
 /// Exercises late failures with both unowned children and already attached documents and streams.
+/// AfterAttachment fails in the second reference, testing cleanup of its parent's first attachment.
+/// Date failures precede the failing reference's own stream allocation; they do not exercise decoder/write failures.
 /// </summary>
 procedure TZUGFeRD22Tests.TestCIIReaderNestedObjectOwnership(const failurePoint: string; invalidData: Boolean);
 const
@@ -985,7 +981,7 @@ var
         begin
           if not invalidData then
             raise;
-          Exit(error.Message = expectedError);
+          Exit((error.ClassType = Exception) and (error.Message = expectedError));
         end;
       end;
       Result := not invalidData and (loadedInvoice <> nil);
@@ -993,6 +989,11 @@ var
       begin
         Assert.AreEqual(1, loadedInvoice.TradeLineItems.Count);
         Assert.AreEqual(2, loadedInvoice.AdditionalReferencedDocuments.Count);
+        Assert.IsNotNull(loadedInvoice.ShipTo);
+        Assert.IsNotNull(loadedInvoice.ShipTo.SpecifiedLegalOrganization);
+        Assert.AreEqual('SHIP-LEGAL', loadedInvoice.ShipTo.SpecifiedLegalOrganization.ID.ID);
+        Assert.IsNotNull(loadedInvoice.ShipToContact);
+        Assert.AreEqual('CONTACT', loadedInvoice.ShipToContact.Name);
         Assert.AreEqual('HEADER-DOC', loadedInvoice.AdditionalReferencedDocuments[0].ID);
         CheckAttachment(loadedInvoice.AdditionalReferencedDocuments[0].AttachmentBinaryObject);
         Assert.AreEqual('HEADER-LATE', loadedInvoice.AdditionalReferencedDocuments[1].ID);
@@ -1056,6 +1057,10 @@ begin
     '</ram:AdditionalReferencedDocument><ram:AdditionalReferencedDocument><ram:IssuerAssignedID>HEADER-LATE</ram:IssuerAssignedID>' +
     '<ram:FormattedIssueDateTime><qdt:DateTimeString format="102">{header-after-attachment}</qdt:DateTimeString></ram:FormattedIssueDateTime>' +
     '</ram:AdditionalReferencedDocument></ram:ApplicableHeaderTradeAgreement>' +
+    '<ram:ApplicableHeaderTradeDelivery><ram:ShipToTradeParty><ram:Name>SHIP</ram:Name>' +
+    '<ram:SpecifiedLegalOrganization><ram:ID>SHIP-LEGAL</ram:ID></ram:SpecifiedLegalOrganization>' +
+    '<ram:DefinedTradeContact><ram:PersonName>CONTACT</ram:PersonName></ram:DefinedTradeContact>' +
+    '</ram:ShipToTradeParty></ram:ApplicableHeaderTradeDelivery>' +
     '</rsm:SupplyChainTradeTransaction></rsm:CrossIndustryInvoice>';
 
   Assert.IsTrue(xmlContent.Contains('{' + failurePoint + '}'), 'Unknown failure point.');
@@ -1070,7 +1075,7 @@ begin
   try
     Assert.IsTrue(LoadAndRelease(True), 'The reader did not produce the expected result or parser exception.');
     for var warmupIndex := 1 to measuredLoadCount do
-      LoadAndRelease(False);
+      Assert.IsTrue(LoadAndRelease(False), 'A warmup load did not produce the expected result or parser exception.');
     firstBatchMemory := GetAllocatedMemory;
     allLoadsMatched := True;
     for var loadIndex := 1 to measuredLoadCount do

--- a/Unittest/intf.ZUGFeRDCrossVersionTests.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRDCrossVersionTests.UnitTests.pas
@@ -1,4 +1,4 @@
-{* Licensed to the Apache Software Foundation (ASF) under one
+﻿{* Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file
@@ -34,6 +34,28 @@ type
     procedure AssertUBLTaxTotalFallback(const ReplacementCurrencyCode: string;
       const MakeFallbackAmbiguous: Boolean);
   public
+    /// <summary>Checks an actual assertion diagnostic against Unicode code points, not another source literal.</summary>
+    [Test]
+    procedure TestDiagnosticEncoding;
+
+    /// <summary>Checks result ownership on successful loads and early/late date failures through both reader entry paths.</summary>
+    [Test]
+    [TestCase('CII1Valid', '100,valid')]
+    [TestCase('CII1Header', '100,header')]
+    [TestCase('CII1Line', '100,line')]
+    [TestCase('CII1PaymentTerms', '100,payment')]
+    [TestCase('CII20Valid', '200,valid')]
+    [TestCase('CII20Header', '200,header')]
+    [TestCase('CII20Line', '200,line')]
+    [TestCase('CII20PaymentTerms', '200,payment')]
+    [TestCase('UBLInvoiceValid', '221,valid')]
+    [TestCase('UBLInvoiceHeader', '221,header')]
+    [TestCase('UBLInvoiceLine', '221,line')]
+    [TestCase('UBLCreditNoteValid', '222,valid')]
+    [TestCase('UBLCreditNoteHeader', '222,header')]
+    [TestCase('UBLCreditNoteLine', '222,line')]
+    procedure TestReaderResultOwnership(readerKind: Integer; const failurePoint: string);
+
     [Test]
     procedure TestAutomaticLineIds;
 
@@ -346,6 +368,11 @@ uses
   Winapi.MSXMLIntf, Winapi.msxml,
   intf.ZUGFeRDInvoiceDescriptor,
   intf.ZUGFeRDInvoiceProvider,
+  intf.ZUGFeRDIInvoiceDescriptorReader,
+  intf.ZUGFeRDInvoiceDescriptor1Reader,
+  intf.ZUGFeRDInvoiceDescriptor20Reader,
+  intf.ZUGFeRDInvoiceDescriptor22UblReader,
+  intf.ZUGFeRDInvoiceTypes,
   intf.ZUGFeRDProfile,
   intf.ZUGFeRDVersion,
   intf.ZUGFeRDFormats,
@@ -378,6 +405,186 @@ uses
   intf.ZUGFeRDAdditionalReferencedDocumentTypeCodes;
 
 { TZUGFeRDCrossVersionTests }
+
+procedure TZUGFeRDCrossVersionTests.TestReaderResultOwnership(readerKind: Integer; const failurePoint: string);
+const
+  loadCount = 10;
+var
+  sourceInvoice: TZUGFeRDInvoiceDescriptor;
+  reader: TZUGFeRDIInvoiceDescriptorReader;
+  version: TZUGFeRDVersion;
+  profile: TZUGFeRDProfile;
+  format: TZUGFeRDFormats;
+  outputStream, inputStream: TStringStream;
+  xmlContent, dateToken, expectedError: string;
+  beforeBytes, afterBytes: NativeUInt;
+  allLoadsMatched: Boolean;
+
+  /// <summary>Preserves parser exceptions and leaves the caller-owned stream available for the next load.</summary>
+  function LoadAndRelease(useDispatcher, checkValues: Boolean): Boolean;
+  var
+    loadedInvoice: TZUGFeRDInvoiceDescriptor;
+  begin
+    inputStream.Position := 0;
+    loadedInvoice := nil;
+    try
+      try
+        if useDispatcher then
+          loadedInvoice := TZUGFeRDInvoiceDescriptor.Load(inputStream)
+        else
+          loadedInvoice := reader.Load(inputStream);
+      except
+        on error: Exception do
+        begin
+          if failurePoint = 'valid' then
+            raise;
+          Exit((error.Message = expectedError) and
+            (((readerKind < 221) and (error.ClassType = Exception)) or
+             ((readerKind >= 221) and (error is TZUGFeRDUnsupportedException))));
+        end;
+      end;
+      Result := failurePoint = 'valid';
+      if checkValues then
+      begin
+        Assert.IsNotNull(loadedInvoice);
+        Assert.AreEqual('471102', loadedInvoice.InvoiceNo);
+        Assert.AreEqual(EncodeDate(2001, 10, 1), loadedInvoice.InvoiceDate.Value);
+        Assert.AreEqual(2, loadedInvoice.TradeLineItems.Count);
+        Assert.AreEqual(EncodeDate(2001, 11, 2), loadedInvoice.TradeLineItems[0].BillingPeriodStart.Value);
+        Assert.IsNotNull(loadedInvoice.Seller);
+        Assert.IsNotNull(loadedInvoice.Buyer);
+        if readerKind >= 221 then
+        begin
+          Assert.AreEqual('4000001123452', loadedInvoice.Seller.GlobalID.ID);
+          Assert.AreEqual('GE2020211', loadedInvoice.Buyer.ID.ID);
+          Assert.IsNotNull(loadedInvoice.ShipTo);
+          Assert.AreEqual('DELIVERY-OWNERSHIP', loadedInvoice.ShipTo.ID.ID);
+        end;
+        if readerKind = 222 then
+          Assert.AreEqual(TZUGFeRDInvoiceType.CreditNote, loadedInvoice.Type_);
+      end;
+    finally
+      loadedInvoice.Free;
+    end;
+  end;
+begin
+  profile := TZUGFeRDProfile.Extended;
+  format := TZUGFeRDFormats.CII;
+  case readerKind of
+    100: begin
+      version := TZUGFeRDVersion.Version1;
+      reader := TZUGFeRDInvoiceDescriptor1Reader.Create;
+    end;
+    200: begin
+      // EXTENDED has a unique 2.0 guideline; COMFORT would select the 2.3 reader.
+      version := TZUGFeRDVersion.Version20;
+      reader := TZUGFeRDInvoiceDescriptor20Reader.Create;
+    end;
+    221, 222: begin
+      version := TZUGFeRDVersion.Version23;
+      profile := TZUGFeRDProfile.XRechnung;
+      format := TZUGFeRDFormats.UBL;
+      reader := TZUGFeRDInvoiceDescriptor22UblReader.Create;
+    end;
+  else
+    raise EArgumentException.Create('Unknown reader kind.');
+  end;
+  try
+    sourceInvoice := TZUGFeRDInvoiceProvider.CreateInvoice;
+    try
+      sourceInvoice.InvoiceDate := EncodeDate(2001, 10, 1);
+      sourceInvoice.TradeLineItems[0].BillingPeriodStart := EncodeDate(2001, 11, 2);
+      sourceInvoice.TradeLineItems[0].BillingPeriodEnd := EncodeDate(2001, 11, 3);
+      sourceInvoice.PaymentTermsList[0].DueDate := EncodeDate(2001, 12, 3);
+      sourceInvoice.ShipTo := TZUGFeRDParty.Create;
+      sourceInvoice.ShipTo.ID.ID := 'DELIVERY-OWNERSHIP';
+      sourceInvoice.ShipTo.Name := 'Delivery';
+      sourceInvoice.ShipTo.Country := TZUGFeRDCountryCodes.DE;
+      if readerKind >= 221 then
+      begin
+        // Exercise both UBL routing branches: a GLN seller ID and an ordinary buyer ID.
+        sourceInvoice.Seller.ID.ID := '4000001123452';
+        sourceInvoice.Seller.ID.SchemeID := TZUGFeRDGlobalIDSchemeIdentifiers.GLN;
+        sourceInvoice.PaymentMeans.SEPACreditorIdentifier := '';
+      end;
+      if readerKind = 222 then
+        sourceInvoice.Type_ := TZUGFeRDInvoiceType.CreditNote;
+      outputStream := TStringStream.Create('', TEncoding.UTF8);
+      try
+        sourceInvoice.Save(outputStream, version, profile, format);
+        xmlContent := outputStream.DataString;
+      finally
+        outputStream.Free;
+      end;
+    finally
+      sourceInvoice.Free;
+    end;
+
+    if failurePoint <> 'valid' then
+    begin
+      if failurePoint = 'header' then
+        dateToken := '20011001'
+      else if failurePoint = 'line' then
+        dateToken := '20011102'
+      else if failurePoint = 'payment' then
+        dateToken := '20011203'
+      else
+        raise EArgumentException.Create('Unknown failure point.');
+      if format = TZUGFeRDFormats.UBL then
+        dateToken := Copy(dateToken, 1, 4) + '-' + Copy(dateToken, 5, 2) + '-' + Copy(dateToken, 7, 2);
+      Assert.AreEqual(1, (Length(xmlContent) - Length(xmlContent.Replace(dateToken, ''))) div Length(dateToken), 'Expected one date at the selected failure point.');
+      xmlContent := xmlContent.Replace(dateToken, Copy(dateToken, 1, Length(dateToken) - 1));
+    end;
+    if format = TZUGFeRDFormats.UBL then
+      expectedError := 'Invalid length of datetime value'
+    else
+      expectedError := 'Wrong length of datetime element (format 102)';
+
+    inputStream := TStringStream.Create(xmlContent, TEncoding.UTF8);
+    try
+      Assert.IsTrue(reader.IsReadableByThisReaderVersion(inputStream), 'The fixture must select the intended reader.');
+      inputStream.Position := 0;
+      Assert.AreEqual(version, TZUGFeRDInvoiceDescriptor.GetVersion(inputStream));
+      Assert.IsTrue(LoadAndRelease(False, True), 'Unexpected result from the direct reader.');
+      Assert.IsTrue(LoadAndRelease(True, True), 'Unexpected result from the dispatcher.');
+      for var warmupIndex := 1 to loadCount do
+      begin
+        Assert.IsTrue(LoadAndRelease(False, False), 'Unexpected direct-reader warmup result.');
+        Assert.IsTrue(LoadAndRelease(True, False), 'Unexpected dispatcher warmup result.');
+      end;
+      beforeBytes := GetAllocatedMemory;
+      allLoadsMatched := True;
+      for var loadIndex := 1 to loadCount do
+      begin
+        allLoadsMatched := LoadAndRelease(False, False) and allLoadsMatched;
+        allLoadsMatched := LoadAndRelease(True, False) and allLoadsMatched;
+      end;
+      afterBytes := GetAllocatedMemory;
+      Assert.IsTrue(allLoadsMatched, 'A repeated load changed the result or exception.');
+      AssertNoMemoryGrowth(beforeBytes, afterBytes);
+      inputStream.Position := 0;
+      Assert.AreEqual(xmlContent, inputStream.DataString, 'Loading must not modify or free the caller-owned stream.');
+    finally
+      inputStream.Free;
+    end;
+  finally
+    reader.Free;
+  end;
+end;
+
+procedure TZUGFeRDCrossVersionTests.TestDiagnosticEncoding;
+var
+  diagnostic: string;
+begin
+  diagnostic := '';
+  try
+    Assert.Fail('ungültig');
+  except
+    on error: Exception do
+      diagnostic := error.Message;
+  end;
+  Assert.IsTrue(diagnostic.Contains('ung' + #$00FC + 'ltig'), 'The compiled assertion diagnostic must contain U+00FC.');
+end;
 
 procedure TZUGFeRDCrossVersionTests.TestAutomaticLineIds;
 var

--- a/Unittest/intf.ZUGFeRDDocumentationSweep.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRDDocumentationSweep.UnitTests.pas
@@ -1,4 +1,4 @@
-{* Licensed to the Apache Software Foundation (ASF) under one
+﻿{* Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
@@ -1,4 +1,4 @@
-{* Licensed to the Apache Software Foundation (ASF) under one
+﻿{* Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/intf.ZUGFeRDAdvancePayment.pas
+++ b/intf.ZUGFeRDAdvancePayment.pas
@@ -1,4 +1,4 @@
-{* Licensed to the Apache Software Foundation (ASF) under one
+﻿{* Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/intf.ZUGFeRDInvoiceDescriptor1Reader.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor1Reader.pas
@@ -135,6 +135,7 @@ begin
   end;
 end;
 
+/// <summary>Transfers the parsed result to the caller only after successful loading.</summary>
 function TZUGFeRDInvoiceDescriptor1Reader.Load(xmldocument : IXMLDocument): TZUGFeRDInvoiceDescriptor;
 var
   doc : IXMLDOMDocument2;
@@ -147,235 +148,259 @@ begin
   //   nsmgr.AddNamespace('rsm', nsmgr.DefaultNamespace);
 
   Result := TZUGFeRDInvoiceDescriptor.Create;
+  try
 
-  Result.IsTest := TZUGFeRDXmlUtils.NodeAsBool(doc.documentElement,'//*[local-name()="SpecifiedExchangedDocumentContext"]/ram:TestIndicator',false);
-  Result.BusinessProcess := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//*[local-name()="BusinessProcessSpecifiedDocumentContextParameter"]/ram:ID');//, nsmgr),
-  Result.Guideline := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:GuidelineSpecifiedDocumentContextParameter/ram:ID'); //, nsmgr)),
-  Result.Profile := TZUGFeRDProfileExtensions.StringToEnum(Result.Guideline);
-  Result.Name := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//*[local-name()="HeaderExchangedDocument"]/ram:Name');//, nsmgr)),
-  Result.Type_ := TEnumExtensions<TZUGFeRDInvoiceType>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//*[local-name()="HeaderExchangedDocument"]/ram:TypeCode'));//, nsmgr)),
-  Result.InvoiceNo := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//*[local-name()="HeaderExchangedDocument"]/ram:ID');//, nsmgr),
-  Result.InvoiceDate := TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//*[local-name()="HeaderExchangedDocument"]/ram:IssueDateTime/udt:DateTimeString');//", nsmgr)
+    Result.IsTest := TZUGFeRDXmlUtils.NodeAsBool(doc.documentElement,'//*[local-name()="SpecifiedExchangedDocumentContext"]/ram:TestIndicator',false);
+    Result.BusinessProcess := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//*[local-name()="BusinessProcessSpecifiedDocumentContextParameter"]/ram:ID');//, nsmgr),
+    Result.Guideline := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:GuidelineSpecifiedDocumentContextParameter/ram:ID'); //, nsmgr)),
+    Result.Profile := TZUGFeRDProfileExtensions.StringToEnum(Result.Guideline);
+    Result.Name := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//*[local-name()="HeaderExchangedDocument"]/ram:Name');//, nsmgr)),
+    Result.Type_ := TEnumExtensions<TZUGFeRDInvoiceType>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//*[local-name()="HeaderExchangedDocument"]/ram:TypeCode'));//, nsmgr)),
+    Result.InvoiceNo := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//*[local-name()="HeaderExchangedDocument"]/ram:ID');//, nsmgr),
+    Result.InvoiceDate := TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//*[local-name()="HeaderExchangedDocument"]/ram:IssueDateTime/udt:DateTimeString');//", nsmgr)
 
-  nodes := doc.selectNodes('//*[local-name()="HeaderExchangedDocument"]/ram:IncludedNote');
-  for i := 0 to nodes.length-1 do
-  begin
-    var content : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Content');
-    var subjectCode : ZUGFeRDNullable<TZUGFeRDSubjectCodes> := TEnumExtensions<TZUGFeRDSubjectCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:SubjectCode'));
-    var contentCode : ZUGFeRDNullable<TZUGFeRDContentCodes> := TEnumExtensions<TZUGFeRDContentCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ContentCode'));
-    Result.AddNote(content, subjectCode, contentCode);
-  end;
-
-  Result.ReferenceOrderNo := TZUGFeRDXmlUtils.NodeAsString(doc, '//ram:ApplicableSupplyChainTradeAgreement/ram:BuyerReference');
-
-  Result.Seller := _nodeAsParty(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeAgreement/ram:SellerTradeParty');
-
-  nodes := doc.selectNodes('//ram:ApplicableSupplyChainTradeAgreement/ram:SellerTradeParty/ram:SpecifiedTaxRegistration');
-  for i := 0 to nodes.length-1 do
-  begin
-    var id : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ID');
-    var schemeID : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ID/@schemeID');
-    Result.AddSellerTaxRegistration(id, TEnumExtensions<TZUGFeRDTaxRegistrationSchemeID>.StringToEnum(schemeID));
-  end;
-
-  if (doc.selectSingleNode('//ram:SellerTradeParty/ram:DefinedTradeContact') <> nil) then
-  begin
-    Result.SellerContact := TZUGFeRDContact.Create;
-    Result.SellerContact.Name := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:SellerTradeParty/ram:DefinedTradeContact/ram:PersonName');
-    Result.SellerContact.OrgUnit := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:SellerTradeParty/ram:DefinedTradeContact/ram:DepartmentName');
-    Result.SellerContact.PhoneNo := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:SellerTradeParty/ram:DefinedTradeContact/ram:TelephoneUniversalCommunication/ram:CompleteNumber');
-    Result.SellerContact.FaxNo := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:SellerTradeParty/ram:DefinedTradeContact/ram:FaxUniversalCommunication/ram:CompleteNumber');
-    Result.SellerContact.EmailAddress := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:SellerTradeParty/ram:DefinedTradeContact/ram:EmailURIUniversalCommunication/ram:URIID');
-  end;
-
-  Result.Buyer := _nodeAsParty(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeAgreement/ram:BuyerTradeParty');
-
-  nodes := doc.selectNodes('//ram:ApplicableSupplyChainTradeAgreement/ram:BuyerTradeParty/ram:SpecifiedTaxRegistration');
-  for i := 0 to nodes.length-1 do
-  begin
-    var id : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ID');
-    var schemeID : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ID/@schemeID');
-    Result.AddBuyerTaxRegistration(id, TEnumExtensions<TZUGFeRDTaxRegistrationSchemeID>.StringToEnum(schemeID));
-  end;
-
-  if (doc.SelectSingleNode('//ram:BuyerTradeParty/ram:DefinedTradeContact') <> nil) then
-  begin
-    Result.BuyerContact := TZUGFeRDContact.Create;
-    Result.SetBuyerContact(
-      TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:BuyerTradeParty/ram:DefinedTradeContact/ram:PersonName'),
-      TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:BuyerTradeParty/ram:DefinedTradeContact/ram:DepartmentName'),
-      TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:BuyerTradeParty/ram:DefinedTradeContact/ram:EmailURIUniversalCommunication/ram:URIID'),
-      TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:BuyerTradeParty/ram:DefinedTradeContact/ram:TelephoneUniversalCommunication/ram:CompleteNumber'),
-      TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:BuyerTradeParty/ram:DefinedTradeContact/ram:FaxUniversalCommunication/ram:CompleteNumber')
-    );
-  end;
-
-  //Read TransportModeCodes --> BT-X-152
-  if (doc.SelectSingleNode('//ram:ApplicableSupplyChainTradeDelivery/ram:RelatedSupplyChainConsignment/ram:SpecifiedLogisticsTransportMovement/ram:ModeCode') <> nil) then
-    Result.TransportMode := TEnumExtensions<TZUGFeRDTransportmodeCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeDelivery/ram:RelatedSupplyChainConsignment/ram:SpecifiedLogisticsTransportMovement/ram:ModeCode'));
-
-  Result.ShipTo := _nodeAsParty(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeDelivery/ram:ShipToTradeParty');
-  Result.ShipFrom := _nodeAsParty(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeDelivery/ram:ShipFromTradeParty');
-  Result.ActualDeliveryDate:=TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeDelivery/ram:ActualDeliverySupplyChainEvent/ram:OccurrenceDateTime/udt:DateTimeString');
-
-  var _deliveryNoteNo : String := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:ID');
-  var _deliveryNoteDate : ZUGFeRDNullable<TDateTime> := TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssueDateTime/udt:DateTimeString');
-
-  if Not (_deliveryNoteDate.HasValue) then
-  begin
-    _deliveryNoteDate := TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssueDateTime');
-  end;
-
-  if ((_deliveryNoteDate.HasValue) or (_deliveryNoteNo <> '')) then
-  begin
-    Result.DeliveryNoteReferencedDocument := TZUGFeRDDeliveryNoteReferencedDocument.Create;
-    Result.SetDeliveryNoteReferenceDocument(_deliveryNoteNo,_deliveryNoteDate);
-  end;
-
-  Result.Invoicee := _nodeAsParty(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeSettlement/ram:InvoiceeTradeParty');
-  Result.Payee := _nodeAsParty(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeSettlement/ram:PayeeTradeParty');
-
-  Result.PaymentReference := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeSettlement/ram:PaymentReference');
-  Result.Currency :=  TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeSettlement/ram:InvoiceCurrencyCode'));
-
-  // TODO: Multiple SpecifiedTradeSettlementPaymentMeans can exist for each account/institution (with different SEPA?)
-  var _tempPaymentMeans : TZUGFeRDPaymentMeans := TZUGFeRDPaymentMeans.Create;
-  _tempPaymentMeans.TypeCode := TEnumExtensions<TZUGFeRDPaymentMeansTypeCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:TypeCode'));
-  _tempPaymentMeans.Information := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:Information');
-  _tempPaymentMeans.SEPACreditorIdentifier := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:ID');
-  _tempPaymentMeans.SEPAMandateReference := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:ID/@schemeAgencyID');
-  Result.PaymentMeans := _tempPaymentMeans;
-
-  Result.BillingPeriodStart := TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeSettlement/ram:BillingSpecifiedPeriod/ram:StartDateTime');
-  Result.BillingPeriodEnd := TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeSettlement/ram:BillingSpecifiedPeriod/ram:EndDateTime');
-
-  var creditorFinancialAccountNodes : IXMLDOMNodeList := doc.SelectNodes('//ram:ApplicableSupplyChainTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:PayeePartyCreditorFinancialAccount');
-  var creditorFinancialInstitutions : IXMLDOMNodeList := doc.SelectNodes('//ram:ApplicableSupplyChainTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:PayeeSpecifiedCreditorFinancialInstitution');
-
-  if (creditorFinancialAccountNodes.length = creditorFinancialInstitutions.length) then
-    for i := 0 to creditorFinancialAccountNodes.length-1 do
-      Result.AddCreditorFinancialAccount(TZUGFeRDXmlUtils.NodeAsString(creditorFinancialAccountNodes[i], './/ram:IBANID'),
-                                         TZUGFeRDXmlUtils.NodeAsString(creditorFinancialInstitutions[i], './/ram:BICID'),
-                                         TZUGFeRDXmlUtils.NodeAsString(creditorFinancialAccountNodes[i], './/ram:ProprietaryID'),
-                                         TZUGFeRDXmlUtils.NodeAsString(creditorFinancialInstitutions[i], './/ram:GermanBankleitzahlID'),
-                                         TZUGFeRDXmlUtils.NodeAsString(creditorFinancialInstitutions[i], './/ram:Name'),
-                                         TZUGFeRDXmlUtils.NodeAsString(creditorFinancialAccountNodes[i], './/ram:AccountName'));
-
-  var debitorFinancialAccountNodes : IXMLDOMNodeList := doc.SelectNodes('//ram:ApplicableSupplyChainTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:PayerPartyDebtorFinancialAccount');
-  var debitorFinancialInstitutions : IXMLDOMNodeList := doc.SelectNodes('//ram:ApplicableSupplyChainTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:PayerSpecifiedDebtorFinancialInstitution');
-
-  //TODO Index prüfen in der Schleife, bei csharp stand 0 drin
-  if (debitorFinancialAccountNodes.length = debitorFinancialInstitutions.length) then
-    for i := 0 to debitorFinancialAccountNodes.length-1 do
-       Result.AddDebitorFinancialAccount(TZUGFeRDXmlUtils.NodeAsString(debitorFinancialAccountNodes[i], './/ram:IBANID'),
-                                         TZUGFeRDXmlUtils.NodeAsString(debitorFinancialInstitutions[i], './/ram:BICID'),
-                                         TZUGFeRDXmlUtils.NodeAsString(debitorFinancialAccountNodes[i], './/ram:ProprietaryID'),
-                                         TZUGFeRDXmlUtils.NodeAsString(debitorFinancialInstitutions[i], './/ram:GermanBankleitzahlID'),
-                                         TZUGFeRDXmlUtils.NodeAsString(debitorFinancialInstitutions[i], './/ram:Name'));
-
-  nodes := doc.SelectNodes('//ram:ApplicableSupplyChainTradeSettlement/ram:ApplicableTradeTax');
-  for i := 0 to nodes.length-1 do
-  begin
-    Result.AddApplicableTradeTax(TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:CalculatedAmount', 0),
-                                 TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:BasisAmount', 0),
-                                 TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:ApplicablePercent', 0),
-                                 TEnumExtensions<TZUGFeRDTaxTypes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:TypeCode')),
-                                 TEnumExtensions<TZUGFeRDTaxCategoryCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:CategoryCode')),
-                                 TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:AllowanceChargeBasisAmount', 0),
-                                 Nil,
-                                 '',
-                                 TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:LineTotalBasisAmount'));
-  end;
-
-  nodes := doc.SelectNodes('//ram:SpecifiedTradeAllowanceCharge');
-  for i := 0 to nodes.length-1 do
-  begin
-    if TZUGFeRDXmlUtils.NodeAsBool(nodes[i], './/ram:ChargeIndicator') then
-      Result.AddTradeCharge(TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:BasisAmount', 0),
-                                   Result.Currency,
-                                   TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:ActualAmount', 0),
-                                   TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Reason'),
-                                   TEnumExtensions<TZUGFeRDTaxTypes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:CategoryTradeTax/ram:TypeCode')),
-                                   TEnumExtensions<TZUGFeRDTaxCategoryCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:CategoryTradeTax/ram:CategoryCode')),
-                                   TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:CategoryTradeTax/ram:ApplicablePercent', 0),
-                                   TEnumExtensions<TZUGFeRDChargeReasonCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:ReasonCode')))
-  else
-      Result.AddTradeAllowance(TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:BasisAmount', 0),
-                                   Result.Currency,
-                                   TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:ActualAmount', 0),
-                                   TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Reason'),
-                                   TEnumExtensions<TZUGFeRDTaxTypes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:CategoryTradeTax/ram:TypeCode')),
-                                   TEnumExtensions<TZUGFeRDTaxCategoryCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:CategoryTradeTax/ram:CategoryCode')),
-                                   TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:CategoryTradeTax/ram:ApplicablePercent', 0),
-                                   TEnumExtensions<TZUGFeRDAllowanceReasonCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:ReasonCode')))
-  end;
-
-  nodes := doc.SelectNodes('//ram:SpecifiedLogisticsServiceCharge');
-  for i := 0 to nodes.length-1 do
-  begin
-    Result.AddLogisticsServiceCharge(TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:AppliedAmount', 0),
-                                     TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Description'),
-                                     TEnumExtensions<TZUGFeRDTaxTypes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:AppliedTradeTax/ram:TypeCode')),
-                                     TEnumExtensions<TZUGFeRDTaxCategoryCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:AppliedTradeTax/ram:CategoryCode')),
-                                     TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:AppliedTradeTax/ram:ApplicablePercent', 0));
-  end;
-
-  nodes := doc.SelectNodes('//ram:SpecifiedTradePaymentTerms');
-  for i := 0 to nodes.length-1 do
-  begin
-    var paymentTerm : TZUGFeRDPaymentTerms := TZUGFeRDPaymentTerms.Create;
-    paymentTerm.Description := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Description');
-    paymentTerm.DueDate:= TZUGFeRDXmlUtils.NodeAsDateTime(nodes[i], './/ram:DueDateDateTime/udt:DateTimeString');
-    paymentTerm.PartialPaymentAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:PartialPaymentAmount');
-    var discountPercent: ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:ApplicableTradePaymentDiscountTerms/ram:CalculationPercent');
-    var penaltyPercent: ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:ApplicableTradePaymentPenaltyTerms/ram:CalculationPercent');
-    var Days: ZUGFeRDNullable<Integer>;
-    if discountPercent.HasValue then
+    nodes := doc.selectNodes('//*[local-name()="HeaderExchangedDocument"]/ram:IncludedNote');
+    for i := 0 to nodes.length-1 do
     begin
-      paymentTerm.PaymentTermsType:= TZUGFeRDPaymentTermsType.Skonto;
-      paymentTerm.Percentage:= discountPercent;
-      if TZUGFeRDQuantityCodes.DAY = TEnumExtensions<TZUGFeRDQuantityCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ApplicableTradePaymentDiscountTerms/ram:BasisPeriodMeasure/@unitCode')) then
-        paymentTerm.DueDays:= TZUGFeRDXmlUtils.NodeAsInt(nodes[i], './/ram:ApplicableTradePaymentDiscountTerms/ram:BasisPeriodMeasure');
-      paymentTerm.MaturityDate:= TZUGFeRDXmlUtils.NodeAsDateTime(nodes[i], './/ram:ApplicableTradePaymentDiscountTerms/ram:BasisDateTime/udt:DateTimeString'); //BT-X-282-0
-      paymentTerm.BaseAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:ApplicableTradePaymentDiscountTerms/ram:BasisAmount');
-      paymentTerm.ActualAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:ApplicableTradePaymentDiscountTerms/ram:ActualDiscountAmount');
-    end
-    else
-    if penaltyPercent.HasValue then
-    begin
-      paymentTerm.PaymentTermsType:= TZUGFeRDPaymentTermsType.Verzug;
-      paymentTerm.Percentage:= penaltyPercent;
-      if TZUGFeRDQuantityCodes.DAY = TEnumExtensions<TZUGFeRDQuantityCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ApplicableTradePaymentPenaltyTerms/ram:BasisPeriodMeasure/@unitCode')) then
-        paymentTerm.DueDays:= TZUGFeRDXmlUtils.NodeAsInt(nodes[i], './/ram:ApplicableTradePaymentPenaltyTerms/ram:BasisPeriodMeasure');
-      paymentTerm.MaturityDate:= TZUGFeRDXmlUtils.NodeAsDateTime(nodes[i], './/ram:ApplicableTradePaymentPenaltyTerms/ram:BasisDateTime/udt:DateTimeString'); // BT-X-276-0
-      paymentTerm.BaseAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:ApplicableTradePaymentPenaltyTerms/ram:BasisAmount');
-      paymentTerm.ActualAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:ApplicableTradePaymentPenaltyTerms/ram:ActualPenaltyAmount');
+      var content : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Content');
+      var subjectCode : ZUGFeRDNullable<TZUGFeRDSubjectCodes> := TEnumExtensions<TZUGFeRDSubjectCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:SubjectCode'));
+      var contentCode : ZUGFeRDNullable<TZUGFeRDContentCodes> := TEnumExtensions<TZUGFeRDContentCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ContentCode'));
+      Result.AddNote(content, subjectCode, contentCode);
     end;
 
-    Result.PaymentTermsList.Add(paymentTerm);
+    Result.ReferenceOrderNo := TZUGFeRDXmlUtils.NodeAsString(doc, '//ram:ApplicableSupplyChainTradeAgreement/ram:BuyerReference');
+
+    Result.Seller := _nodeAsParty(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeAgreement/ram:SellerTradeParty');
+
+    nodes := doc.selectNodes('//ram:ApplicableSupplyChainTradeAgreement/ram:SellerTradeParty/ram:SpecifiedTaxRegistration');
+    for i := 0 to nodes.length-1 do
+    begin
+      var id : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ID');
+      var schemeID : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ID/@schemeID');
+      Result.AddSellerTaxRegistration(id, TEnumExtensions<TZUGFeRDTaxRegistrationSchemeID>.StringToEnum(schemeID));
+    end;
+
+    if (doc.selectSingleNode('//ram:SellerTradeParty/ram:DefinedTradeContact') <> nil) then
+    begin
+      Result.SellerContact := TZUGFeRDContact.Create;
+      Result.SellerContact.Name := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:SellerTradeParty/ram:DefinedTradeContact/ram:PersonName');
+      Result.SellerContact.OrgUnit := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:SellerTradeParty/ram:DefinedTradeContact/ram:DepartmentName');
+      Result.SellerContact.PhoneNo := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:SellerTradeParty/ram:DefinedTradeContact/ram:TelephoneUniversalCommunication/ram:CompleteNumber');
+      Result.SellerContact.FaxNo := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:SellerTradeParty/ram:DefinedTradeContact/ram:FaxUniversalCommunication/ram:CompleteNumber');
+      Result.SellerContact.EmailAddress := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:SellerTradeParty/ram:DefinedTradeContact/ram:EmailURIUniversalCommunication/ram:URIID');
+    end;
+
+    Result.Buyer := _nodeAsParty(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeAgreement/ram:BuyerTradeParty');
+
+    nodes := doc.selectNodes('//ram:ApplicableSupplyChainTradeAgreement/ram:BuyerTradeParty/ram:SpecifiedTaxRegistration');
+    for i := 0 to nodes.length-1 do
+    begin
+      var id : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ID');
+      var schemeID : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ID/@schemeID');
+      Result.AddBuyerTaxRegistration(id, TEnumExtensions<TZUGFeRDTaxRegistrationSchemeID>.StringToEnum(schemeID));
+    end;
+
+    if (doc.SelectSingleNode('//ram:BuyerTradeParty/ram:DefinedTradeContact') <> nil) then
+    begin
+      Result.BuyerContact := TZUGFeRDContact.Create;
+      Result.SetBuyerContact(
+        TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:BuyerTradeParty/ram:DefinedTradeContact/ram:PersonName'),
+        TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:BuyerTradeParty/ram:DefinedTradeContact/ram:DepartmentName'),
+        TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:BuyerTradeParty/ram:DefinedTradeContact/ram:EmailURIUniversalCommunication/ram:URIID'),
+        TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:BuyerTradeParty/ram:DefinedTradeContact/ram:TelephoneUniversalCommunication/ram:CompleteNumber'),
+        TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:BuyerTradeParty/ram:DefinedTradeContact/ram:FaxUniversalCommunication/ram:CompleteNumber')
+      );
+    end;
+
+    //Read TransportModeCodes --> BT-X-152
+    if (doc.SelectSingleNode('//ram:ApplicableSupplyChainTradeDelivery/ram:RelatedSupplyChainConsignment/ram:SpecifiedLogisticsTransportMovement/ram:ModeCode') <> nil) then
+      Result.TransportMode := TEnumExtensions<TZUGFeRDTransportmodeCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeDelivery/ram:RelatedSupplyChainConsignment/ram:SpecifiedLogisticsTransportMovement/ram:ModeCode'));
+
+    Result.ShipTo := _nodeAsParty(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeDelivery/ram:ShipToTradeParty');
+    Result.ShipFrom := _nodeAsParty(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeDelivery/ram:ShipFromTradeParty');
+    Result.ActualDeliveryDate:=TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeDelivery/ram:ActualDeliverySupplyChainEvent/ram:OccurrenceDateTime/udt:DateTimeString');
+
+    var _deliveryNoteNo : String := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:ID');
+    var _deliveryNoteDate : ZUGFeRDNullable<TDateTime> := TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssueDateTime/udt:DateTimeString');
+
+    if Not (_deliveryNoteDate.HasValue) then
+    begin
+      _deliveryNoteDate := TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssueDateTime');
+    end;
+
+    if ((_deliveryNoteDate.HasValue) or (_deliveryNoteNo <> '')) then
+    begin
+      Result.DeliveryNoteReferencedDocument := TZUGFeRDDeliveryNoteReferencedDocument.Create;
+      Result.SetDeliveryNoteReferenceDocument(_deliveryNoteNo,_deliveryNoteDate);
+    end;
+
+    Result.Invoicee := _nodeAsParty(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeSettlement/ram:InvoiceeTradeParty');
+    Result.Payee := _nodeAsParty(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeSettlement/ram:PayeeTradeParty');
+
+    Result.PaymentReference := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeSettlement/ram:PaymentReference');
+    Result.Currency :=  TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeSettlement/ram:InvoiceCurrencyCode'));
+
+    // TODO: Multiple SpecifiedTradeSettlementPaymentMeans can exist for each account/institution (with different SEPA?)
+    var _tempPaymentMeans : TZUGFeRDPaymentMeans := TZUGFeRDPaymentMeans.Create;
+    try
+      _tempPaymentMeans.TypeCode := TEnumExtensions<TZUGFeRDPaymentMeansTypeCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:TypeCode'));
+      _tempPaymentMeans.Information := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:Information');
+      _tempPaymentMeans.SEPACreditorIdentifier := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:ID');
+      _tempPaymentMeans.SEPAMandateReference := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:ID/@schemeAgencyID');
+      Result.PaymentMeans := _tempPaymentMeans;
+    except
+      _tempPaymentMeans.Free;
+      raise;
+    end;
+
+    Result.BillingPeriodStart := TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeSettlement/ram:BillingSpecifiedPeriod/ram:StartDateTime');
+    Result.BillingPeriodEnd := TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeSettlement/ram:BillingSpecifiedPeriod/ram:EndDateTime');
+
+    var creditorFinancialAccountNodes : IXMLDOMNodeList := doc.SelectNodes('//ram:ApplicableSupplyChainTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:PayeePartyCreditorFinancialAccount');
+    var creditorFinancialInstitutions : IXMLDOMNodeList := doc.SelectNodes('//ram:ApplicableSupplyChainTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:PayeeSpecifiedCreditorFinancialInstitution');
+
+    if (creditorFinancialAccountNodes.length = creditorFinancialInstitutions.length) then
+      for i := 0 to creditorFinancialAccountNodes.length-1 do
+        Result.AddCreditorFinancialAccount(TZUGFeRDXmlUtils.NodeAsString(creditorFinancialAccountNodes[i], './/ram:IBANID'),
+                                           TZUGFeRDXmlUtils.NodeAsString(creditorFinancialInstitutions[i], './/ram:BICID'),
+                                           TZUGFeRDXmlUtils.NodeAsString(creditorFinancialAccountNodes[i], './/ram:ProprietaryID'),
+                                           TZUGFeRDXmlUtils.NodeAsString(creditorFinancialInstitutions[i], './/ram:GermanBankleitzahlID'),
+                                           TZUGFeRDXmlUtils.NodeAsString(creditorFinancialInstitutions[i], './/ram:Name'),
+                                           TZUGFeRDXmlUtils.NodeAsString(creditorFinancialAccountNodes[i], './/ram:AccountName'));
+
+    var debitorFinancialAccountNodes : IXMLDOMNodeList := doc.SelectNodes('//ram:ApplicableSupplyChainTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:PayerPartyDebtorFinancialAccount');
+    var debitorFinancialInstitutions : IXMLDOMNodeList := doc.SelectNodes('//ram:ApplicableSupplyChainTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:PayerSpecifiedDebtorFinancialInstitution');
+
+    //TODO Index prüfen in der Schleife, bei csharp stand 0 drin
+    if (debitorFinancialAccountNodes.length = debitorFinancialInstitutions.length) then
+      for i := 0 to debitorFinancialAccountNodes.length-1 do
+         Result.AddDebitorFinancialAccount(TZUGFeRDXmlUtils.NodeAsString(debitorFinancialAccountNodes[i], './/ram:IBANID'),
+                                           TZUGFeRDXmlUtils.NodeAsString(debitorFinancialInstitutions[i], './/ram:BICID'),
+                                           TZUGFeRDXmlUtils.NodeAsString(debitorFinancialAccountNodes[i], './/ram:ProprietaryID'),
+                                           TZUGFeRDXmlUtils.NodeAsString(debitorFinancialInstitutions[i], './/ram:GermanBankleitzahlID'),
+                                           TZUGFeRDXmlUtils.NodeAsString(debitorFinancialInstitutions[i], './/ram:Name'));
+
+    nodes := doc.SelectNodes('//ram:ApplicableSupplyChainTradeSettlement/ram:ApplicableTradeTax');
+    for i := 0 to nodes.length-1 do
+    begin
+      Result.AddApplicableTradeTax(TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:CalculatedAmount', 0),
+                                   TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:BasisAmount', 0),
+                                   TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:ApplicablePercent', 0),
+                                   TEnumExtensions<TZUGFeRDTaxTypes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:TypeCode')),
+                                   TEnumExtensions<TZUGFeRDTaxCategoryCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:CategoryCode')),
+                                   TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:AllowanceChargeBasisAmount', 0),
+                                   Nil,
+                                   '',
+                                   TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:LineTotalBasisAmount'));
+    end;
+
+    nodes := doc.SelectNodes('//ram:SpecifiedTradeAllowanceCharge');
+    for i := 0 to nodes.length-1 do
+    begin
+      if TZUGFeRDXmlUtils.NodeAsBool(nodes[i], './/ram:ChargeIndicator') then
+        Result.AddTradeCharge(TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:BasisAmount', 0),
+                                     Result.Currency,
+                                     TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:ActualAmount', 0),
+                                     TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Reason'),
+                                     TEnumExtensions<TZUGFeRDTaxTypes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:CategoryTradeTax/ram:TypeCode')),
+                                     TEnumExtensions<TZUGFeRDTaxCategoryCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:CategoryTradeTax/ram:CategoryCode')),
+                                     TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:CategoryTradeTax/ram:ApplicablePercent', 0),
+                                     TEnumExtensions<TZUGFeRDChargeReasonCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:ReasonCode')))
+    else
+        Result.AddTradeAllowance(TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:BasisAmount', 0),
+                                     Result.Currency,
+                                     TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:ActualAmount', 0),
+                                     TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Reason'),
+                                     TEnumExtensions<TZUGFeRDTaxTypes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:CategoryTradeTax/ram:TypeCode')),
+                                     TEnumExtensions<TZUGFeRDTaxCategoryCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:CategoryTradeTax/ram:CategoryCode')),
+                                     TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:CategoryTradeTax/ram:ApplicablePercent', 0),
+                                     TEnumExtensions<TZUGFeRDAllowanceReasonCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:ReasonCode')))
+    end;
+
+    nodes := doc.SelectNodes('//ram:SpecifiedLogisticsServiceCharge');
+    for i := 0 to nodes.length-1 do
+    begin
+      Result.AddLogisticsServiceCharge(TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:AppliedAmount', 0),
+                                       TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Description'),
+                                       TEnumExtensions<TZUGFeRDTaxTypes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:AppliedTradeTax/ram:TypeCode')),
+                                       TEnumExtensions<TZUGFeRDTaxCategoryCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:AppliedTradeTax/ram:CategoryCode')),
+                                       TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:AppliedTradeTax/ram:ApplicablePercent', 0));
+    end;
+
+    nodes := doc.SelectNodes('//ram:SpecifiedTradePaymentTerms');
+    for i := 0 to nodes.length-1 do
+    begin
+      var paymentTerm : TZUGFeRDPaymentTerms := TZUGFeRDPaymentTerms.Create;
+      try
+        paymentTerm.Description := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Description');
+        paymentTerm.DueDate:= TZUGFeRDXmlUtils.NodeAsDateTime(nodes[i], './/ram:DueDateDateTime/udt:DateTimeString');
+        paymentTerm.PartialPaymentAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:PartialPaymentAmount');
+        var discountPercent: ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:ApplicableTradePaymentDiscountTerms/ram:CalculationPercent');
+        var penaltyPercent: ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:ApplicableTradePaymentPenaltyTerms/ram:CalculationPercent');
+        var Days: ZUGFeRDNullable<Integer>;
+        if discountPercent.HasValue then
+        begin
+          paymentTerm.PaymentTermsType:= TZUGFeRDPaymentTermsType.Skonto;
+          paymentTerm.Percentage:= discountPercent;
+          if TZUGFeRDQuantityCodes.DAY = TEnumExtensions<TZUGFeRDQuantityCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ApplicableTradePaymentDiscountTerms/ram:BasisPeriodMeasure/@unitCode')) then
+            paymentTerm.DueDays:= TZUGFeRDXmlUtils.NodeAsInt(nodes[i], './/ram:ApplicableTradePaymentDiscountTerms/ram:BasisPeriodMeasure');
+          paymentTerm.MaturityDate:= TZUGFeRDXmlUtils.NodeAsDateTime(nodes[i], './/ram:ApplicableTradePaymentDiscountTerms/ram:BasisDateTime/udt:DateTimeString'); //BT-X-282-0
+          paymentTerm.BaseAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:ApplicableTradePaymentDiscountTerms/ram:BasisAmount');
+          paymentTerm.ActualAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:ApplicableTradePaymentDiscountTerms/ram:ActualDiscountAmount');
+        end
+        else
+        if penaltyPercent.HasValue then
+        begin
+          paymentTerm.PaymentTermsType:= TZUGFeRDPaymentTermsType.Verzug;
+          paymentTerm.Percentage:= penaltyPercent;
+          if TZUGFeRDQuantityCodes.DAY = TEnumExtensions<TZUGFeRDQuantityCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ApplicableTradePaymentPenaltyTerms/ram:BasisPeriodMeasure/@unitCode')) then
+            paymentTerm.DueDays:= TZUGFeRDXmlUtils.NodeAsInt(nodes[i], './/ram:ApplicableTradePaymentPenaltyTerms/ram:BasisPeriodMeasure');
+          paymentTerm.MaturityDate:= TZUGFeRDXmlUtils.NodeAsDateTime(nodes[i], './/ram:ApplicableTradePaymentPenaltyTerms/ram:BasisDateTime/udt:DateTimeString'); // BT-X-276-0
+          paymentTerm.BaseAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:ApplicableTradePaymentPenaltyTerms/ram:BasisAmount');
+          paymentTerm.ActualAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:ApplicableTradePaymentPenaltyTerms/ram:ActualPenaltyAmount');
+        end;
+
+        Result.PaymentTermsList.Add(paymentTerm);
+      except
+        paymentTerm.Free;
+        raise;
+      end;
+    end;
+
+    Result.LineTotalAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementMonetarySummation/ram:LineTotalAmount', 0);
+    Result.ChargeTotalAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementMonetarySummation/ram:ChargeTotalAmount');
+    Result.AllowanceTotalAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementMonetarySummation/ram:AllowanceTotalAmount');
+    Result.TaxBasisAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementMonetarySummation/ram:TaxBasisTotalAmount');
+    Result.TaxTotalAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementMonetarySummation/ram:TaxTotalAmount', 0);
+    Result.GrandTotalAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementMonetarySummation/ram:GrandTotalAmount', 0);
+    Result.RoundingAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementMonetarySummation/ram:RoundingAmount', 0);
+    Result.TotalPrepaidAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementMonetarySummation/ram:TotalPrepaidAmount', 0);
+    Result.DuePayableAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementMonetarySummation/ram:DuePayableAmount', 0);
+
+    if (doc.DocumentElement.SelectSingleNode('//ram:ApplicableSupplyChainTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssueDateTime/udt:DateTimeString') <> nil) then
+      Result.OrderDate:= TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssueDateTime/udt:DateTimeString')
+    else
+      Result.OrderDate:= TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssueDateTime');
+    Result.OrderNo := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeAgreement/ram:BuyerOrderReferencedDocument/ram:ID');
+
+    nodes := doc.SelectNodes('//ram:IncludedSupplyChainTradeLineItem');
+    for i := 0 to nodes.length-1 do
+    begin
+      var parsedItem := _parseTradeLineItem(nodes[i]);
+      try
+        Result.TradeLineItems.Add(parsedItem);
+      except
+        parsedItem.Free;
+        raise;
+      end;
+    end;
+  except
+    Result.Free;
+    raise;
   end;
-
-  Result.LineTotalAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementMonetarySummation/ram:LineTotalAmount', 0);
-  Result.ChargeTotalAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementMonetarySummation/ram:ChargeTotalAmount');
-  Result.AllowanceTotalAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementMonetarySummation/ram:AllowanceTotalAmount');
-  Result.TaxBasisAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementMonetarySummation/ram:TaxBasisTotalAmount');
-  Result.TaxTotalAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementMonetarySummation/ram:TaxTotalAmount', 0);
-  Result.GrandTotalAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementMonetarySummation/ram:GrandTotalAmount', 0);
-  Result.RoundingAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementMonetarySummation/ram:RoundingAmount', 0);
-  Result.TotalPrepaidAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementMonetarySummation/ram:TotalPrepaidAmount', 0);
-  Result.DuePayableAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementMonetarySummation/ram:DuePayableAmount', 0);
-
-  if (doc.DocumentElement.SelectSingleNode('//ram:ApplicableSupplyChainTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssueDateTime/udt:DateTimeString') <> nil) then
-    Result.OrderDate:= TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssueDateTime/udt:DateTimeString')
-  else
-    Result.OrderDate:= TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssueDateTime');
-  Result.OrderNo := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableSupplyChainTradeAgreement/ram:BuyerOrderReferencedDocument/ram:ID');
-
-  nodes := doc.SelectNodes('//ram:IncludedSupplyChainTradeLineItem');
-  for i := 0 to nodes.length-1 do
-    Result.TradeLineItems.Add(_parseTradeLineItem(nodes[i]));
 end;
 
+/// <summary>Transfers the parsed result to the caller only after successful loading.</summary>
 function TZUGFeRDInvoiceDescriptor1Reader._nodeAsParty(basenode: IXmlDomNode;
   const xpath: string) : TZUGFeRDParty;
 var
@@ -389,32 +414,38 @@ begin
   if (node = nil) then
     exit;
   Result := TZUGFeRDParty.Create;
-  Result.ID.ID := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:ID');
-  Result.ID.SchemeID := TZUGFeRDGlobalIDSchemeIdentifiers.Unknown;
-  Result.GlobalID.ID := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:GlobalID');
-  Result.GlobalID.SchemeID := TEnumExtensions<TZUGFeRDGlobalIDSchemeIdentifiers>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(node, 'ram:GlobalID/@schemeID'));
-  Result.Name := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:Name');
-  Result.Description := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:Description'); // Seller only BT-33
-  Result.Postcode := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:PostcodeCode');
-  Result.City := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:CityName');
-  Result.Country := TEnumExtensions<TZUGFeRDCountryCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:CountryID'));
+  try
+    Result.ID.ID := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:ID');
+    Result.ID.SchemeID := TZUGFeRDGlobalIDSchemeIdentifiers.Unknown;
+    Result.GlobalID.ID := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:GlobalID');
+    Result.GlobalID.SchemeID := TEnumExtensions<TZUGFeRDGlobalIDSchemeIdentifiers>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(node, 'ram:GlobalID/@schemeID'));
+    Result.Name := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:Name');
+    Result.Description := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:Description'); // Seller only BT-33
+    Result.Postcode := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:PostcodeCode');
+    Result.City := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:CityName');
+    Result.Country := TEnumExtensions<TZUGFeRDCountryCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:CountryID'));
 
-  lineOne := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:LineOne');
-  lineTwo := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:LineTwo');
+    lineOne := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:LineOne');
+    lineTwo := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:LineTwo');
 
-  if (not lineTwo.IsEmpty) then
-  begin
-    Result.Street2 := lineOne;
-    Result.ContactName := lineOne; // backward compatibility
-    Result.Street := lineTwo;
-  end else
-  begin
-    Result.Street := lineOne;
-    Result.Street2 := '';
-    Result.ContactName := '';
+    if (not lineTwo.IsEmpty) then
+    begin
+      Result.Street2 := lineOne;
+      Result.ContactName := lineOne; // backward compatibility
+      Result.Street := lineTwo;
+    end else
+    begin
+      Result.Street := lineOne;
+      Result.Street2 := '';
+      Result.ContactName := '';
+    end;
+  except
+    Result.Free;
+    raise;
   end;
 end;
 
+/// <summary>Transfers the parsed result to the caller only after successful loading.</summary>
 function TZUGFeRDInvoiceDescriptor1Reader._parseTradeLineItem(
   tradeLineItem: IXmlDomNode): TZUGFeRDTradeLineItem;
 var
@@ -428,133 +459,143 @@ begin
 
   var lineId: string := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:AssociatedDocumentLineDocument/ram:LineID');
   Result := TZUGFeRDTradeLineItem.Create(lineId);
+  try
 
-  Result.GlobalID.ID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:GlobalID');
-  Result.GlobalID.SchemeID := TEnumExtensions<TZUGFeRDGlobalIDSchemeIdentifiers>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:GlobalID/@schemeID'));
-  Result.SellerAssignedID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:SellerAssignedID');
-  Result.BuyerAssignedID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:BuyerAssignedID');
-  Result.Name := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:Name');
-  Result.Description := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:Description');
-  Result.BilledQuantity := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:BilledQuantity', 0);
-  Result.UnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:BilledQuantity/@unitCode'));
-  Result.PackageQuantity := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:PackageQuantity');
-  Result.PackageUnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:PackageQuantity/@unitCode'));
-  Result.ChargeFreeQuantity := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:ChargeFreeQuantity');
-  Result.ChargeFreeUnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:ChargeFreeQuantity/@unitCode'));
-  Result.ShipTo := _nodeAsParty(tradeLineItem, './/ram:ShipToTradeParty');
-  Result.LineTotalAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:LineTotalAmount', 0);
-  Result.TaxCategoryCode := TEnumExtensions<TZUGFeRDTaxCategoryCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:ApplicableTradeTax/ram:CategoryCode'));
-  Result.TaxType := TEnumExtensions<TZUGFeRDTaxTypes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:ApplicableTradeTax/ram:TypeCode'));
-  Result.TaxPercent := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:ApplicableTradeTax/ram:ApplicablePercent', 0);
-  Result.NetUnitPrice:= TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:NetPriceProductTradePrice/ram:ChargeAmount', 0);
-  Result.NetQuantity := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:NetPriceProductTradePrice/ram:BasisQuantity');
-  Result.NetUnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:NetPriceProductTradePrice/ram:BasisQuantity/@unitCode'));
-  Result.GrossUnitPrice:= TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:GrossPriceProductTradePrice/ram:ChargeAmount', 0);
-  Result.GrossQuantity := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:GrossPriceProductTradePrice/ram:BasisQuantity');
-  Result.GrossUnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:GrossPriceProductTradePrice/ram:BasisQuantity/@unitCode'));
-  Result.BillingPeriodStart:= TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:BillingSpecifiedPeriod/ram:StartDateTime/udt:DateTimeString');
-  Result.BillingPeriodEnd:= TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:BillingSpecifiedPeriod/ram:EndDateTime/udt:DateTimeString');
+    Result.GlobalID.ID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:GlobalID');
+    Result.GlobalID.SchemeID := TEnumExtensions<TZUGFeRDGlobalIDSchemeIdentifiers>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:GlobalID/@schemeID'));
+    Result.SellerAssignedID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:SellerAssignedID');
+    Result.BuyerAssignedID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:BuyerAssignedID');
+    Result.Name := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:Name');
+    Result.Description := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:Description');
+    Result.BilledQuantity := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:BilledQuantity', 0);
+    Result.UnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:BilledQuantity/@unitCode'));
+    Result.PackageQuantity := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:PackageQuantity');
+    Result.PackageUnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:PackageQuantity/@unitCode'));
+    Result.ChargeFreeQuantity := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:ChargeFreeQuantity');
+    Result.ChargeFreeUnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:ChargeFreeQuantity/@unitCode'));
+    Result.ShipTo := _nodeAsParty(tradeLineItem, './/ram:ShipToTradeParty');
+    Result.LineTotalAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:LineTotalAmount', 0);
+    Result.TaxCategoryCode := TEnumExtensions<TZUGFeRDTaxCategoryCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:ApplicableTradeTax/ram:CategoryCode'));
+    Result.TaxType := TEnumExtensions<TZUGFeRDTaxTypes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:ApplicableTradeTax/ram:TypeCode'));
+    Result.TaxPercent := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:ApplicableTradeTax/ram:ApplicablePercent', 0);
+    Result.NetUnitPrice:= TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:NetPriceProductTradePrice/ram:ChargeAmount', 0);
+    Result.NetQuantity := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:NetPriceProductTradePrice/ram:BasisQuantity');
+    Result.NetUnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:NetPriceProductTradePrice/ram:BasisQuantity/@unitCode'));
+    Result.GrossUnitPrice:= TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:GrossPriceProductTradePrice/ram:ChargeAmount', 0);
+    Result.GrossQuantity := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:GrossPriceProductTradePrice/ram:BasisQuantity');
+    Result.GrossUnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:GrossPriceProductTradePrice/ram:BasisQuantity/@unitCode'));
+    Result.BillingPeriodStart:= TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:BillingSpecifiedPeriod/ram:StartDateTime/udt:DateTimeString');
+    Result.BillingPeriodEnd:= TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:BillingSpecifiedPeriod/ram:EndDateTime/udt:DateTimeString');
 
-  if (tradeLineItem.SelectSingleNode('.//ram:AssociatedDocumentLineDocument') <> nil) then
-  begin
-    nodes := tradeLineItem.SelectNodes('.//ram:AssociatedDocumentLineDocument/ram:IncludedNote');
+    if (tradeLineItem.SelectSingleNode('.//ram:AssociatedDocumentLineDocument') <> nil) then
+    begin
+      nodes := tradeLineItem.SelectNodes('.//ram:AssociatedDocumentLineDocument/ram:IncludedNote');
+      for i := 0 to nodes.length-1 do
+      begin
+        var noteItem : TZUGFeRDNote := TZUGFeRDNote.Create(
+            TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Content'),
+            TEnumExtensions<TZUGFeRDSubjectCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:SubjectCode')),
+            TEnumExtensions<TZUGFeRDContentCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ContentCode'))
+          );
+        try
+          Result.AssociatedDocument.Notes.Add(noteItem);
+        except
+          noteItem.Free;
+          raise;
+        end;
+      end;
+    end;
+
+    nodes := tradeLineItem.SelectNodes('.//ram:SpecifiedSupplyChainTradeAgreement/ram:GrossPriceProductTradePrice/ram:AppliedTradeAllowanceCharge');
     for i := 0 to nodes.length-1 do
     begin
-      var noteItem : TZUGFeRDNote := TZUGFeRDNote.Create(
-          TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Content'),
-          TEnumExtensions<TZUGFeRDSubjectCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:SubjectCode')),
-          TEnumExtensions<TZUGFeRDContentCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ContentCode'))
-        );
-      Result.AssociatedDocument.Notes.Add(noteItem);
-    end;
-  end;
 
-  nodes := tradeLineItem.SelectNodes('.//ram:SpecifiedSupplyChainTradeAgreement/ram:GrossPriceProductTradePrice/ram:AppliedTradeAllowanceCharge');
-  for i := 0 to nodes.length-1 do
-  begin
+      var chargeIndicator : Boolean := TZUGFeRDXmlUtils.NodeAsBool(nodes[i], './ram:ChargeIndicator/udt:Indicator');
+      var basisAmount : Currency := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './ram:BasisAmount',0);
+      var calculationPercent : ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './ram:CalculationPercent');
+      var basisAmountCurrency : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:BasisAmount/@currencyID');
+      var actualAmount : Currency := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './ram:ActualAmount',0);
+      var actualAmountCurrency : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:ActualAmount/@currencyID');
+      var reason : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:Reason');
 
-    var chargeIndicator : Boolean := TZUGFeRDXmlUtils.NodeAsBool(nodes[i], './ram:ChargeIndicator/udt:Indicator');
-    var basisAmount : Currency := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './ram:BasisAmount',0);
-    var calculationPercent : ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './ram:CalculationPercent');
-    var basisAmountCurrency : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:BasisAmount/@currencyID');
-    var actualAmount : Currency := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './ram:ActualAmount',0);
-    var actualAmountCurrency : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:ActualAmount/@currencyID');
-    var reason : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:Reason');
-
-    if chargeIndicator then // charge
-    begin
-      if calculationPercent.HasValue then
-        Result.AddTradeCharge(TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToEnum(basisAmountCurrency),
-                                      basisAmount,
-                                      actualAmount,
-                                      calculationPercent,
-                                      reason)
+      if chargeIndicator then // charge
+      begin
+        if calculationPercent.HasValue then
+          Result.AddTradeCharge(TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToEnum(basisAmountCurrency),
+                                        basisAmount,
+                                        actualAmount,
+                                        calculationPercent,
+                                        reason)
+        else
+          Result.AddTradeCharge(TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToEnum(basisAmountCurrency),
+                                        basisAmount,
+                                        actualAmount,
+                                        reason);
+      end
       else
-        Result.AddTradeCharge(TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToEnum(basisAmountCurrency),
-                                      basisAmount,
-                                      actualAmount,
-                                      reason);
-    end
-    else
-    begin
-      if calculationPercent.HasValue then
-        Result.AddTradeAllowance(TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToEnum(basisAmountCurrency),
-                                      basisAmount,
-                                      actualAmount,
-                                      calculationPercent,
-                                      reason)
-      else
-        Result.AddTradeAllowance(TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToEnum(basisAmountCurrency),
-                                      basisAmount,
-                                      actualAmount,
-                                      reason);
+      begin
+        if calculationPercent.HasValue then
+          Result.AddTradeAllowance(TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToEnum(basisAmountCurrency),
+                                        basisAmount,
+                                        actualAmount,
+                                        calculationPercent,
+                                        reason)
+        else
+          Result.AddTradeAllowance(TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToEnum(basisAmountCurrency),
+                                        basisAmount,
+                                        actualAmount,
+                                        reason);
+      end;
     end;
-  end;
 
-  if (Result.UnitCode = TZUGFeRDQuantityCodes.Unknown) then
-  begin
-    // UnitCode alternativ aus BilledQuantity extrahieren
-    Result.UnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:BilledQuantity/@unitCode'));
-  end;
+    if (Result.UnitCode = TZUGFeRDQuantityCodes.Unknown) then
+    begin
+      // UnitCode alternativ aus BilledQuantity extrahieren
+      Result.UnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:BilledQuantity/@unitCode'));
+    end;
 
-  if (tradeLineItem.SelectSingleNode('.//ram:SpecifiedSupplyChainTradeAgreement/ram:BuyerOrderReferencedDocument/ram:ID') <> nil) then
-  begin
-    Result.BuyerOrderReferencedDocument := TZUGFeRDBuyerOrderReferencedDocument.Create;
-    Result.BuyerOrderReferencedDocument.ID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedSupplyChainTradeAgreement/ram:BuyerOrderReferencedDocument/ram:ID');
-    Result.BuyerOrderReferencedDocument.IssueDateTime:= TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:SpecifiedSupplyChainTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssueDateTime');
-    Result.BuyerOrderReferencedDocument.LineID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedSupplyChainTradeAgreement/ram:BuyerOrderReferencedDocument/ram:LineID');
-  end;
+    if (tradeLineItem.SelectSingleNode('.//ram:SpecifiedSupplyChainTradeAgreement/ram:BuyerOrderReferencedDocument/ram:ID') <> nil) then
+    begin
+      Result.BuyerOrderReferencedDocument := TZUGFeRDBuyerOrderReferencedDocument.Create;
+      Result.BuyerOrderReferencedDocument.ID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedSupplyChainTradeAgreement/ram:BuyerOrderReferencedDocument/ram:ID');
+      Result.BuyerOrderReferencedDocument.IssueDateTime:= TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:SpecifiedSupplyChainTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssueDateTime');
+      Result.BuyerOrderReferencedDocument.LineID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedSupplyChainTradeAgreement/ram:BuyerOrderReferencedDocument/ram:LineID');
+    end;
 
-  if (tradeLineItem.SelectSingleNode('.//ram:SpecifiedSupplyChainTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:ID') <> nil) then
-  begin
-    Result.DeliveryNoteReferencedDocument := TZUGFeRDDeliveryNoteReferencedDocument.Create;
-    Result.DeliveryNoteReferencedDocument.ID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedSupplyChainTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:ID');
-    Result.DeliveryNoteReferencedDocument.IssueDateTime:= TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:SpecifiedSupplyChainTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssueDateTime');
-    Result.DeliveryNoteReferencedDocument.LineID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedSupplyChainTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:LineID');
-  end;
+    if (tradeLineItem.SelectSingleNode('.//ram:SpecifiedSupplyChainTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:ID') <> nil) then
+    begin
+      Result.DeliveryNoteReferencedDocument := TZUGFeRDDeliveryNoteReferencedDocument.Create;
+      Result.DeliveryNoteReferencedDocument.ID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedSupplyChainTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:ID');
+      Result.DeliveryNoteReferencedDocument.IssueDateTime:= TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:SpecifiedSupplyChainTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssueDateTime');
+      Result.DeliveryNoteReferencedDocument.LineID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedSupplyChainTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:LineID');
+    end;
 
-  if (tradeLineItem.SelectSingleNode('.//ram:SpecifiedSupplyChainTradeDelivery/ram:ActualDeliverySupplyChainEvent/ram:OccurrenceDateTime') <> nil) then
-  begin
-    Result.ActualDeliveryDate:= TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:SpecifiedSupplyChainTradeDelivery/ram:ActualDeliverySupplyChainEvent/ram:OccurrenceDateTime/udt:DateTimeString');
-  end;
+    if (tradeLineItem.SelectSingleNode('.//ram:SpecifiedSupplyChainTradeDelivery/ram:ActualDeliverySupplyChainEvent/ram:OccurrenceDateTime') <> nil) then
+    begin
+      Result.ActualDeliveryDate:= TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:SpecifiedSupplyChainTradeDelivery/ram:ActualDeliverySupplyChainEvent/ram:OccurrenceDateTime/udt:DateTimeString');
+    end;
 
-  if (tradeLineItem.SelectSingleNode('.//ram:SpecifiedSupplyChainTradeAgreement/ram:ContractReferencedDocument/ram:ID') <> nil) then
-  begin
-    Result.ContractReferencedDocument := TZUGFeRDContractReferencedDocument.Create;
-    Result.ContractReferencedDocument.ID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedSupplyChainTradeAgreement/ram:ContractReferencedDocument/ram:ID');
-    Result.ContractReferencedDocument.IssueDateTime:= TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:SpecifiedSupplyChainTradeAgreement/ram:ContractReferencedDocument/ram:IssueDateTime');
-    Result.ContractReferencedDocument.LineID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedSupplyChainTradeAgreement/ram:ContractReferencedDocument/ram:LineID');
-  end;
+    if (tradeLineItem.SelectSingleNode('.//ram:SpecifiedSupplyChainTradeAgreement/ram:ContractReferencedDocument/ram:ID') <> nil) then
+    begin
+      Result.ContractReferencedDocument := TZUGFeRDContractReferencedDocument.Create;
+      Result.ContractReferencedDocument.ID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedSupplyChainTradeAgreement/ram:ContractReferencedDocument/ram:ID');
+      Result.ContractReferencedDocument.IssueDateTime:= TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:SpecifiedSupplyChainTradeAgreement/ram:ContractReferencedDocument/ram:IssueDateTime');
+      Result.ContractReferencedDocument.LineID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedSupplyChainTradeAgreement/ram:ContractReferencedDocument/ram:LineID');
+    end;
 
-  //Get all referenced AND embedded documents
-  nodes := tradeLineItem.SelectNodes('.//ram:SpecifiedSupplyChainTradeAgreement/ram:AdditionalReferencedDocument');
-  for i := 0 to nodes.length-1 do
-  begin
-    Result.AddAdditionalReferencedDocument(
-        TZUGFeRDXmlUtils.NodeAsString(nodes[i], 'ram:ID'),
-        TEnumExtensions<TZUGFeRDReferenceTypeCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], 'ram:ReferenceTypeCode')),
-        TZUGFeRDXmlUtils.NodeAsDateTime(nodes[i], 'ram:IssueDateTime')
-    );
+    //Get all referenced AND embedded documents
+    nodes := tradeLineItem.SelectNodes('.//ram:SpecifiedSupplyChainTradeAgreement/ram:AdditionalReferencedDocument');
+    for i := 0 to nodes.length-1 do
+    begin
+      Result.AddAdditionalReferencedDocument(
+          TZUGFeRDXmlUtils.NodeAsString(nodes[i], 'ram:ID'),
+          TEnumExtensions<TZUGFeRDReferenceTypeCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], 'ram:ReferenceTypeCode')),
+          TZUGFeRDXmlUtils.NodeAsDateTime(nodes[i], 'ram:IssueDateTime')
+      );
+    end;
+  except
+    Result.Free;
+    raise;
   end;
 end;
 

--- a/intf.ZUGFeRDInvoiceDescriptor20Reader.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor20Reader.pas
@@ -152,6 +152,7 @@ begin
   end;
 end;
 
+/// <summary>Transfers the parsed result to the caller only after successful loading.</summary>
 function TZUGFeRDInvoiceDescriptor20Reader.Load(xmldocument : IXMLDocument): TZUGFeRDInvoiceDescriptor;
 var
   doc : IXMLDOMDocument2;
@@ -165,362 +166,399 @@ begin
   //   nsmgr.AddNamespace('rsm', nsmgr.DefaultNamespace);
 
   Result := TZUGFeRDInvoiceDescriptor.Create;
+  try
 
-  Result.IsTest := TZUGFeRDXmlUtils.NodeAsBool(doc.documentElement,'//*[local-name()="ExchangedDocumentContext"]/ram:TestIndicator',false);
-  Result.BusinessProcess := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//*[local-name()="BusinessProcessSpecifiedDocumentContextParameter"]/ram:ID');//, nsmgr),
-  Result.Guideline := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:GuidelineSpecifiedDocumentContextParameter/ram:ID'); //, nsmgr)),
-  Result.Profile := TZUGFeRDProfileExtensions.StringToEnum(Result.Guideline);
-  Result.Name := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//*[local-name()="ExchangedDocument"]/ram:Name');//, nsmgr)),
-  Result.Type_ := TEnumExtensions<TZUGFeRDInvoiceType>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//*[local-name()="ExchangedDocument"]/ram:TypeCode'));//, nsmgr)),
-  Result.InvoiceNo := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//*[local-name()="ExchangedDocument"]/ram:ID');//, nsmgr),
-  Result.InvoiceDate := TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//*[local-name()="ExchangedDocument"]/ram:IssueDateTime/udt:DateTimeString');//", nsmgr)
+    Result.IsTest := TZUGFeRDXmlUtils.NodeAsBool(doc.documentElement,'//*[local-name()="ExchangedDocumentContext"]/ram:TestIndicator',false);
+    Result.BusinessProcess := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//*[local-name()="BusinessProcessSpecifiedDocumentContextParameter"]/ram:ID');//, nsmgr),
+    Result.Guideline := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:GuidelineSpecifiedDocumentContextParameter/ram:ID'); //, nsmgr)),
+    Result.Profile := TZUGFeRDProfileExtensions.StringToEnum(Result.Guideline);
+    Result.Name := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//*[local-name()="ExchangedDocument"]/ram:Name');//, nsmgr)),
+    Result.Type_ := TEnumExtensions<TZUGFeRDInvoiceType>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//*[local-name()="ExchangedDocument"]/ram:TypeCode'));//, nsmgr)),
+    Result.InvoiceNo := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//*[local-name()="ExchangedDocument"]/ram:ID');//, nsmgr),
+    Result.InvoiceDate := TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//*[local-name()="ExchangedDocument"]/ram:IssueDateTime/udt:DateTimeString');//", nsmgr)
 
-  nodes := doc.selectNodes('//*[local-name()="ExchangedDocument"]/ram:IncludedNote');
-  for i := 0 to nodes.length-1 do
-    Result.AddNote(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Content'),
-                   TEnumExtensions<TZUGFeRDSubjectCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:SubjectCode')),
-                   TEnumExtensions<TZUGFeRDContentCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ContentCode')));
+    nodes := doc.selectNodes('//*[local-name()="ExchangedDocument"]/ram:IncludedNote');
+    for i := 0 to nodes.length-1 do
+      Result.AddNote(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Content'),
+                     TEnumExtensions<TZUGFeRDSubjectCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:SubjectCode')),
+                     TEnumExtensions<TZUGFeRDContentCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ContentCode')));
 
-  Result.ReferenceOrderNo := TZUGFeRDXmlUtils.NodeAsString(doc, '//ram:ApplicableHeaderTradeAgreement/ram:BuyerReference');
+    Result.ReferenceOrderNo := TZUGFeRDXmlUtils.NodeAsString(doc, '//ram:ApplicableHeaderTradeAgreement/ram:BuyerReference');
 
-  Result.Seller := _nodeAsParty(doc.DocumentElement, '//ram:ApplicableHeaderTradeAgreement/ram:SellerTradeParty');
+    Result.Seller := _nodeAsParty(doc.DocumentElement, '//ram:ApplicableHeaderTradeAgreement/ram:SellerTradeParty');
 
-  nodes := doc.selectNodes('//ram:ApplicableHeaderTradeAgreement/ram:SellerTradeParty/ram:SpecifiedTaxRegistration');
-  for i := 0 to nodes.length-1 do
-  begin
-    var id : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ID');
-    var schemeID : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ID/@schemeID');
-    Result.AddSellerTaxRegistration(id, TEnumExtensions<TZUGFeRDTaxRegistrationSchemeID>.StringToEnum(schemeID));
-  end;
+    nodes := doc.selectNodes('//ram:ApplicableHeaderTradeAgreement/ram:SellerTradeParty/ram:SpecifiedTaxRegistration');
+    for i := 0 to nodes.length-1 do
+    begin
+      var id : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ID');
+      var schemeID : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ID/@schemeID');
+      Result.AddSellerTaxRegistration(id, TEnumExtensions<TZUGFeRDTaxRegistrationSchemeID>.StringToEnum(schemeID));
+    end;
 
-  if (doc.selectSingleNode('//ram:SellerTradeParty/ram:DefinedTradeContact') <> nil) then
-  begin
-    Result.SellerContact := TZUGFeRDContact.Create;
-    Result.SellerContact.Name := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:SellerTradeParty/ram:DefinedTradeContact/ram:PersonName');
-    Result.SellerContact.OrgUnit := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:SellerTradeParty/ram:DefinedTradeContact/ram:DepartmentName');
-    Result.SellerContact.PhoneNo := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:SellerTradeParty/ram:DefinedTradeContact/ram:TelephoneUniversalCommunication/ram:CompleteNumber');
-    Result.SellerContact.FaxNo := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:SellerTradeParty/ram:DefinedTradeContact/ram:FaxUniversalCommunication/ram:CompleteNumber');
-    Result.SellerContact.EmailAddress := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:SellerTradeParty/ram:DefinedTradeContact/ram:EmailURIUniversalCommunication/ram:URIID');
-  end;
+    if (doc.selectSingleNode('//ram:SellerTradeParty/ram:DefinedTradeContact') <> nil) then
+    begin
+      Result.SellerContact := TZUGFeRDContact.Create;
+      Result.SellerContact.Name := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:SellerTradeParty/ram:DefinedTradeContact/ram:PersonName');
+      Result.SellerContact.OrgUnit := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:SellerTradeParty/ram:DefinedTradeContact/ram:DepartmentName');
+      Result.SellerContact.PhoneNo := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:SellerTradeParty/ram:DefinedTradeContact/ram:TelephoneUniversalCommunication/ram:CompleteNumber');
+      Result.SellerContact.FaxNo := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:SellerTradeParty/ram:DefinedTradeContact/ram:FaxUniversalCommunication/ram:CompleteNumber');
+      Result.SellerContact.EmailAddress := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:SellerTradeParty/ram:DefinedTradeContact/ram:EmailURIUniversalCommunication/ram:URIID');
+    end;
 
-  Result.Buyer := _nodeAsParty(doc.DocumentElement, '//ram:ApplicableHeaderTradeAgreement/ram:BuyerTradeParty');
+    Result.Buyer := _nodeAsParty(doc.DocumentElement, '//ram:ApplicableHeaderTradeAgreement/ram:BuyerTradeParty');
 
-  nodes := doc.selectNodes('//ram:ApplicableHeaderTradeAgreement/ram:BuyerTradeParty/ram:SpecifiedTaxRegistration');
-  for i := 0 to nodes.length-1 do
-  begin
-    var id : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ID');
-    var schemeID : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ID/@schemeID');
-    Result.AddBuyerTaxRegistration(id, TEnumExtensions<TZUGFeRDTaxRegistrationSchemeID>.StringToEnum(schemeID));
-  end;
+    nodes := doc.selectNodes('//ram:ApplicableHeaderTradeAgreement/ram:BuyerTradeParty/ram:SpecifiedTaxRegistration');
+    for i := 0 to nodes.length-1 do
+    begin
+      var id : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ID');
+      var schemeID : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ID/@schemeID');
+      Result.AddBuyerTaxRegistration(id, TEnumExtensions<TZUGFeRDTaxRegistrationSchemeID>.StringToEnum(schemeID));
+    end;
 
-  if (doc.SelectSingleNode('//ram:BuyerTradeParty/ram:DefinedTradeContact') <> nil) then
-  begin
-    Result.BuyerContact := TZUGFeRDContact.Create;
-    Result.SetBuyerContact(
-      TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:BuyerTradeParty/ram:DefinedTradeContact/ram:PersonName'),
-      TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:BuyerTradeParty/ram:DefinedTradeContact/ram:DepartmentName'),
-      TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:BuyerTradeParty/ram:DefinedTradeContact/ram:EmailURIUniversalCommunication/ram:URIID'),
-      TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:BuyerTradeParty/ram:DefinedTradeContact/ram:TelephoneUniversalCommunication/ram:CompleteNumber'),
-      TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:BuyerTradeParty/ram:DefinedTradeContact/ram:FaxUniversalCommunication/ram:CompleteNumber')
-    );
-  end;
+    if (doc.SelectSingleNode('//ram:BuyerTradeParty/ram:DefinedTradeContact') <> nil) then
+    begin
+      Result.BuyerContact := TZUGFeRDContact.Create;
+      Result.SetBuyerContact(
+        TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:BuyerTradeParty/ram:DefinedTradeContact/ram:PersonName'),
+        TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:BuyerTradeParty/ram:DefinedTradeContact/ram:DepartmentName'),
+        TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:BuyerTradeParty/ram:DefinedTradeContact/ram:EmailURIUniversalCommunication/ram:URIID'),
+        TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:BuyerTradeParty/ram:DefinedTradeContact/ram:TelephoneUniversalCommunication/ram:CompleteNumber'),
+        TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:BuyerTradeParty/ram:DefinedTradeContact/ram:FaxUniversalCommunication/ram:CompleteNumber')
+      );
+    end;
 
-  // SellerTaxRepresentativeTradeParty STEUERBEVOLLMÄCHTIGTER DES VERKÄUFERS, BG-11
-  Result.SellerTaxRepresentative := _nodeAsParty(doc.DocumentElement, '//ram:ApplicableHeaderTradeAgreement/ram:SellerTaxRepresentativeTradeParty');
-  nodes := doc.selectNodes('//ram:ApplicableHeaderTradeAgreement/ram:SellerTaxRepresentativeTradeParty/ram:SpecifiedTaxRegistration');
-  for i := 0 to nodes.length-1 do
-  begin
-    var id : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ID');
-    var schemeID : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ID/@schemeID');
-    Result.AddSellerTaxRepresentativeTaxRegistration(id, TEnumExtensions<TZUGFeRDTaxRegistrationSchemeID>.StringToEnum(schemeID));
-  end;
+    // SellerTaxRepresentativeTradeParty STEUERBEVOLLMÄCHTIGTER DES VERKÄUFERS, BG-11
+    Result.SellerTaxRepresentative := _nodeAsParty(doc.DocumentElement, '//ram:ApplicableHeaderTradeAgreement/ram:SellerTaxRepresentativeTradeParty');
+    nodes := doc.selectNodes('//ram:ApplicableHeaderTradeAgreement/ram:SellerTaxRepresentativeTradeParty/ram:SpecifiedTaxRegistration');
+    for i := 0 to nodes.length-1 do
+    begin
+      var id : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ID');
+      var schemeID : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ID/@schemeID');
+      Result.AddSellerTaxRepresentativeTaxRegistration(id, TEnumExtensions<TZUGFeRDTaxRegistrationSchemeID>.StringToEnum(schemeID));
+    end;
 
-  //Get all referenced and embedded documents (BG-24)
-  nodes := doc.SelectNodes('.//ram:ApplicableHeaderTradeAgreement/ram:AdditionalReferencedDocument');
-  for i := 0 to nodes.length-1 do
-    Result.AdditionalReferencedDocuments.Add(_getAdditionalReferencedDocument(nodes[i]));
+    //Get all referenced and embedded documents (BG-24)
+    nodes := doc.SelectNodes('.//ram:ApplicableHeaderTradeAgreement/ram:AdditionalReferencedDocument');
+    for i := 0 to nodes.length-1 do
+    begin
+      var parsedItem := _getAdditionalReferencedDocument(nodes[i]);
+      try
+        Result.AdditionalReferencedDocuments.Add(parsedItem);
+      except
+        parsedItem.Free;
+        raise;
+      end;
+    end;
 
-  //Read TransportModeCodes --> BT-X-152
-  if (doc.SelectSingleNode('//ram:ApplicableHeaderTradeDelivery/ram:RelatedSupplyChainConsignment/ram:SpecifiedLogisticsTransportMovement/ram:ModeCode') <> nil) then
-    Result.TransportMode := TEnumExtensions<TZUGFeRDTransportmodeCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableHeaderTradeDelivery/ram:RelatedSupplyChainConsignment/ram:SpecifiedLogisticsTransportMovement/ram:ModeCode'));
+    //Read TransportModeCodes --> BT-X-152
+    if (doc.SelectSingleNode('//ram:ApplicableHeaderTradeDelivery/ram:RelatedSupplyChainConsignment/ram:SpecifiedLogisticsTransportMovement/ram:ModeCode') <> nil) then
+      Result.TransportMode := TEnumExtensions<TZUGFeRDTransportmodeCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableHeaderTradeDelivery/ram:RelatedSupplyChainConsignment/ram:SpecifiedLogisticsTransportMovement/ram:ModeCode'));
 
-  Result.ShipTo := _nodeAsParty(doc.DocumentElement, '//ram:ApplicableHeaderTradeDelivery/ram:ShipToTradeParty');
-  if (doc.selectSingleNode('//ram:ShipToTradeParty/ram:DefinedTradeContact') <> nil) then
-  begin
-    Result.ShipToContact := TZUGFeRDContact.Create;
-    Result.ShipToContact.Name := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ShipToTradeParty/ram:DefinedTradeContact/ram:PersonName');
-    Result.ShipToContact.OrgUnit := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ShipToTradeParty/ram:DefinedTradeContact/ram:DepartmentName');
-    Result.ShipToContact.PhoneNo := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ShipToTradeParty/ram:DefinedTradeContact/ram:TelephoneUniversalCommunication/ram:CompleteNumber');
-    Result.ShipToContact.FaxNo := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ShipToTradeParty/ram:DefinedTradeContact/ram:FaxUniversalCommunication/ram:CompleteNumber');
-    Result.ShipToContact.EmailAddress := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ShipToTradeParty/ram:DefinedTradeContact/ram:EmailURIUniversalCommunication/ram:URIID');
-  end;
+    Result.ShipTo := _nodeAsParty(doc.DocumentElement, '//ram:ApplicableHeaderTradeDelivery/ram:ShipToTradeParty');
+    if (doc.selectSingleNode('//ram:ShipToTradeParty/ram:DefinedTradeContact') <> nil) then
+    begin
+      Result.ShipToContact := TZUGFeRDContact.Create;
+      Result.ShipToContact.Name := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ShipToTradeParty/ram:DefinedTradeContact/ram:PersonName');
+      Result.ShipToContact.OrgUnit := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ShipToTradeParty/ram:DefinedTradeContact/ram:DepartmentName');
+      Result.ShipToContact.PhoneNo := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ShipToTradeParty/ram:DefinedTradeContact/ram:TelephoneUniversalCommunication/ram:CompleteNumber');
+      Result.ShipToContact.FaxNo := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ShipToTradeParty/ram:DefinedTradeContact/ram:FaxUniversalCommunication/ram:CompleteNumber');
+      Result.ShipToContact.EmailAddress := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ShipToTradeParty/ram:DefinedTradeContact/ram:EmailURIUniversalCommunication/ram:URIID');
+    end;
 
-  Result.ShipFrom := _nodeAsParty(doc.DocumentElement, '//ram:ApplicableHeaderTradeDelivery/ram:ShipFromTradeParty');
-  Result.ActualDeliveryDate:= TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableHeaderTradeDelivery/ram:ActualDeliverySupplyChainEvent/ram:OccurrenceDateTime/udt:DateTimeString');
+    Result.ShipFrom := _nodeAsParty(doc.DocumentElement, '//ram:ApplicableHeaderTradeDelivery/ram:ShipFromTradeParty');
+    Result.ActualDeliveryDate:= TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableHeaderTradeDelivery/ram:ActualDeliverySupplyChainEvent/ram:OccurrenceDateTime/udt:DateTimeString');
 
-  var _receivingAdviceNo : String := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableHeaderTradeDelivery/ram:ReceivingAdviceReferencedDocument/ram:IssuerAssignedID');
-  var _receivingAdviceDate : ZUGFeRDNullable<TDateTime> := TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableHeaderTradeDelivery/ram:ReceivingAdviceReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString');
+    var _receivingAdviceNo : String := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableHeaderTradeDelivery/ram:ReceivingAdviceReferencedDocument/ram:IssuerAssignedID');
+    var _receivingAdviceDate : ZUGFeRDNullable<TDateTime> := TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableHeaderTradeDelivery/ram:ReceivingAdviceReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString');
 
-  if Not(_receivingAdviceDate.HasValue) then
-    _receivingAdviceDate := TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableHeaderTradeDelivery/ram:ReceivingAdviceReferencedDocument/ram:FormattedIssueDateTime');
+    if Not(_receivingAdviceDate.HasValue) then
+      _receivingAdviceDate := TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableHeaderTradeDelivery/ram:ReceivingAdviceReferencedDocument/ram:FormattedIssueDateTime');
 
-  if _receivingAdviceDate.HasValue or (_receivingAdviceNo <> '') then
-    Result.SetReceivingAdviceReferencedDocument(_receivingAdviceNo, _receivingAdviceDate);
+    if _receivingAdviceDate.HasValue or (_receivingAdviceNo <> '') then
+      Result.SetReceivingAdviceReferencedDocument(_receivingAdviceNo, _receivingAdviceDate);
 
-  var _deliveryNoteNo : String := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableHeaderTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssuerAssignedID');
-  var _deliveryNoteDate : ZUGFeRDNullable<TDateTime> := TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableHeaderTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssueDateTime/udt:DateTimeString');
+    var _deliveryNoteNo : String := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableHeaderTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssuerAssignedID');
+    var _deliveryNoteDate : ZUGFeRDNullable<TDateTime> := TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableHeaderTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssueDateTime/udt:DateTimeString');
 
-  if Not (_deliveryNoteDate.HasValue) then
-  begin
-    _deliveryNoteDate := TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableHeaderTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssueDateTime');
-  end;
+    if Not (_deliveryNoteDate.HasValue) then
+    begin
+      _deliveryNoteDate := TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableHeaderTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssueDateTime');
+    end;
 
-  if ((_deliveryNoteDate.HasValue) or (_deliveryNoteNo <> '')) then
-  begin
-    Result.DeliveryNoteReferencedDocument := TZUGFeRDDeliveryNoteReferencedDocument.Create;
-    Result.SetDeliveryNoteReferenceDocument(_deliveryNoteNo,_deliveryNoteDate);
-  end;
+    if ((_deliveryNoteDate.HasValue) or (_deliveryNoteNo <> '')) then
+    begin
+      Result.DeliveryNoteReferencedDocument := TZUGFeRDDeliveryNoteReferencedDocument.Create;
+      Result.SetDeliveryNoteReferenceDocument(_deliveryNoteNo,_deliveryNoteDate);
+    end;
 
-  Result.Invoicee := _nodeAsParty(doc.DocumentElement, '//ram:ApplicableHeaderTradeSettlement/ram:InvoiceeTradeParty');
-  nodes := doc.SelectNodes('//ram:ApplicableHeaderTradeSettlement/ram:InvoiceeTradeParty/ram:SpecifiedTaxRegistration');
-  for i := 0 to nodes.length-1 do
-    Result.AddInvoiceeTaxRegistration(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ID'),
-                                      TEnumExtensions<TZUGFeRDTaxRegistrationSchemeID>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ID/@schemeID')));
+    Result.Invoicee := _nodeAsParty(doc.DocumentElement, '//ram:ApplicableHeaderTradeSettlement/ram:InvoiceeTradeParty');
+    nodes := doc.SelectNodes('//ram:ApplicableHeaderTradeSettlement/ram:InvoiceeTradeParty/ram:SpecifiedTaxRegistration');
+    for i := 0 to nodes.length-1 do
+      Result.AddInvoiceeTaxRegistration(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ID'),
+                                        TEnumExtensions<TZUGFeRDTaxRegistrationSchemeID>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ID/@schemeID')));
 
-  Result.Invoicer := _nodeAsParty(doc.DocumentElement, '//ram:ApplicableHeaderTradeSettlement/ram:InvoicerTradeParty');
-  if (doc.selectSingleNode('//ram:InvoicerTradeParty/ram:DefinedTradeContact') <> nil) then
-  begin
-    Result.InvoicerContact := TZUGFeRDContact.Create;
-    Result.InvoicerContact.Name := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:InvoicerTradeParty/ram:DefinedTradeContact/ram:PersonName');
-    Result.InvoicerContact.OrgUnit := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:InvoicerTradeParty/ram:DefinedTradeContact/ram:DepartmentName');
-    Result.InvoicerContact.PhoneNo := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:InvoicerTradeParty/ram:DefinedTradeContact/ram:TelephoneUniversalCommunication/ram:CompleteNumber');
-    Result.InvoicerContact.FaxNo := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:InvoicerTradeParty/ram:DefinedTradeContact/ram:FaxUniversalCommunication/ram:CompleteNumber');
-    Result.InvoicerContact.EmailAddress := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:InvoicerTradeParty/ram:DefinedTradeContact/ram:EmailURIUniversalCommunication/ram:URIID');
-  end;
+    Result.Invoicer := _nodeAsParty(doc.DocumentElement, '//ram:ApplicableHeaderTradeSettlement/ram:InvoicerTradeParty');
+    if (doc.selectSingleNode('//ram:InvoicerTradeParty/ram:DefinedTradeContact') <> nil) then
+    begin
+      Result.InvoicerContact := TZUGFeRDContact.Create;
+      Result.InvoicerContact.Name := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:InvoicerTradeParty/ram:DefinedTradeContact/ram:PersonName');
+      Result.InvoicerContact.OrgUnit := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:InvoicerTradeParty/ram:DefinedTradeContact/ram:DepartmentName');
+      Result.InvoicerContact.PhoneNo := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:InvoicerTradeParty/ram:DefinedTradeContact/ram:TelephoneUniversalCommunication/ram:CompleteNumber');
+      Result.InvoicerContact.FaxNo := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:InvoicerTradeParty/ram:DefinedTradeContact/ram:FaxUniversalCommunication/ram:CompleteNumber');
+      Result.InvoicerContact.EmailAddress := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:InvoicerTradeParty/ram:DefinedTradeContact/ram:EmailURIUniversalCommunication/ram:URIID');
+    end;
 
-  Result.Payee := _nodeAsParty(doc.DocumentElement, '//ram:ApplicableHeaderTradeSettlement/ram:PayeeTradeParty');
+    Result.Payee := _nodeAsParty(doc.DocumentElement, '//ram:ApplicableHeaderTradeSettlement/ram:PayeeTradeParty');
 
-  Result.PaymentReference := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableHeaderTradeSettlement/ram:PaymentReference');
-  Result.Currency :=  TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableHeaderTradeSettlement/ram:InvoiceCurrencyCode'));
-  Result.TaxCurrency := TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableHeaderTradeSettlement/ram:TaxCurrencyCode')); // BT-6
-  Result.SellerReferenceNo := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableHeaderTradeSettlement/ram:InvoiceIssuerReference');
+    Result.PaymentReference := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableHeaderTradeSettlement/ram:PaymentReference');
+    Result.Currency :=  TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableHeaderTradeSettlement/ram:InvoiceCurrencyCode'));
+    Result.TaxCurrency := TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableHeaderTradeSettlement/ram:TaxCurrencyCode')); // BT-6
+    Result.SellerReferenceNo := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableHeaderTradeSettlement/ram:InvoiceIssuerReference');
 
-  // TODO: Multiple SpecifiedTradeSettlementPaymentMeans can exist for each account/institution (with different SEPA?)
-  Result.PaymentMeans := TZUGFeRDPaymentMeans.Create;
-  Result.PaymentMeans.TypeCode := TEnumExtensions<TZUGFeRDPaymentMeansTypeCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:TypeCode'));
-  Result.PaymentMeans.Information := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:Information');
-  Result.PaymentMeans.SEPACreditorIdentifier := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableHeaderTradeSettlement/ram:CreditorReferenceID');
-  Result.PaymentMeans.SEPAMandateReference := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID');
+    // TODO: Multiple SpecifiedTradeSettlementPaymentMeans can exist for each account/institution (with different SEPA?)
+    Result.PaymentMeans := TZUGFeRDPaymentMeans.Create;
+    Result.PaymentMeans.TypeCode := TEnumExtensions<TZUGFeRDPaymentMeansTypeCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:TypeCode'));
+    Result.PaymentMeans.Information := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:Information');
+    Result.PaymentMeans.SEPACreditorIdentifier := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableHeaderTradeSettlement/ram:CreditorReferenceID');
+    Result.PaymentMeans.SEPAMandateReference := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID');
 
-  var financialCardId : String := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:ApplicableTradeSettlementFinancialCard/ram:ID');
-  var financialCardCardholderName : String := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:ApplicableTradeSettlementFinancialCard/ram:CardholderName');
+    var financialCardId : String := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:ApplicableTradeSettlementFinancialCard/ram:ID');
+    var financialCardCardholderName : String := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:ApplicableTradeSettlementFinancialCard/ram:CardholderName');
 
-  if ((financialCardId <> '') or (financialCardCardholderName <> '')) then
-  begin
-    Result.PaymentMeans.FinancialCard := TZUGFeRDFinancialCard.Create;
-    Result.PaymentMeans.FinancialCard.Id := financialCardId;
-    Result.PaymentMeans.FinancialCard.CardholderName := financialCardCardholderName;
-  end;
+    if ((financialCardId <> '') or (financialCardCardholderName <> '')) then
+    begin
+      Result.PaymentMeans.FinancialCard := TZUGFeRDFinancialCard.Create;
+      Result.PaymentMeans.FinancialCard.Id := financialCardId;
+      Result.PaymentMeans.FinancialCard.CardholderName := financialCardCardholderName;
+    end;
 
-  //TODO udt:DateTimeString
-  Result.BillingPeriodStart := TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableHeaderTradeSettlement/ram:BillingSpecifiedPeriod/ram:StartDateTime');
-  Result.BillingPeriodEnd := TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableHeaderTradeSettlement/ram:BillingSpecifiedPeriod/ram:EndDateTime');
+    //TODO udt:DateTimeString
+    Result.BillingPeriodStart := TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableHeaderTradeSettlement/ram:BillingSpecifiedPeriod/ram:StartDateTime');
+    Result.BillingPeriodEnd := TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableHeaderTradeSettlement/ram:BillingSpecifiedPeriod/ram:EndDateTime');
 
-  var creditorFinancialAccountNodes : IXMLDOMNodeList := doc.SelectNodes('//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:PayeePartyCreditorFinancialAccount');
-  var creditorFinancialInstitutions : IXMLDOMNodeList := doc.SelectNodes('//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:PayeeSpecifiedCreditorFinancialInstitution');
+    var creditorFinancialAccountNodes : IXMLDOMNodeList := doc.SelectNodes('//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:PayeePartyCreditorFinancialAccount');
+    var creditorFinancialInstitutions : IXMLDOMNodeList := doc.SelectNodes('//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:PayeeSpecifiedCreditorFinancialInstitution');
 
-  if (creditorFinancialAccountNodes.length = creditorFinancialInstitutions.length) then
-  for i := 0 to creditorFinancialAccountNodes.length-1 do
-  begin
-    var _account : TZUGFeRDBankAccount := TZUGFeRDBankAccount.Create;
-    _account.ID := TZUGFeRDXmlUtils.NodeAsString(creditorFinancialAccountNodes[i], './/ram:ProprietaryID');
-    _account.IBAN := TZUGFeRDXmlUtils.NodeAsString(creditorFinancialAccountNodes[i], './/ram:IBANID');
-    _account.Name := TZUGFeRDXmlUtils.NodeAsString(creditorFinancialAccountNodes[i], './/ram:AccountName');
-    _account.BIC := TZUGFeRDXmlUtils.NodeAsString(creditorFinancialInstitutions[i], './/ram:BICID');
-    _account.Bankleitzahl := TZUGFeRDXmlUtils.NodeAsString(creditorFinancialInstitutions[i], './/ram:GermanBankleitzahlID');
-    _account.BankName := TZUGFeRDXmlUtils.NodeAsString(creditorFinancialInstitutions[i], './/ram:Name');
-    Result.CreditorBankAccounts.Add(_account);
-  end;
-
-  var specifiedTradeSettlementPaymentMeansNodes : IXMLDOMNodeList := doc.SelectNodes('//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans');
-  for i := 0 to specifiedTradeSettlementPaymentMeansNodes.length-1 do
-  begin
-      var payerPartyDebtorFinancialAccountNode : IXMLDOMNode := specifiedTradeSettlementPaymentMeansNodes[i].selectSingleNode('ram:PayerPartyDebtorFinancialAccount');
-
-      if (payerPartyDebtorFinancialAccountNode = nil) then
-        continue;
-
+    if (creditorFinancialAccountNodes.length = creditorFinancialInstitutions.length) then
+    for i := 0 to creditorFinancialAccountNodes.length-1 do
+    begin
       var _account : TZUGFeRDBankAccount := TZUGFeRDBankAccount.Create;
-      _account.ID := TZUGFeRDXmlUtils.NodeAsString(payerPartyDebtorFinancialAccountNode, './/ram:ProprietaryID');
-      _account.IBAN := TZUGFeRDXmlUtils.NodeAsString(payerPartyDebtorFinancialAccountNode, './/ram:IBANID');
-      _account.Bankleitzahl := TZUGFeRDXmlUtils.NodeAsString(payerPartyDebtorFinancialAccountNode, './/ram:GermanBankleitzahlID');
-      _account.BankName := TZUGFeRDXmlUtils.NodeAsString(payerPartyDebtorFinancialAccountNode, './/ram:Name');
-
-      var payerSpecifiedDebtorFinancialInstitutionNode : IXMLDOMNode := specifiedTradeSettlementPaymentMeansNodes[i].SelectSingleNode('ram:PayerSpecifiedDebtorFinancialInstitution');
-      if (payerSpecifiedDebtorFinancialInstitutionNode <> nil) then
-          _account.BIC := TZUGFeRDXmlUtils.NodeAsString(payerSpecifiedDebtorFinancialInstitutionNode, './/ram:BICID');
-
-      Result.DebitorBankAccounts.Add(_account);
-  end;
-
-  //XmlNodeList debitorFinancialAccountNodes := doc.SelectNodes("//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:PayerPartyDebtorFinancialAccount');
-  //XmlNodeList debitorFinancialInstitutions := doc.SelectNodes("//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:PayerSpecifiedDebtorFinancialInstitution');
-
-  //if (debitorFinancialAccountNodes.Count == debitorFinancialInstitutions.Count)
-  //{
-  //    for (int i := 0; i < debitorFinancialAccountNodes.Count; i++)
-  //    {
-  //        BankAccount _account := new BankAccount()
-  //        {
-  //            ID := TZUGFeRDXmlUtils.NodeAsString(debitorFinancialAccountNodes[0], ".//ram:ProprietaryID'),
-  //            IBAN := TZUGFeRDXmlUtils.NodeAsString(debitorFinancialAccountNodes[0], ".//ram:IBANID'),
-  //            BIC := TZUGFeRDXmlUtils.NodeAsString(debitorFinancialInstitutions[0], ".//ram:BICID'),
-  //            Bankleitzahl := TZUGFeRDXmlUtils.NodeAsString(debitorFinancialInstitutions[0], ".//ram:GermanBankleitzahlID'),
-  //            BankName := TZUGFeRDXmlUtils.NodeAsString(debitorFinancialInstitutions[0], ".//ram:Name'),
-  //        };
-
-  //        Result.DebitorBankAccounts.Add(_account);
-  //    } // !for(i)
-  //
-
-  nodes := doc.SelectNodes('//ram:ApplicableHeaderTradeSettlement/ram:ApplicableTradeTax');
-  for i := 0 to nodes.length-1 do
-    Result.AddApplicableTradeTax(TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:CalculatedAmount', 0),
-                                 TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:BasisAmount', 0),
-                                 TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:RateApplicablePercent', 0),
-                                 TEnumExtensions<TZUGFeRDTaxTypes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:TypeCode')),
-                                 TEnumExtensions<TZUGFeRDTaxCategoryCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:CategoryCode')),
-                                 TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:AllowanceChargeBasisAmount'),
-                                 TEnumExtensions<TZUGFeRDTaxExemptionReasonCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ExemptionReasonCode')),
-                                 TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ExemptionReason'),
-                                 TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:LineTotalBasisAmount')
-                                ).SetTaxPointDate(TZUGFeRDXmlUtils.NodeAsDateTime(nodes[i], './/ram:TaxPointDate/udt:DateString'),
-                                                  TEnumExtensions<TZUGFeRDDateTypeCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:DueDateTypeCode')));
-
-  nodes := doc.SelectNodes('//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeAllowanceCharge');
-  for i := 0 to nodes.length-1 do
-  begin
-    var chargePercentage: ZUGFeRDNullable<Currency> :=TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:CalculationPercent');
-    var basisAmount: ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:BasisAmount');
-    var actualAmount: ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:ActualAmount', 0);
-    var reason: string := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Reason');
-    var taxTypeCode: ZUGFeRDNullable<TZUGFeRDTaxTypes> := TEnumExtensions<TZUGFeRDTaxTypes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:CategoryTradeTax/ram:TypeCode'));
-    var taxCategoryCode: ZUGFeRDNullable<TZUGFeRDTaxCategoryCodes> := TEnumExtensions<TZUGFeRDTaxCategoryCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:CategoryTradeTax/ram:CategoryCode'));
-    var taxPercent: ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:CategoryTradeTax/ram:RateApplicablePercent', 0);
-    if TZUGFeRDXmlUtils.NodeAsBool(nodes[i], './/ram:ChargeIndicator') then
-    begin
-      var chargeReasonCode: ZUGFeRDNullable<TZUGFeRDChargeReasonCodes> := TEnumExtensions<TZUGFeRDChargeReasonCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:ReasonCode'));
-      Result.AddTradeCharge(basisAmount, Result.Currency, actualAmount, chargePercentage, reason, taxTypeCode, taxCategoryCode, taxPercent, chargeReasonCode);
-   end
-    else
-    begin
-      var allowanceReasonCode: ZUGFeRDNullable<TZUGFeRDAllowanceReasonCodes> := TEnumExtensions<TZUGFeRDAllowanceReasonCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:ReasonCode'));
-      Result.AddTradeAllowance(basisAmount, Result.Currency, actualAmount, chargePercentage, reason, taxTypeCode, taxCategoryCode, taxPercent, allowanceReasonCode);
-    end;
-  end;
-
-  nodes := doc.SelectNodes('//ram:SpecifiedLogisticsServiceCharge');
-  for i := 0 to nodes.length-1 do
-  begin
-    Result.AddLogisticsServiceCharge(TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:AppliedAmount', 0),
-                                     TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Description'),
-                                     TEnumExtensions<TZUGFeRDTaxTypes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:AppliedTradeTax/ram:TypeCode')),
-                                     TEnumExtensions<TZUGFeRDTaxCategoryCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:AppliedTradeTax/ram:CategoryCode')),
-                                     TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:AppliedTradeTax/ram:RateApplicablePercent', 0));
-  end;
-
-  nodes := doc.SelectNodes('//ram:SpecifiedTradePaymentTerms');
-  for i := 0 to nodes.length-1 do
-  begin
-    var paymentTerm : TZUGFeRDPaymentTerms := TZUGFeRDPaymentTerms.Create;
-    paymentTerm.Description := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Description');
-    paymentTerm.DueDate:= TZUGFeRDXmlUtils.NodeAsDateTime(nodes[i], './/ram:DueDateDateTime/udt:DateTimeString');
-    paymentTerm.PartialPaymentAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:PartialPaymentAmount');
-    var discountPercent: ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:ApplicableTradePaymentDiscountTerms/ram:CalculationPercent');
-    var penaltyPercent: ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:ApplicableTradePaymentPenaltyTerms/ram:CalculationPercent');
-    var Days: ZUGFeRDNullable<Integer>;
-    if discountPercent.HasValue then
-    begin
-      paymentTerm.PaymentTermsType:= TZUGFeRDPaymentTermsType.Skonto;
-      paymentTerm.Percentage:= discountPercent;
-      if TZUGFeRDQuantityCodes.DAY = TEnumExtensions<TZUGFeRDQuantityCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ApplicableTradePaymentDiscountTerms/ram:BasisPeriodMeasure/@unitCode')) then
-        paymentTerm.DueDays:= TZUGFeRDXmlUtils.NodeAsInt(nodes[i], './/ram:ApplicableTradePaymentDiscountTerms/ram:BasisPeriodMeasure');
-      paymentTerm.MaturityDate:= TZUGFeRDXmlUtils.NodeAsDateTime(nodes[i], './/ram:ApplicableTradePaymentDiscountTerms/ram:BasisDateTime/udt:DateTimeString'); //BT-X-282-0
-      paymentTerm.BaseAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:ApplicableTradePaymentDiscountTerms/ram:BasisAmount');
-      paymentTerm.ActualAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:ApplicableTradePaymentDiscountTerms/ram:ActualDiscountAmount');
-    end
-    else
-    if penaltyPercent.HasValue then
-    begin
-      paymentTerm.PaymentTermsType:= TZUGFeRDPaymentTermsType.Verzug;
-      paymentTerm.Percentage:= penaltyPercent;
-      if TZUGFeRDQuantityCodes.DAY = TEnumExtensions<TZUGFeRDQuantityCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ApplicableTradePaymentPenaltyTerms/ram:BasisPeriodMeasure/@unitCode')) then
-        paymentTerm.DueDays:= TZUGFeRDXmlUtils.NodeAsInt(nodes[i], './/ram:ApplicableTradePaymentPenaltyTerms/ram:BasisPeriodMeasure');
-      paymentTerm.MaturityDate:= TZUGFeRDXmlUtils.NodeAsDateTime(nodes[i], './/ram:ApplicableTradePaymentPenaltyTerms/ram:BasisDateTime/udt:DateTimeString'); // BT-X-276-0
-      paymentTerm.BaseAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:ApplicableTradePaymentPenaltyTerms/ram:BasisAmount');
-      paymentTerm.ActualAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:ApplicableTradePaymentPenaltyTerms/ram:ActualPenaltyAmount');
+      try
+        _account.ID := TZUGFeRDXmlUtils.NodeAsString(creditorFinancialAccountNodes[i], './/ram:ProprietaryID');
+        _account.IBAN := TZUGFeRDXmlUtils.NodeAsString(creditorFinancialAccountNodes[i], './/ram:IBANID');
+        _account.Name := TZUGFeRDXmlUtils.NodeAsString(creditorFinancialAccountNodes[i], './/ram:AccountName');
+        _account.BIC := TZUGFeRDXmlUtils.NodeAsString(creditorFinancialInstitutions[i], './/ram:BICID');
+        _account.Bankleitzahl := TZUGFeRDXmlUtils.NodeAsString(creditorFinancialInstitutions[i], './/ram:GermanBankleitzahlID');
+        _account.BankName := TZUGFeRDXmlUtils.NodeAsString(creditorFinancialInstitutions[i], './/ram:Name');
+        Result.CreditorBankAccounts.Add(_account);
+      except
+        _account.Free;
+        raise;
+      end;
     end;
 
-    Result.PaymentTermsList.Add(paymentTerm);
-  end;
+    var specifiedTradeSettlementPaymentMeansNodes : IXMLDOMNodeList := doc.SelectNodes('//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans');
+    for i := 0 to specifiedTradeSettlementPaymentMeansNodes.length-1 do
+    begin
+        var payerPartyDebtorFinancialAccountNode : IXMLDOMNode := specifiedTradeSettlementPaymentMeansNodes[i].selectSingleNode('ram:PayerPartyDebtorFinancialAccount');
 
-  Result.LineTotalAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementHeaderMonetarySummation/ram:LineTotalAmount');
-  Result.ChargeTotalAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementHeaderMonetarySummation/ram:ChargeTotalAmount');
-  Result.AllowanceTotalAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementHeaderMonetarySummation/ram:AllowanceTotalAmount');
-  Result.TaxBasisAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementHeaderMonetarySummation/ram:TaxBasisTotalAmount');
-  // BT-110: TaxTotalAmount in invoice currency — prefer the element with matching currencyID, fall back to first element
-  Result.TaxTotalAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementHeaderMonetarySummation/ram:TaxTotalAmount[@currencyID=''' + TEnumExtensions<TZUGFeRDCurrencyCodes>.EnumToString(Result.Currency) + ''']');
-  if not Result.TaxTotalAmount.HasValue then
-    Result.TaxTotalAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementHeaderMonetarySummation/ram:TaxTotalAmount');
+        if (payerPartyDebtorFinancialAccountNode = nil) then
+          continue;
 
-  // BT-111: TaxTotalAmount in accounting currency — only when BT-6 differs from BT-5
-  if Result.TaxCurrency.HasValue and (Result.TaxCurrency.Value <> Result.Currency) then
-    Result.TaxTotalAmountInAccountingCurrency:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementHeaderMonetarySummation/ram:TaxTotalAmount[@currencyID=''' + TEnumExtensions<TZUGFeRDCurrencyCodes>.EnumToString(Result.TaxCurrency.Value) + ''']');
+        var _account : TZUGFeRDBankAccount := TZUGFeRDBankAccount.Create;
+        try
+          _account.ID := TZUGFeRDXmlUtils.NodeAsString(payerPartyDebtorFinancialAccountNode, './/ram:ProprietaryID');
+          _account.IBAN := TZUGFeRDXmlUtils.NodeAsString(payerPartyDebtorFinancialAccountNode, './/ram:IBANID');
+          _account.Bankleitzahl := TZUGFeRDXmlUtils.NodeAsString(payerPartyDebtorFinancialAccountNode, './/ram:GermanBankleitzahlID');
+          _account.BankName := TZUGFeRDXmlUtils.NodeAsString(payerPartyDebtorFinancialAccountNode, './/ram:Name');
 
-  Result.GrandTotalAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementHeaderMonetarySummation/ram:GrandTotalAmount');
-  Result.RoundingAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementHeaderMonetarySummation/ram:RoundingAmount');
-  Result.TotalPrepaidAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementHeaderMonetarySummation/ram:TotalPrepaidAmount');
-  Result.DuePayableAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementHeaderMonetarySummation/ram:DuePayableAmount');
+          var payerSpecifiedDebtorFinancialInstitutionNode : IXMLDOMNode := specifiedTradeSettlementPaymentMeansNodes[i].SelectSingleNode('ram:PayerSpecifiedDebtorFinancialInstitution');
+          if (payerSpecifiedDebtorFinancialInstitutionNode <> nil) then
+              _account.BIC := TZUGFeRDXmlUtils.NodeAsString(payerSpecifiedDebtorFinancialInstitutionNode, './/ram:BICID');
 
-  // in this version we should only have on invoice referenced document but nevertheless...
-  nodes := doc.SelectNodes('//ram:ApplicableHeaderTradeSettlement/ram:InvoiceReferencedDocument');
-  for i := 0 to nodes.length-1 do
-  begin
-    Result.AddInvoiceReferencedDocument(
-      TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:IssuerAssignedID'),
-      TZUGFeRDXmlUtils.NodeAsDateTime(nodes[i], './ram:FormattedIssueDateTime')
-    );
-  end;
+          Result.DebitorBankAccounts.Add(_account);
+        except
+          _account.Free;
+          raise;
+        end;
+    end;
 
-  node := doc.SelectSingleNode('//ram:ApplicableHeaderTradeAgreement/ram:BuyerOrderReferencedDocument');
-  if node <> nil then
-  begin
-    Result.OrderDate:= TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableHeaderTradeAgreement/ram:BuyerOrderReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString');
-    Result.OrderNo := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableHeaderTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssuerAssignedID');
-  end;
+    //XmlNodeList debitorFinancialAccountNodes := doc.SelectNodes("//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:PayerPartyDebtorFinancialAccount');
+    //XmlNodeList debitorFinancialInstitutions := doc.SelectNodes("//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:PayerSpecifiedDebtorFinancialInstitution');
 
-  nodes := doc.SelectNodes('//ram:IncludedSupplyChainTradeLineItem');
-  for i := 0 to nodes.length-1 do
-    Result.TradeLineItems.Add(_parseTradeLineItem(nodes[i]));
+    //if (debitorFinancialAccountNodes.Count == debitorFinancialInstitutions.Count)
+    //{
+    //    for (int i := 0; i < debitorFinancialAccountNodes.Count; i++)
+    //    {
+    //        BankAccount _account := new BankAccount()
+    //        {
+    //            ID := TZUGFeRDXmlUtils.NodeAsString(debitorFinancialAccountNodes[0], ".//ram:ProprietaryID'),
+    //            IBAN := TZUGFeRDXmlUtils.NodeAsString(debitorFinancialAccountNodes[0], ".//ram:IBANID'),
+    //            BIC := TZUGFeRDXmlUtils.NodeAsString(debitorFinancialInstitutions[0], ".//ram:BICID'),
+    //            Bankleitzahl := TZUGFeRDXmlUtils.NodeAsString(debitorFinancialInstitutions[0], ".//ram:GermanBankleitzahlID'),
+    //            BankName := TZUGFeRDXmlUtils.NodeAsString(debitorFinancialInstitutions[0], ".//ram:Name'),
+    //        };
 
-  var deliveryCodeStr: string := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableHeaderTradeAgreement/ram:ApplicableTradeDeliveryTerms/ram:DeliveryTypeCode');
-  if deliveryCodeStr <> '' then
-  begin
-    var tradeCode:= TEnumExtensions<TZUGFeRDTradeDeliveryTermCodes>.StringToNullableEnum(deliveryCodeStr);
-    if tradeCode<>Nil then
-      Result.ApplicableTradeDeliveryTermsCode:= tradeCode;
-  end;
+    //        Result.DebitorBankAccounts.Add(_account);
+    //    } // !for(i)
+    //
 
-  // SellerOrderReferencedDocument
-  node := doc.SelectSingleNode('//ram:ApplicableHeaderTradeAgreement/ram:SellerOrderReferencedDocument');
-  if node <> nil then
-  begin
-    Result.SellerOrderReferencedDocument := TZUGFeRDSellerOrderReferencedDocument.Create;
-    Result.SellerOrderReferencedDocument.ID := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableHeaderTradeAgreement/ram:SellerOrderReferencedDocument/ram:IssuerAssignedID');
-    Result.SellerOrderReferencedDocument.IssueDateTime:= TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableHeaderTradeAgreement/ram:SellerOrderReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString');
+    nodes := doc.SelectNodes('//ram:ApplicableHeaderTradeSettlement/ram:ApplicableTradeTax');
+    for i := 0 to nodes.length-1 do
+      Result.AddApplicableTradeTax(TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:CalculatedAmount', 0),
+                                   TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:BasisAmount', 0),
+                                   TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:RateApplicablePercent', 0),
+                                   TEnumExtensions<TZUGFeRDTaxTypes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:TypeCode')),
+                                   TEnumExtensions<TZUGFeRDTaxCategoryCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:CategoryCode')),
+                                   TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:AllowanceChargeBasisAmount'),
+                                   TEnumExtensions<TZUGFeRDTaxExemptionReasonCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ExemptionReasonCode')),
+                                   TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ExemptionReason'),
+                                   TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:LineTotalBasisAmount')
+                                  ).SetTaxPointDate(TZUGFeRDXmlUtils.NodeAsDateTime(nodes[i], './/ram:TaxPointDate/udt:DateString'),
+                                                    TEnumExtensions<TZUGFeRDDateTypeCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:DueDateTypeCode')));
+
+    nodes := doc.SelectNodes('//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeAllowanceCharge');
+    for i := 0 to nodes.length-1 do
+    begin
+      var chargePercentage: ZUGFeRDNullable<Currency> :=TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:CalculationPercent');
+      var basisAmount: ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:BasisAmount');
+      var actualAmount: ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:ActualAmount', 0);
+      var reason: string := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Reason');
+      var taxTypeCode: ZUGFeRDNullable<TZUGFeRDTaxTypes> := TEnumExtensions<TZUGFeRDTaxTypes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:CategoryTradeTax/ram:TypeCode'));
+      var taxCategoryCode: ZUGFeRDNullable<TZUGFeRDTaxCategoryCodes> := TEnumExtensions<TZUGFeRDTaxCategoryCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:CategoryTradeTax/ram:CategoryCode'));
+      var taxPercent: ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:CategoryTradeTax/ram:RateApplicablePercent', 0);
+      if TZUGFeRDXmlUtils.NodeAsBool(nodes[i], './/ram:ChargeIndicator') then
+      begin
+        var chargeReasonCode: ZUGFeRDNullable<TZUGFeRDChargeReasonCodes> := TEnumExtensions<TZUGFeRDChargeReasonCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:ReasonCode'));
+        Result.AddTradeCharge(basisAmount, Result.Currency, actualAmount, chargePercentage, reason, taxTypeCode, taxCategoryCode, taxPercent, chargeReasonCode);
+     end
+      else
+      begin
+        var allowanceReasonCode: ZUGFeRDNullable<TZUGFeRDAllowanceReasonCodes> := TEnumExtensions<TZUGFeRDAllowanceReasonCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:ReasonCode'));
+        Result.AddTradeAllowance(basisAmount, Result.Currency, actualAmount, chargePercentage, reason, taxTypeCode, taxCategoryCode, taxPercent, allowanceReasonCode);
+      end;
+    end;
+
+    nodes := doc.SelectNodes('//ram:SpecifiedLogisticsServiceCharge');
+    for i := 0 to nodes.length-1 do
+    begin
+      Result.AddLogisticsServiceCharge(TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:AppliedAmount', 0),
+                                       TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Description'),
+                                       TEnumExtensions<TZUGFeRDTaxTypes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:AppliedTradeTax/ram:TypeCode')),
+                                       TEnumExtensions<TZUGFeRDTaxCategoryCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:AppliedTradeTax/ram:CategoryCode')),
+                                       TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:AppliedTradeTax/ram:RateApplicablePercent', 0));
+    end;
+
+    nodes := doc.SelectNodes('//ram:SpecifiedTradePaymentTerms');
+    for i := 0 to nodes.length-1 do
+    begin
+      var paymentTerm : TZUGFeRDPaymentTerms := TZUGFeRDPaymentTerms.Create;
+      try
+        paymentTerm.Description := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Description');
+        paymentTerm.DueDate:= TZUGFeRDXmlUtils.NodeAsDateTime(nodes[i], './/ram:DueDateDateTime/udt:DateTimeString');
+        paymentTerm.PartialPaymentAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:PartialPaymentAmount');
+        var discountPercent: ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:ApplicableTradePaymentDiscountTerms/ram:CalculationPercent');
+        var penaltyPercent: ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:ApplicableTradePaymentPenaltyTerms/ram:CalculationPercent');
+        var Days: ZUGFeRDNullable<Integer>;
+        if discountPercent.HasValue then
+        begin
+          paymentTerm.PaymentTermsType:= TZUGFeRDPaymentTermsType.Skonto;
+          paymentTerm.Percentage:= discountPercent;
+          if TZUGFeRDQuantityCodes.DAY = TEnumExtensions<TZUGFeRDQuantityCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ApplicableTradePaymentDiscountTerms/ram:BasisPeriodMeasure/@unitCode')) then
+            paymentTerm.DueDays:= TZUGFeRDXmlUtils.NodeAsInt(nodes[i], './/ram:ApplicableTradePaymentDiscountTerms/ram:BasisPeriodMeasure');
+          paymentTerm.MaturityDate:= TZUGFeRDXmlUtils.NodeAsDateTime(nodes[i], './/ram:ApplicableTradePaymentDiscountTerms/ram:BasisDateTime/udt:DateTimeString'); //BT-X-282-0
+          paymentTerm.BaseAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:ApplicableTradePaymentDiscountTerms/ram:BasisAmount');
+          paymentTerm.ActualAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:ApplicableTradePaymentDiscountTerms/ram:ActualDiscountAmount');
+        end
+        else
+        if penaltyPercent.HasValue then
+        begin
+          paymentTerm.PaymentTermsType:= TZUGFeRDPaymentTermsType.Verzug;
+          paymentTerm.Percentage:= penaltyPercent;
+          if TZUGFeRDQuantityCodes.DAY = TEnumExtensions<TZUGFeRDQuantityCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ApplicableTradePaymentPenaltyTerms/ram:BasisPeriodMeasure/@unitCode')) then
+            paymentTerm.DueDays:= TZUGFeRDXmlUtils.NodeAsInt(nodes[i], './/ram:ApplicableTradePaymentPenaltyTerms/ram:BasisPeriodMeasure');
+          paymentTerm.MaturityDate:= TZUGFeRDXmlUtils.NodeAsDateTime(nodes[i], './/ram:ApplicableTradePaymentPenaltyTerms/ram:BasisDateTime/udt:DateTimeString'); // BT-X-276-0
+          paymentTerm.BaseAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:ApplicableTradePaymentPenaltyTerms/ram:BasisAmount');
+          paymentTerm.ActualAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:ApplicableTradePaymentPenaltyTerms/ram:ActualPenaltyAmount');
+        end;
+
+        Result.PaymentTermsList.Add(paymentTerm);
+      except
+        paymentTerm.Free;
+        raise;
+      end;
+    end;
+
+    Result.LineTotalAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementHeaderMonetarySummation/ram:LineTotalAmount');
+    Result.ChargeTotalAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementHeaderMonetarySummation/ram:ChargeTotalAmount');
+    Result.AllowanceTotalAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementHeaderMonetarySummation/ram:AllowanceTotalAmount');
+    Result.TaxBasisAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementHeaderMonetarySummation/ram:TaxBasisTotalAmount');
+    // BT-110: TaxTotalAmount in invoice currency — prefer the element with matching currencyID, fall back to first element
+    Result.TaxTotalAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementHeaderMonetarySummation/ram:TaxTotalAmount[@currencyID=''' + TEnumExtensions<TZUGFeRDCurrencyCodes>.EnumToString(Result.Currency) + ''']');
+    if not Result.TaxTotalAmount.HasValue then
+      Result.TaxTotalAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementHeaderMonetarySummation/ram:TaxTotalAmount');
+
+    // BT-111: TaxTotalAmount in accounting currency — only when BT-6 differs from BT-5
+    if Result.TaxCurrency.HasValue and (Result.TaxCurrency.Value <> Result.Currency) then
+      Result.TaxTotalAmountInAccountingCurrency:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementHeaderMonetarySummation/ram:TaxTotalAmount[@currencyID=''' + TEnumExtensions<TZUGFeRDCurrencyCodes>.EnumToString(Result.TaxCurrency.Value) + ''']');
+
+    Result.GrandTotalAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementHeaderMonetarySummation/ram:GrandTotalAmount');
+    Result.RoundingAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementHeaderMonetarySummation/ram:RoundingAmount');
+    Result.TotalPrepaidAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementHeaderMonetarySummation/ram:TotalPrepaidAmount');
+    Result.DuePayableAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(doc.DocumentElement, '//ram:SpecifiedTradeSettlementHeaderMonetarySummation/ram:DuePayableAmount');
+
+    // in this version we should only have on invoice referenced document but nevertheless...
+    nodes := doc.SelectNodes('//ram:ApplicableHeaderTradeSettlement/ram:InvoiceReferencedDocument');
+    for i := 0 to nodes.length-1 do
+    begin
+      Result.AddInvoiceReferencedDocument(
+        TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:IssuerAssignedID'),
+        TZUGFeRDXmlUtils.NodeAsDateTime(nodes[i], './ram:FormattedIssueDateTime')
+      );
+    end;
+
+    node := doc.SelectSingleNode('//ram:ApplicableHeaderTradeAgreement/ram:BuyerOrderReferencedDocument');
+    if node <> nil then
+    begin
+      Result.OrderDate:= TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableHeaderTradeAgreement/ram:BuyerOrderReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString');
+      Result.OrderNo := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableHeaderTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssuerAssignedID');
+    end;
+
+    nodes := doc.SelectNodes('//ram:IncludedSupplyChainTradeLineItem');
+    for i := 0 to nodes.length-1 do
+    begin
+      var parsedItem := _parseTradeLineItem(nodes[i]);
+      try
+        Result.TradeLineItems.Add(parsedItem);
+      except
+        parsedItem.Free;
+        raise;
+      end;
+    end;
+
+    var deliveryCodeStr: string := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableHeaderTradeAgreement/ram:ApplicableTradeDeliveryTerms/ram:DeliveryTypeCode');
+    if deliveryCodeStr <> '' then
+    begin
+      var tradeCode:= TEnumExtensions<TZUGFeRDTradeDeliveryTermCodes>.StringToNullableEnum(deliveryCodeStr);
+      if tradeCode<>Nil then
+        Result.ApplicableTradeDeliveryTermsCode:= tradeCode;
+    end;
+
+    // SellerOrderReferencedDocument
+    node := doc.SelectSingleNode('//ram:ApplicableHeaderTradeAgreement/ram:SellerOrderReferencedDocument');
+    if node <> nil then
+    begin
+      Result.SellerOrderReferencedDocument := TZUGFeRDSellerOrderReferencedDocument.Create;
+      Result.SellerOrderReferencedDocument.ID := TZUGFeRDXmlUtils.NodeAsString(doc.DocumentElement, '//ram:ApplicableHeaderTradeAgreement/ram:SellerOrderReferencedDocument/ram:IssuerAssignedID');
+      Result.SellerOrderReferencedDocument.IssueDateTime:= TZUGFeRDXmlUtils.NodeAsDateTime(doc.DocumentElement, '//ram:ApplicableHeaderTradeAgreement/ram:SellerOrderReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString');
+    end;
+  except
+    Result.Free;
+    raise;
   end;
 end;
 
+/// <summary>Transfers the parsed result to the caller only after successful loading.</summary>
 function TZUGFeRDInvoiceDescriptor20Reader._parseTradeLineItem(
   tradeLineItem: IXmlDomNode): TZUGFeRDTradeLineItem;
 var
@@ -539,138 +577,167 @@ begin
     TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:AssociatedDocumentLineDocument/ram:LineStatusReasonCode'));
 
   Result := TZUGFeRDTradeLineItem.Create(lineId);
+  try
 
-  // Beide Felder werden unabhaengig voneinander uebernommen, siehe 23CII-Reader
-  if lineStatusCode.HasValue then
-    Result.AssociatedDocument.LineStatusCode := lineStatusCode;
-  if lineStatusReasonCode.HasValue then
-    Result.AssociatedDocument.LineStatusReasonCode := lineStatusReasonCode;
+    // Beide Felder werden unabhaengig voneinander uebernommen, siehe 23CII-Reader
+    if lineStatusCode.HasValue then
+      Result.AssociatedDocument.LineStatusCode := lineStatusCode;
+    if lineStatusReasonCode.HasValue then
+      Result.AssociatedDocument.LineStatusReasonCode := lineStatusReasonCode;
 
-  Result.GlobalID.SchemeID := TEnumExtensions<TZUGFeRDGlobalIDSchemeIdentifiers>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:GlobalID/@schemeID'));
-  Result.GlobalID.ID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:GlobalID');
-  Result.SellerAssignedID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:SellerAssignedID');
-  Result.BuyerAssignedID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:BuyerAssignedID');
-  Result.Name := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:Name');
-  Result.Description := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:Description');
-  Result.BilledQuantity := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:BilledQuantity', 0);
-  Result.UnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:BilledQuantity/@unitCode'));
-  Result.PackageQuantity := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:PackageQuantity');
-  Result.PackageUnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:PackageQuantity/@unitCode'));
-  Result.ChargeFreeQuantity := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:ChargeFreeQuantity');
-  Result.ChargeFreeUnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:ChargeFreeQuantity/@unitCode'));
-  Result.ShipTo := _nodeAsParty(tradeLineItem, './/ram:ShipToTradeParty');
-  Result.LineTotalAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:LineTotalAmount');
-  Result.TaxCategoryCode := TEnumExtensions<TZUGFeRDTaxCategoryCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:ApplicableTradeTax/ram:CategoryCode'));
-  Result.TaxType := TEnumExtensions<TZUGFeRDTaxTypes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:ApplicableTradeTax/ram:TypeCode'));
-  Result.TaxPercent := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:ApplicableTradeTax/ram:RateApplicablePercent', 0);
-  Result.NetUnitPrice:= TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:NetPriceProductTradePrice/ram:ChargeAmount');
-  Result.NetQuantity := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:NetPriceProductTradePrice/ram:BasisQuantity');
-  Result.NetUnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:NetPriceProductTradePrice/ram:BasisQuantity/@unitCode'));
-  Result.GrossUnitPrice:= TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:GrossPriceProductTradePrice/ram:ChargeAmount');
-  Result.GrossQuantity := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:GrossPriceProductTradePrice/ram:BasisQuantity');
-  Result.GrossUnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:GrossPriceProductTradePrice/ram:BasisQuantity/@unitCode'));
-  Result.BillingPeriodStart := TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:BillingSpecifiedPeriod/ram:StartDateTime/udt:DateTimeString');
-  Result.BillingPeriodEnd := TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:BillingSpecifiedPeriod/ram:EndDateTime/udt:DateTimeString');
+    Result.GlobalID.SchemeID := TEnumExtensions<TZUGFeRDGlobalIDSchemeIdentifiers>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:GlobalID/@schemeID'));
+    Result.GlobalID.ID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:GlobalID');
+    Result.SellerAssignedID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:SellerAssignedID');
+    Result.BuyerAssignedID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:BuyerAssignedID');
+    Result.Name := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:Name');
+    Result.Description := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:Description');
+    Result.BilledQuantity := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:BilledQuantity', 0);
+    Result.UnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:BilledQuantity/@unitCode'));
+    Result.PackageQuantity := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:PackageQuantity');
+    Result.PackageUnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:PackageQuantity/@unitCode'));
+    Result.ChargeFreeQuantity := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:ChargeFreeQuantity');
+    Result.ChargeFreeUnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:ChargeFreeQuantity/@unitCode'));
+    Result.ShipTo := _nodeAsParty(tradeLineItem, './/ram:ShipToTradeParty');
+    Result.LineTotalAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:LineTotalAmount');
+    Result.TaxCategoryCode := TEnumExtensions<TZUGFeRDTaxCategoryCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:ApplicableTradeTax/ram:CategoryCode'));
+    Result.TaxType := TEnumExtensions<TZUGFeRDTaxTypes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:ApplicableTradeTax/ram:TypeCode'));
+    Result.TaxPercent := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:ApplicableTradeTax/ram:RateApplicablePercent', 0);
+    Result.NetUnitPrice:= TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:NetPriceProductTradePrice/ram:ChargeAmount');
+    Result.NetQuantity := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:NetPriceProductTradePrice/ram:BasisQuantity');
+    Result.NetUnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:NetPriceProductTradePrice/ram:BasisQuantity/@unitCode'));
+    Result.GrossUnitPrice:= TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:GrossPriceProductTradePrice/ram:ChargeAmount');
+    Result.GrossQuantity := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:GrossPriceProductTradePrice/ram:BasisQuantity');
+    Result.GrossUnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:GrossPriceProductTradePrice/ram:BasisQuantity/@unitCode'));
+    Result.BillingPeriodStart := TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:BillingSpecifiedPeriod/ram:StartDateTime/udt:DateTimeString');
+    Result.BillingPeriodEnd := TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:BillingSpecifiedPeriod/ram:EndDateTime/udt:DateTimeString');
 
-  nodes := tradeLineItem.SelectNodes('.//ram:SpecifiedTradeProduct/ram:ApplicableProductCharacteristic');
-  for i := 0 to nodes.length-1 do
-  begin
-    var apcItem : TZUGFeRDApplicableProductCharacteristic := TZUGFeRDApplicableProductCharacteristic.Create;
-    apcItem.Description := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Description');
-    apcItem.Value := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Value');
-    Result.ApplicableProductCharacteristics.Add(apcItem);
-  end;
-
-  nodes := tradeLineItem.SelectNodes('.//ram:SpecifiedTradeProduct/ram:IncludedReferencedProduct');
-  for i := 0 to nodes.length-1 do
-  begin
-    var IncludedReferenceProduct: TZUGFeRDIncludedReferencedProduct:= TZUGFeRDIncludedReferencedProduct.Create;
-    IncludedReferenceProduct.GlobalID.SchemeID := TEnumExtensions<TZUGFeRDGlobalIDSchemeIdentifiers>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:GlobalID/@schemeID'));
-    IncludedReferenceProduct.GlobalID.ID := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:GlobalID');
-    IncludedReferenceProduct.SellerAssignedID := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:SellerAssignedID');
-    IncludedReferenceProduct.BuyerAssignedID := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:BuyerAssignedID');
-    IncludedReferenceProduct.IndustryAssignedID := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:IndustryAssignedID');
-    IncludedReferenceProduct.Name:= TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Name');
-    IncludedReferenceProduct.Description := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Description');
-    IncludedReferenceProduct.UnitQuantity:= TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:UnitQuantity');
-    IncludedReferenceProduct.UnitCode:= TEnumExtensions<TZUGFeRDQuantityCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:UnitQuantity/@unitCode'));
-    Result.IncludedReferencedProducts.Add(IncludedReferenceProduct);
-  end;
-
-  if tradeLineItem.SelectSingleNode('.//ram:AssociatedDocumentLineDocument') <> nil then
-  begin
-    nodes := tradeLineItem.SelectNodes('.//ram:AssociatedDocumentLineDocument/ram:IncludedNote');
+    nodes := tradeLineItem.SelectNodes('.//ram:SpecifiedTradeProduct/ram:ApplicableProductCharacteristic');
     for i := 0 to nodes.length-1 do
     begin
-      var noteItem : TZUGFeRDNote := TZUGFeRDNote.Create(
-          TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Content'),
-          TEnumExtensions<TZUGFeRDSubjectCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:SubjectCode')),
-          TEnumExtensions<TZUGFeRDContentCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ContentCode'))
-        );
-      Result.AssociatedDocument.Notes.Add(noteItem);
+      var apcItem : TZUGFeRDApplicableProductCharacteristic := TZUGFeRDApplicableProductCharacteristic.Create;
+      try
+        apcItem.Description := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Description');
+        apcItem.Value := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Value');
+        Result.ApplicableProductCharacteristics.Add(apcItem);
+      except
+        apcItem.Free;
+        raise;
+      end;
     end;
+
+    nodes := tradeLineItem.SelectNodes('.//ram:SpecifiedTradeProduct/ram:IncludedReferencedProduct');
+    for i := 0 to nodes.length-1 do
+    begin
+      var IncludedReferenceProduct: TZUGFeRDIncludedReferencedProduct:= TZUGFeRDIncludedReferencedProduct.Create;
+      try
+        IncludedReferenceProduct.GlobalID.SchemeID := TEnumExtensions<TZUGFeRDGlobalIDSchemeIdentifiers>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:GlobalID/@schemeID'));
+        IncludedReferenceProduct.GlobalID.ID := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:GlobalID');
+        IncludedReferenceProduct.SellerAssignedID := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:SellerAssignedID');
+        IncludedReferenceProduct.BuyerAssignedID := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:BuyerAssignedID');
+        IncludedReferenceProduct.IndustryAssignedID := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:IndustryAssignedID');
+        IncludedReferenceProduct.Name:= TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Name');
+        IncludedReferenceProduct.Description := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Description');
+        IncludedReferenceProduct.UnitQuantity:= TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:UnitQuantity');
+        IncludedReferenceProduct.UnitCode:= TEnumExtensions<TZUGFeRDQuantityCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:UnitQuantity/@unitCode'));
+        Result.IncludedReferencedProducts.Add(IncludedReferenceProduct);
+      except
+        IncludedReferenceProduct.Free;
+        raise;
+      end;
+    end;
+
+    if tradeLineItem.SelectSingleNode('.//ram:AssociatedDocumentLineDocument') <> nil then
+    begin
+      nodes := tradeLineItem.SelectNodes('.//ram:AssociatedDocumentLineDocument/ram:IncludedNote');
+      for i := 0 to nodes.length-1 do
+      begin
+        var noteItem : TZUGFeRDNote := TZUGFeRDNote.Create(
+            TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Content'),
+            TEnumExtensions<TZUGFeRDSubjectCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:SubjectCode')),
+            TEnumExtensions<TZUGFeRDContentCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ContentCode'))
+          );
+        try
+          Result.AssociatedDocument.Notes.Add(noteItem);
+        except
+          noteItem.Free;
+          raise;
+        end;
+      end;
+    end;
+
+    nodes := tradeLineItem.SelectNodes('.//ram:SpecifiedLineTradeAgreement/ram:GrossPriceProductTradePrice/ram:AppliedTradeAllowanceCharge');
+    for i := 0 to nodes.length-1 do
+    begin
+
+      var chargeIndicator : Boolean := TZUGFeRDXmlUtils.NodeAsBool(nodes[i], './ram:ChargeIndicator/udt:Indicator');
+      var basisAmount : ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './ram:BasisAmount');
+      var basisAmountCurrency : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:BasisAmount/@currencyID');
+      var actualAmount : Currency := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './ram:ActualAmount',0);
+      var actualAmountCurrency : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:ActualAmount/@currencyID');
+      var reason : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:Reason');
+
+      if chargeIndicator then // charge
+        Result.AddTradeCharge(TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToEnum(basisAmountCurrency),
+                                      basisAmount,
+                                      actualAmount,
+                                      reason)
+      else // allowance
+        Result.AddTradeAllowance(TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToEnum(basisAmountCurrency),
+                                      basisAmount,
+                                      actualAmount,
+                                      reason);
+    end;
+
+    if not Result.UnitCode.HasValue then
+      // UnitCode alternativ aus BilledQuantity extrahieren
+      Result.UnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:BilledQuantity/@unitCode'));
+
+    if (tradeLineItem.SelectSingleNode('.//ram:SpecifiedLineTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssuerAssignedID') <> nil) then
+    begin
+      Result.BuyerOrderReferencedDocument := TZUGFeRDBuyerOrderReferencedDocument.Create;
+      Result.BuyerOrderReferencedDocument.ID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedLineTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssuerAssignedID');
+      Result.BuyerOrderReferencedDocument.IssueDateTime:= TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:SpecifiedLineTradeAgreement/ram:BuyerOrderReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString');
+      Result.BuyerOrderReferencedDocument.LineID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedLineTradeAgreement/ram:BuyerOrderReferencedDocument/ram:LineID');
+    end;
+
+    if (tradeLineItem.SelectSingleNode('.//ram:SpecifiedLineTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssuerAssignedID') <> nil) then
+    begin
+      Result.DeliveryNoteReferencedDocument := TZUGFeRDDeliveryNoteReferencedDocument.Create;
+      Result.DeliveryNoteReferencedDocument.ID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedLineTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssuerAssignedID');
+      Result.DeliveryNoteReferencedDocument.IssueDateTime:= TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:SpecifiedLineTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString');
+      Result.DeliveryNoteReferencedDocument.LineID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedLineTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:LineID');
+    end;
+
+    if (tradeLineItem.SelectSingleNode('.//ram:SpecifiedLineTradeDelivery/ram:ActualDeliverySupplyChainEvent/ram:OccurrenceDateTime') <> nil) then
+      Result.ActualDeliveryDate:= TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:SpecifiedLineTradeDelivery/ram:ActualDeliverySupplyChainEvent/ram:OccurrenceDateTime/udt:DateTimeString');
+
+    if (tradeLineItem.SelectSingleNode('.//ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument/ram:IssuerAssignedID') <> nil) then
+    begin
+      Result.ContractReferencedDocument := TZUGFeRDContractReferencedDocument.Create;
+      Result.ContractReferencedDocument.ID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument/ram:IssuerAssignedID');
+      Result.ContractReferencedDocument.IssueDateTime:= TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString');
+      Result.ContractReferencedDocument.LineID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument/ram:LineID');
+    end;
+
+    //Get all referenced AND embedded documents
+    nodes := tradeLineItem.SelectNodes('.//ram:SpecifiedLineTradeAgreement/ram:AdditionalReferencedDocument');
+    for i := 0 to nodes.length-1 do
+    begin
+      var parsedItem := _getAdditionalReferencedDocument(nodes[i]);
+      try
+        Result.AdditionalReferencedDocuments.Add(parsedItem);
+      except
+        parsedItem.Free;
+        raise;
+      end;
+    end;
+  except
+    Result.Free;
+    raise;
   end;
-
-  nodes := tradeLineItem.SelectNodes('.//ram:SpecifiedLineTradeAgreement/ram:GrossPriceProductTradePrice/ram:AppliedTradeAllowanceCharge');
-  for i := 0 to nodes.length-1 do
-  begin
-
-    var chargeIndicator : Boolean := TZUGFeRDXmlUtils.NodeAsBool(nodes[i], './ram:ChargeIndicator/udt:Indicator');
-    var basisAmount : ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './ram:BasisAmount');
-    var basisAmountCurrency : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:BasisAmount/@currencyID');
-    var actualAmount : Currency := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './ram:ActualAmount',0);
-    var actualAmountCurrency : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:ActualAmount/@currencyID');
-    var reason : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:Reason');
-
-    if chargeIndicator then // charge
-      Result.AddTradeCharge(TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToEnum(basisAmountCurrency),
-                                    basisAmount,
-                                    actualAmount,
-                                    reason)
-    else // allowance
-      Result.AddTradeAllowance(TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToEnum(basisAmountCurrency),
-                                    basisAmount,
-                                    actualAmount,
-                                    reason);
-  end;
-
-  if not Result.UnitCode.HasValue then
-    // UnitCode alternativ aus BilledQuantity extrahieren
-    Result.UnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:BilledQuantity/@unitCode'));
-
-  if (tradeLineItem.SelectSingleNode('.//ram:SpecifiedLineTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssuerAssignedID') <> nil) then
-  begin
-    Result.BuyerOrderReferencedDocument := TZUGFeRDBuyerOrderReferencedDocument.Create;
-    Result.BuyerOrderReferencedDocument.ID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedLineTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssuerAssignedID');
-    Result.BuyerOrderReferencedDocument.IssueDateTime:= TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:SpecifiedLineTradeAgreement/ram:BuyerOrderReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString');
-    Result.BuyerOrderReferencedDocument.LineID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedLineTradeAgreement/ram:BuyerOrderReferencedDocument/ram:LineID');
-  end;
-
-  if (tradeLineItem.SelectSingleNode('.//ram:SpecifiedLineTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssuerAssignedID') <> nil) then
-  begin
-    Result.DeliveryNoteReferencedDocument := TZUGFeRDDeliveryNoteReferencedDocument.Create;
-    Result.DeliveryNoteReferencedDocument.ID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedLineTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssuerAssignedID');
-    Result.DeliveryNoteReferencedDocument.IssueDateTime:= TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:SpecifiedLineTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString');
-    Result.DeliveryNoteReferencedDocument.LineID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedLineTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:LineID');
-  end;
-
-  if (tradeLineItem.SelectSingleNode('.//ram:SpecifiedLineTradeDelivery/ram:ActualDeliverySupplyChainEvent/ram:OccurrenceDateTime') <> nil) then
-    Result.ActualDeliveryDate:= TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:SpecifiedLineTradeDelivery/ram:ActualDeliverySupplyChainEvent/ram:OccurrenceDateTime/udt:DateTimeString');
-
-  if (tradeLineItem.SelectSingleNode('.//ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument/ram:IssuerAssignedID') <> nil) then
-  begin
-    Result.ContractReferencedDocument := TZUGFeRDContractReferencedDocument.Create;
-    Result.ContractReferencedDocument.ID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument/ram:IssuerAssignedID');
-    Result.ContractReferencedDocument.IssueDateTime:= TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString');
-    Result.ContractReferencedDocument.LineID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument/ram:LineID');
-  end;
-
-  //Get all referenced AND embedded documents
-  nodes := tradeLineItem.SelectNodes('.//ram:SpecifiedLineTradeAgreement/ram:AdditionalReferencedDocument');
-  for i := 0 to nodes.length-1 do
-    Result.AdditionalReferencedDocuments.Add(_getAdditionalReferencedDocument(nodes[i]));
 end;
 
+/// <summary>Transfers the parsed result to the caller only after successful loading.</summary>
 function TZUGFeRDInvoiceDescriptor20Reader._nodeAsParty(basenode: IXmlDomNode; const xpath: string) : TZUGFeRDParty;
 var
   node : IXmlDomNode;
@@ -683,49 +750,60 @@ begin
   if (node = nil) then
     exit;
   Result := TZUGFeRDParty.Create;
-  Result.ID.SchemeID := TEnumExtensions<TZUGFeRDGlobalIDSchemeIdentifiers>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(node, 'ram:ID/@schemeID'));
-  Result.ID.ID := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:ID');
-  Result.GlobalID.SchemeID := TEnumExtensions<TZUGFeRDGlobalIDSchemeIdentifiers>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(node, 'ram:GlobalID/@schemeID'));
-  Result.GlobalID.ID := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:GlobalID');
-  Result.Name := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:Name');
-  Result.Description := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:Description'); // Seller only BT-33
-  Result.Postcode := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:PostcodeCode');
-  Result.City := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:CityName');
-  Result.Country := TEnumExtensions<TZUGFeRDCountryCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:CountryID'));
+  try
+    Result.ID.SchemeID := TEnumExtensions<TZUGFeRDGlobalIDSchemeIdentifiers>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(node, 'ram:ID/@schemeID'));
+    Result.ID.ID := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:ID');
+    Result.GlobalID.SchemeID := TEnumExtensions<TZUGFeRDGlobalIDSchemeIdentifiers>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(node, 'ram:GlobalID/@schemeID'));
+    Result.GlobalID.ID := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:GlobalID');
+    Result.Name := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:Name');
+    Result.Description := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:Description'); // Seller only BT-33
+    Result.Postcode := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:PostcodeCode');
+    Result.City := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:CityName');
+    Result.Country := TEnumExtensions<TZUGFeRDCountryCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:CountryID'));
 
-  lineOne:= TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:LineOne');
-  lineTwo:= TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:LineTwo');
-  if (not lineTwo.IsEmpty) then
-  begin
-    Result.Street2 := lineOne;
-    Result.ContactName := lineOne; // backward compatibility
-    Result.Street := lineTwo;
-  end else
-  begin
-    Result.Street := lineOne;
-    Result.Street2 := '';
-    Result.ContactName := '';
+    lineOne:= TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:LineOne');
+    lineTwo:= TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:LineTwo');
+    if (not lineTwo.IsEmpty) then
+    begin
+      Result.Street2 := lineOne;
+      Result.ContactName := lineOne; // backward compatibility
+      Result.Street := lineTwo;
+    end else
+    begin
+      Result.Street := lineOne;
+      Result.Street2 := '';
+      Result.ContactName := '';
+    end;
+    Result.AddressLine3 := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:LineThree');
+    Result.CountrySubdivisionName := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:CountrySubDivisionName');
+  except
+    Result.Free;
+    raise;
   end;
-  Result.AddressLine3 := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:LineThree');
-  Result.CountrySubdivisionName := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:CountrySubDivisionName');
 end;
 
+/// <summary>Transfers the parsed result to the caller only after successful loading.</summary>
 function TZUGFeRDInvoiceDescriptor20Reader._getAdditionalReferencedDocument(a_oXmlNode: IXmlDomNode): TZUGFeRDAdditionalReferencedDocument;
 begin
   var strBase64BinaryData : String := TZUGFeRDXmlUtils.NodeAsString(a_oXmlNode, 'ram:AttachmentBinaryObject');
   Result := TZUGFeRDAdditionalReferencedDocument.Create(false);
-  Result.ID := TZUGFeRDXmlUtils.NodeAsString(a_oXmlNode, 'ram:IssuerAssignedID');
-  Result.TypeCode := TEnumExtensions<TZUGFeRDAdditionalReferencedDocumentTypeCode>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(a_oXmlNode, 'ram:TypeCode'));
-  Result.Name := TZUGFeRDXmlUtils.NodeAsString(a_oXmlNode, 'ram:Name');
-  Result.IssueDateTime:= TZUGFeRDXmlUtils.NodeAsDateTime(a_oXmlNode, 'ram:FormattedIssueDateTime/qdt:DateTimeString');
-  if strBase64BinaryData <> '' then
-  begin
-    Result.AttachmentBinaryObject := TMemoryStream.Create;
-    var strBase64BinaryDataBytes : TBytes := TNetEncoding.Base64.DecodeStringToBytes(strBase64BinaryData);
-    Result.AttachmentBinaryObject.Write(strBase64BinaryDataBytes,Length(strBase64BinaryDataBytes));
+  try
+    Result.ID := TZUGFeRDXmlUtils.NodeAsString(a_oXmlNode, 'ram:IssuerAssignedID');
+    Result.TypeCode := TEnumExtensions<TZUGFeRDAdditionalReferencedDocumentTypeCode>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(a_oXmlNode, 'ram:TypeCode'));
+    Result.Name := TZUGFeRDXmlUtils.NodeAsString(a_oXmlNode, 'ram:Name');
+    Result.IssueDateTime:= TZUGFeRDXmlUtils.NodeAsDateTime(a_oXmlNode, 'ram:FormattedIssueDateTime/qdt:DateTimeString');
+    if strBase64BinaryData <> '' then
+    begin
+      Result.AttachmentBinaryObject := TMemoryStream.Create;
+      var strBase64BinaryDataBytes : TBytes := TNetEncoding.Base64.DecodeStringToBytes(strBase64BinaryData);
+      Result.AttachmentBinaryObject.Write(strBase64BinaryDataBytes,Length(strBase64BinaryDataBytes));
+    end;
+    Result.Filename := TZUGFeRDXmlUtils.NodeAsString(a_oXmlNode, 'ram:AttachmentBinaryObject/@filename');
+    Result.ReferenceTypeCode := TEnumExtensions<TZUGFeRDReferenceTypeCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(a_oXmlNode, 'ram:ReferenceTypeCode'));
+  except
+    Result.Free;
+    raise;
   end;
-  Result.Filename := TZUGFeRDXmlUtils.NodeAsString(a_oXmlNode, 'ram:AttachmentBinaryObject/@filename');
-  Result.ReferenceTypeCode := TEnumExtensions<TZUGFeRDReferenceTypeCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(a_oXmlNode, 'ram:ReferenceTypeCode'));
 end;
 
 end.

--- a/intf.ZUGFeRDInvoiceDescriptor22UBLWriter.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor22UBLWriter.pas
@@ -1,4 +1,4 @@
-{* Licensed to the Apache Software Foundation (ASF) under one
+﻿{* Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/intf.ZUGFeRDInvoiceDescriptor22UblReader.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor22UblReader.pas
@@ -1,4 +1,4 @@
-{* Licensed to the Apache Software Foundation (ASF) under one
+﻿{* Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file
@@ -186,6 +186,7 @@ begin
   end;
 end;
 
+/// <summary>Transfers the parsed result to the caller only after successful loading.</summary>
 function TZUGFeRDInvoiceDescriptor22UBLReader.Load(
   xmldocument : IXMLDocument): TZUGFeRDInvoiceDescriptor;
 var
@@ -223,392 +224,421 @@ begin
   baseNode := doc.documentElement;
 
   Result := TZUGFeRDInvoiceDescriptor.Create;
+  try
 
-  Result.IsTest := TZUGFeRDXmlUtils.NodeAsBool(doc.documentElement, '//cbc:TestIndicator', false);
-  Result.BusinessProcess := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cbc:ProfileID');
-  // Profil aus BT-24 (cbc:CustomizationID) ableiten statt hart XRechnung zu setzen.
-  // Relativer XPath, weil ext:UBLExtensions vor BT-24 beliebigen Fremdinhalt (auch eine
-  // cbc:CustomizationID) enthalten darf. Die Rohkennung bleibt wie beim CII-Reader in GuideLine.
-  Result.GuideLine := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, 'cbc:CustomizationID');
-  begin
-    var customizationID: string := Result.GuideLine;
-    // XRechnung mit Extension (BG-DEX): dieselbe Spezifikation, nur erweitert; die Bibliothek
-    // kennt kein eigenes Extension-Profil. Nur die bekannten Extension-URNs werden auf die
-    // jeweilige Basis-URN zurückgeführt, fremde oder fingierte Kennungen bleiben Unknown.
-    if SameText(customizationID, 'urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_2.3#conformant#urn:xoev-de:kosit:extension:xrechnung_2.3') then
-      customizationID := 'urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_2.3'
-    else
-    if SameText(customizationID, 'urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0#conformant#urn:xeinkauf.de:kosit:extension:xrechnung_3.0') then
-      customizationID := 'urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0';
-    Result.Profile := TZUGFeRDProfileExtensions.StringToEnum(customizationID);
-  end;
-  // XRechnung-URNs (1.2 bis 3.0) ergeben XRechnung: der UBL-Writer kennt nur dieses Profil,
-  // XRechnung1 wäre beim Zurückschreiben nicht nutzbar (Dispatcher lässt UBL nur mit
-  // XRechnung zu). Fremde CIUS wie Peppol BIS Billing 3.0 haben kein Enum-Profil und bleiben
-  // bewusst Unknown, statt stillschweigend als XRechnung zu gelten; die Kennung steht in
-  // GuideLine. Reines EN 16931 (urn:cen.eu:en16931:2017) ergibt Comfort.
-  if Result.Profile = TZUGFeRDProfile.XRechnung1 then
-    Result.Profile := TZUGFeRDProfile.XRechnung;
-  Result.InvoiceNo := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cbc:ID');
-  Result.InvoiceDate := TZUGFeRDXmlUtils.NodeAsDateTime(doc.documentElement, '//cbc:IssueDate');
-  Result.Type_ := TEnumExtensions<TZUGFeRDInvoiceType>.StringToEnum(
-    TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, typeSelector));
-
-  // Notes - parse #SubjectCode#Content format
-  nodes := baseNode.selectNodes('cbc:Note');
-  for i := 0 to nodes.length - 1 do
-  begin
-    var content : string := TZUGFeRDXmlUtils.NodeAsString(nodes[i], '.');
-    if content.Trim = '' then
-      continue;
-    var contentParts : TArray<string> := content.Split(['#'], TStringSplitOptions.ExcludeEmpty);
-    var subjectCodeAsString : string := '';
-    if (Length(contentParts) > 1) and (Length(contentParts[0]) = 3) then
+    Result.IsTest := TZUGFeRDXmlUtils.NodeAsBool(doc.documentElement, '//cbc:TestIndicator', false);
+    Result.BusinessProcess := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cbc:ProfileID');
+    // Profil aus BT-24 (cbc:CustomizationID) ableiten statt hart XRechnung zu setzen.
+    // Relativer XPath, weil ext:UBLExtensions vor BT-24 beliebigen Fremdinhalt (auch eine
+    // cbc:CustomizationID) enthalten darf. Die Rohkennung bleibt wie beim CII-Reader in GuideLine.
+    Result.GuideLine := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, 'cbc:CustomizationID');
     begin
-      subjectCodeAsString := contentParts[0];
-      content := contentParts[1];
+      var customizationID: string := Result.GuideLine;
+      // XRechnung mit Extension (BG-DEX): dieselbe Spezifikation, nur erweitert; die Bibliothek
+      // kennt kein eigenes Extension-Profil. Nur die bekannten Extension-URNs werden auf die
+      // jeweilige Basis-URN zurückgeführt, fremde oder fingierte Kennungen bleiben Unknown.
+      if SameText(customizationID, 'urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_2.3#conformant#urn:xoev-de:kosit:extension:xrechnung_2.3') then
+        customizationID := 'urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_2.3'
+      else
+      if SameText(customizationID, 'urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0#conformant#urn:xeinkauf.de:kosit:extension:xrechnung_3.0') then
+        customizationID := 'urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0';
+      Result.Profile := TZUGFeRDProfileExtensions.StringToEnum(customizationID);
     end;
-    var subjectCode : ZUGFeRDNullable<TZUGFeRDSubjectCodes> :=
-      TEnumExtensions<TZUGFeRDSubjectCodes>.StringToNullableEnum(subjectCodeAsString);
-    Result.AddNote(content, subjectCode);
-  end;
+    // XRechnung-URNs (1.2 bis 3.0) ergeben XRechnung: der UBL-Writer kennt nur dieses Profil,
+    // XRechnung1 wäre beim Zurückschreiben nicht nutzbar (Dispatcher lässt UBL nur mit
+    // XRechnung zu). Fremde CIUS wie Peppol BIS Billing 3.0 haben kein Enum-Profil und bleiben
+    // bewusst Unknown, statt stillschweigend als XRechnung zu gelten; die Kennung steht in
+    // GuideLine. Reines EN 16931 (urn:cen.eu:en16931:2017) ergibt Comfort.
+    if Result.Profile = TZUGFeRDProfile.XRechnung1 then
+      Result.Profile := TZUGFeRDProfile.XRechnung;
+    Result.InvoiceNo := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cbc:ID');
+    Result.InvoiceDate := TZUGFeRDXmlUtils.NodeAsDateTime(doc.documentElement, '//cbc:IssueDate');
+    Result.Type_ := TEnumExtensions<TZUGFeRDInvoiceType>.StringToEnum(
+      TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, typeSelector));
 
-  Result.ReferenceOrderNo := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cbc:BuyerReference');
-
-  // Seller (BG-4)
-  Result.Seller := _nodeAsParty(doc.documentElement, '//cac:AccountingSupplierParty/cac:Party');
-
-  if doc.selectSingleNode('//cac:AccountingSupplierParty/cac:Party/cbc:EndpointID') <> nil then
-  begin
-    var id : string := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:AccountingSupplierParty/cac:Party/cbc:EndpointID');
-    var schemeID : string := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:AccountingSupplierParty/cac:Party/cbc:EndpointID/@schemeID');
-    var eas : ZUGFeRDNullable<TZUGFeRDElectronicAddressSchemeIdentifiers> :=
-      TEnumExtensions<TZUGFeRDElectronicAddressSchemeIdentifiers>.StringToNullableEnum(schemeID);
-    if eas.HasValue then
-      Result.SetSellerElectronicAddress(id, eas);
-  end;
-
-  // Seller Tax Registrations
-  nodes := doc.selectNodes('//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme');
-  for i := 0 to nodes.length - 1 do
-  begin
-    var id : string := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/cbc:CompanyID');
-    var taxSchemeID : string := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/cac:TaxScheme/cbc:ID');
-    // Map UBL tax scheme: VAT -> VA, TAX -> FC
-    var schemeID : TZUGFeRDTaxRegistrationSchemeID;
-    if SameText(taxSchemeID, 'VAT') then
-      schemeID := TZUGFeRDTaxRegistrationSchemeID.VA
-    else
-      schemeID := TZUGFeRDTaxRegistrationSchemeID.FC;
-    Result.AddSellerTaxRegistration(id, schemeID);
-  end;
-
-  // Seller Contact
-  if doc.selectSingleNode('//cac:AccountingSupplierParty/cac:Party/cac:Contact') <> nil then
-  begin
-    Result.SellerContact := TZUGFeRDContact.Create;
-    Result.SellerContact.Name := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:AccountingSupplierParty/cac:Party/cac:Contact/cbc:Name');
-    Result.SellerContact.OrgUnit := '';
-    Result.SellerContact.PhoneNo := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:AccountingSupplierParty/cac:Party/cac:Contact/cbc:Telephone');
-    Result.SellerContact.FaxNo := '';
-    Result.SellerContact.EmailAddress := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:AccountingSupplierParty/cac:Party/cac:Contact/cbc:ElectronicMail');
-  end;
-
-  // Buyer (BG-7)
-  Result.Buyer := _nodeAsParty(doc.documentElement, '//cac:AccountingCustomerParty/cac:Party');
-
-  if doc.selectSingleNode('//cac:AccountingCustomerParty/cac:Party/cbc:EndpointID') <> nil then
-  begin
-    var id : string := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:AccountingCustomerParty/cac:Party/cbc:EndpointID');
-    var schemeID : string := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:AccountingCustomerParty/cac:Party/cbc:EndpointID/@schemeID');
-    var eas : ZUGFeRDNullable<TZUGFeRDElectronicAddressSchemeIdentifiers> :=
-      TEnumExtensions<TZUGFeRDElectronicAddressSchemeIdentifiers>.StringToNullableEnum(schemeID);
-    if eas.HasValue then
-      Result.SetBuyerElectronicAddress(id, eas);
-  end;
-
-  // Buyer Tax Registrations
-  nodes := doc.selectNodes('//cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme');
-  for i := 0 to nodes.length - 1 do
-  begin
-    var id : string := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/cbc:CompanyID');
-    var taxSchemeID : string := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/cac:TaxScheme/cbc:ID');
-    var schemeID : TZUGFeRDTaxRegistrationSchemeID;
-    if SameText(taxSchemeID, 'VAT') then
-      schemeID := TZUGFeRDTaxRegistrationSchemeID.VA
-    else
-      schemeID := TZUGFeRDTaxRegistrationSchemeID.FC;
-    Result.AddBuyerTaxRegistration(id, schemeID);
-  end;
-
-  // Buyer Contact
-  if doc.selectSingleNode('//cac:AccountingCustomerParty/cac:Party/cac:Contact') <> nil then
-  begin
-    Result.BuyerContact := TZUGFeRDContact.Create;
-    Result.BuyerContact.Name := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:AccountingCustomerParty/cac:Party/cac:Contact/cbc:Name');
-    Result.BuyerContact.OrgUnit := '';
-    Result.BuyerContact.PhoneNo := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:AccountingCustomerParty/cac:Party/cac:Contact/cbc:Telephone');
-    Result.BuyerContact.FaxNo := '';
-    Result.BuyerContact.EmailAddress := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:AccountingCustomerParty/cac:Party/cac:Contact/cbc:ElectronicMail');
-  end;
-
-  // Tax Representative (BG-11) - Note: in UBL TaxRepresentativeParty contains party info directly
-  Result.SellerTaxRepresentative := _nodeAsParty(doc.documentElement, '//cac:TaxRepresentativeParty');
-
-  // Delivery (BG-13)
-  var deliveryNode : IXMLDOMNode := doc.selectSingleNode('//cac:Delivery');
-  if deliveryNode <> nil then
-  begin
-    var deliveryLocationNode : IXMLDOMNode := deliveryNode.selectSingleNode('.//cac:DeliveryLocation');
-    if deliveryLocationNode <> nil then
+    // Notes - parse #SubjectCode#Content format
+    nodes := baseNode.selectNodes('cbc:Note');
+    for i := 0 to nodes.length - 1 do
     begin
-      Result.ShipTo := _nodeAsAddressParty(deliveryLocationNode, 'cac:Address');
-      if Result.ShipTo = nil then
-        Result.ShipTo := TZUGFeRDParty.Create;
-      Result.ShipTo.GlobalID := TZUGFeRDGlobalID.Create;
-      Result.ShipTo.ID := TZUGFeRDGlobalID.CreateWithParams(
-        TEnumExtensions<TZUGFeRDGlobalIDSchemeIdentifiers>.StringToNullableEnum(
-          TZUGFeRDXmlUtils.NodeAsString(deliveryLocationNode, './/cbc:ID/@schemeID')),
-        TZUGFeRDXmlUtils.NodeAsString(deliveryLocationNode, './/cbc:ID'));
-      Result.ShipTo.Name := TZUGFeRDXmlUtils.NodeAsString(deliveryNode, './/cac:DeliveryParty/cac:PartyName/cbc:Name');
-    end;
-    Result.ActualDeliveryDate := TZUGFeRDXmlUtils.NodeAsDateTime(doc.documentElement, '//cac:Delivery/cbc:ActualDeliveryDate');
-  end;
-
-  // Payee (BG-10)
-  Result.Payee := _nodeAsParty(doc.documentElement, '//cac:PayeeParty');
-
-  // Payment Reference
-  Result.PaymentReference := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:PaymentMeans/cbc:PaymentID');
-
-  // Currency (BT-5)
-  Result.Currency := TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToEnum(
-    TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cbc:DocumentCurrencyCode'));
-
-  // Tax Currency (BT-6)
-  var optionalTaxCurrency : ZUGFeRDNullable<TZUGFeRDCurrencyCodes> :=
-    TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToNullableEnum(
-      TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cbc:TaxCurrencyCode'));
-  if optionalTaxCurrency.HasValue then
-    Result.TaxCurrency := optionalTaxCurrency;
-
-  // PaymentMeans (BG-16)
-  Result.PaymentMeans := TZUGFeRDPaymentMeans.Create;
-  Result.PaymentMeans.TypeCode := TEnumExtensions<TZUGFeRDPaymentMeansTypeCodes>.StringToNullableEnum(
-    TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:PaymentMeans/cbc:PaymentMeansCode'));
-  Result.PaymentMeans.Information := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:PaymentMeans/cbc:PaymentMeansCode/@name');
-  Result.PaymentMeans.SEPACreditorIdentifier := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement,
-    '//cac:AccountingSupplierParty/cac:Party/cac:PartyIdentification/cbc:ID[@schemeID=''SEPA'']');
-  Result.PaymentMeans.SEPAMandateReference := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement,
-    '//cac:PaymentMeans/cac:PaymentMandate/cbc:ID');
-
-  var financialCardId : string := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement,
-    '//cac:PaymentMeans/cac:CardAccount/cbc:PrimaryAccountNumberID');
-  var financialCardCardholderName : string := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement,
-    '//cac:PaymentMeans/cac:CardAccount/cbc:HolderName');
-
-  if (financialCardId <> '') or (financialCardCardholderName <> '') then
-  begin
-    Result.PaymentMeans.FinancialCard := TZUGFeRDFinancialCard.Create;
-    Result.PaymentMeans.FinancialCard.Id := financialCardId;
-    Result.PaymentMeans.FinancialCard.CardholderName := financialCardCardholderName;
-  end;
-
-  // Billing Period
-  Result.BillingPeriodStart := TZUGFeRDXmlUtils.NodeAsDateTime(doc.documentElement, '/*[1]/cac:InvoicePeriod/cbc:StartDate');
-  Result.BillingPeriodEnd := TZUGFeRDXmlUtils.NodeAsDateTime(doc.documentElement, '/*[1]/cac:InvoicePeriod/cbc:EndDate');
-
-  // Creditor Bank Accounts (BG-17)
-  nodes := doc.selectNodes('//cac:PaymentMeans/cac:PayeeFinancialAccount');
-  for i := 0 to nodes.length - 1 do
-  begin
-    var bankAccount : TZUGFeRDBankAccount := _nodeAsBankAccount(nodes[i], '.');
-    if bankAccount <> nil then
-      Result.CreditorBankAccounts.Add(bankAccount);
-  end;
-
-  // Debitor Bank Accounts (BG-19)
-  nodes := doc.selectNodes('//cac:PaymentMeans/cac:PaymentMandate/cac:PayerFinancialAccount');
-  for i := 0 to nodes.length - 1 do
-  begin
-    var bankAccount : TZUGFeRDBankAccount := _nodeAsBankAccount(nodes[i], '.');
-    if bankAccount <> nil then
-      Result.DebitorBankAccounts.Add(bankAccount);
-  end;
-
-  // Taxes (BG-23)
-  nodes := doc.selectNodes('/*/cac:TaxTotal/cac:TaxSubtotal');
-  for i := 0 to nodes.length - 1 do
-  begin
-    var taxableAmount : Currency := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], 'cbc:TaxableAmount', 0);
-    var percent : Currency := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], 'cac:TaxCategory/cbc:Percent', 0);
-    var taxAmount : Currency := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], 'cbc:TaxAmount', 0);
-    var taxType : TZUGFeRDTaxTypes := TEnumExtensions<TZUGFeRDTaxTypes>.StringToEnum(
-      TZUGFeRDXmlUtils.NodeAsString(nodes[i], 'cac:TaxCategory/cac:TaxScheme/cbc:ID'));
-    var categoryCode : TZUGFeRDTaxCategoryCodes := TEnumExtensions<TZUGFeRDTaxCategoryCodes>.StringToEnum(
-      TZUGFeRDXmlUtils.NodeAsString(nodes[i], 'cac:TaxCategory/cbc:ID'));
-    var exemptionReasonCode : ZUGFeRDNullable<TZUGFeRDTaxExemptionReasonCodes> :=
-      TEnumExtensions<TZUGFeRDTaxExemptionReasonCodes>.StringToNullableEnum(
-        TZUGFeRDXmlUtils.NodeAsString(nodes[i], 'cac:TaxCategory/cbc:TaxExemptionReasonCode'));
-    var exemptionReason : string := TZUGFeRDXmlUtils.NodeAsString(nodes[i], 'cac:TaxCategory/cbc:TaxExemptionReason');
-
-    Result.AddApplicableTradeTax(taxAmount, taxableAmount, percent, taxType, categoryCode,
-      nil, exemptionReasonCode, exemptionReason);
-  end;
-
-  // Document-level AllowanceCharges (BG-20, BG-21)
-  // Use baseNode with direct child selector to avoid getting line-level ones
-  nodes := baseNode.selectNodes('cac:AllowanceCharge');
-  for i := 0 to nodes.length - 1 do
-  begin
-    var chargePercentage : ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/cbc:MultiplierFactorNumeric');
-    var basisAmount : ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/cbc:BaseAmount');
-    var actualAmount : ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/cbc:Amount', 0);
-    var reason : string := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/cbc:AllowanceChargeReason');
-    var taxTypeCode : ZUGFeRDNullable<TZUGFeRDTaxTypes> := TEnumExtensions<TZUGFeRDTaxTypes>.StringToNullableEnum(
-      TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/cac:TaxCategory/cac:TaxScheme/cbc:ID'));
-    var taxCategoryCode : ZUGFeRDNullable<TZUGFeRDTaxCategoryCodes> := TEnumExtensions<TZUGFeRDTaxCategoryCodes>.StringToNullableEnum(
-      TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/cac:TaxCategory/cbc:ID'));
-    var taxPercent : ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/cac:TaxCategory/cbc:Percent', 0);
-
-    if TZUGFeRDXmlUtils.NodeAsBool(nodes[i], './/cbc:ChargeIndicator') then // charge
-    begin
-      var chargeReasonCode : ZUGFeRDNullable<TZUGFeRDChargeReasonCodes> := TEnumExtensions<TZUGFeRDChargeReasonCodes>.StringToNullableEnum(
-        TZUGFeRDXmlUtils.NodeAsString(nodes[i], './cbc:AllowanceChargeReasonCode'));
-      Result.AddTradeCharge(basisAmount, Result.Currency, actualAmount, chargePercentage, reason, taxTypeCode, taxCategoryCode, taxPercent, chargeReasonCode);
-    end
-    else // allowance
-    begin
-      var allowanceReasonCode : ZUGFeRDNullable<TZUGFeRDAllowanceReasonCodes> := TEnumExtensions<TZUGFeRDAllowanceReasonCodes>.StringToNullableEnum(
-        TZUGFeRDXmlUtils.NodeAsString(nodes[i], './cbc:AllowanceChargeReasonCode'));
-      Result.AddTradeAllowance(basisAmount, Result.Currency, actualAmount, chargePercentage, reason, taxTypeCode, taxCategoryCode, taxPercent, allowanceReasonCode);
-    end;
-  end;
-
-  // Invoice Referenced Documents (BG-3)
-  nodes := doc.documentElement.selectNodes('//cac:BillingReference/cac:InvoiceDocumentReference');
-  for i := 0 to nodes.length - 1 do
-  begin
-    Result.AddInvoiceReferencedDocument(
-      TZUGFeRDXmlUtils.NodeAsString(nodes[i], './cbc:ID'),
-      TZUGFeRDXmlUtils.NodeAsDateTime(nodes[i], './cbc:IssueDate'));
-    break; // only one occurrence allowed in UBL
-  end;
-
-  // Despatch Document Reference (BT-16)
-  node := baseNode.selectSingleNode('cac:DespatchDocumentReference/cbc:ID');
-  if node <> nil then
-    Result.SetDespatchAdviceReferencedDocument(node.text);
-
-  // Receiving Advice Reference (BT-15)
-  node := baseNode.selectSingleNode('cac:ReceiptDocumentReference/cbc:ID');
-  if node <> nil then
-    Result.SetReceivingAdviceReferencedDocument(node.text);
-
-  // Payment Terms
-  Result.AddTradePaymentTerms(
-    TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:PaymentTerms/cbc:Note'),
-    TZUGFeRDXmlUtils.NodeAsDateTime(doc.documentElement, '//cbc:DueDate'));
-
-  // Monetary Totals
-  Result.LineTotalAmount := TZUGFeRDXmlUtils.NodeAsDecimal(doc.documentElement, '//cac:LegalMonetaryTotal/cbc:LineExtensionAmount');
-  Result.ChargeTotalAmount := TZUGFeRDXmlUtils.NodeAsDecimal(doc.documentElement, '//cac:LegalMonetaryTotal/cbc:ChargeTotalAmount');
-  Result.AllowanceTotalAmount := TZUGFeRDXmlUtils.NodeAsDecimal(doc.documentElement, '//cac:LegalMonetaryTotal/cbc:AllowanceTotalAmount');
-  Result.TaxBasisAmount := TZUGFeRDXmlUtils.NodeAsDecimal(doc.documentElement, '//cac:LegalMonetaryTotal/cbc:TaxExclusiveAmount');
-  Result.TaxTotalAmount := TZUGFeRDXmlUtils.NodeAsDecimal(doc.documentElement,
-    Format('/*/cac:TaxTotal/cbc:TaxAmount[@currencyID=''%s'']',
-      [TEnumExtensions<TZUGFeRDCurrencyCodes>.EnumToString(Result.Currency)]));
-  if not Result.TaxTotalAmount.HasValue then
-  begin
-    // PEPPOL-EN16931-R053 identifies BT-110 as the single TaxTotal group with a
-    // VAT breakdown. Requiring exactly one group avoids confusing reordered BT-111.
-    nodes := doc.documentElement.selectNodes('/*/cac:TaxTotal[cac:TaxSubtotal]/cbc:TaxAmount');
-    if nodes.length = 1 then
-      Result.TaxTotalAmount := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[0], '.');
-  end;
-  if Result.TaxCurrency.HasValue and (Result.TaxCurrency.Value <> Result.Currency) then
-    Result.TaxTotalAmountInAccountingCurrency := TZUGFeRDXmlUtils.NodeAsDecimal(doc.documentElement,
-      Format('/*/cac:TaxTotal/cbc:TaxAmount[@currencyID=''%s'']',
-        [TEnumExtensions<TZUGFeRDCurrencyCodes>.EnumToString(Result.TaxCurrency.Value)]));
-  Result.GrandTotalAmount := TZUGFeRDXmlUtils.NodeAsDecimal(doc.documentElement, '//cac:LegalMonetaryTotal/cbc:TaxInclusiveAmount');
-  Result.RoundingAmount := TZUGFeRDXmlUtils.NodeAsDecimal(doc.documentElement, '//cac:LegalMonetaryTotal/cbc:PayableRoundingAmount');
-  Result.TotalPrepaidAmount := TZUGFeRDXmlUtils.NodeAsDecimal(doc.documentElement, '//cac:LegalMonetaryTotal/cbc:PrepaidAmount');
-  Result.DuePayableAmount := TZUGFeRDXmlUtils.NodeAsDecimal(doc.documentElement, '//cac:LegalMonetaryTotal/cbc:PayableAmount');
-
-  // Accounting Cost
-  nodes := doc.selectNodes('//cbc:AccountingCost');
-  for i := 0 to nodes.length - 1 do
-  begin
-    var content : string := TZUGFeRDXmlUtils.NodeAsString(nodes[i], '.');
-    if content.Trim <> '' then
-      Result.AddReceivableSpecifiedTradeAccountingAccount(content);
-  end;
-
-  // Order Reference (BT-13)
-  Result.OrderNo := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:OrderReference/cbc:ID');
-
-  // Seller Order Referenced Document (BT-14)
-  if doc.selectSingleNode('//cac:OrderReference/cbc:SalesOrderID') <> nil then
-  begin
-    Result.SellerOrderReferencedDocument := TZUGFeRDSellerOrderReferencedDocument.Create;
-    Result.SellerOrderReferencedDocument.ID := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:OrderReference/cbc:SalesOrderID');
-  end;
-
-  // Contract Referenced Document (BT-12)
-  if doc.selectSingleNode('//cac:ContractDocumentReference/cbc:ID') <> nil then
-  begin
-    Result.ContractReferencedDocument := TZUGFeRDContractReferencedDocument.Create;
-    Result.ContractReferencedDocument.ID := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:ContractDocumentReference/cbc:ID');
-  end;
-
-  // Additional Document References (BG-24)
-  nodes := doc.selectNodes('//cac:AdditionalDocumentReference');
-  for i := 0 to nodes.length - 1 do
-  begin
-    var document : TZUGFeRDAdditionalReferencedDocument := TZUGFeRDAdditionalReferencedDocument.Create(false);
-    document.ID := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/cbc:ID');
-    document.ReferenceTypeCode := TEnumExtensions<TZUGFeRDReferenceTypeCodes>.StringToNullableEnum(
-      TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/cbc:ID/@schemeID'));
-    document.TypeCode := TEnumExtensions<TZUGFeRDAdditionalReferencedDocumentTypeCode>.StringToEnum(
-      TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/cbc:DocumentTypeCode'));
-    document.Name := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/cbc:DocumentDescription');
-
-    var binaryObjectNode : IXMLDOMNode := nodes[i].selectSingleNode('.//cac:Attachment/cbc:EmbeddedDocumentBinaryObject');
-    if binaryObjectNode <> nil then
-    begin
-      var filenameAttr : IXMLDOMNode := binaryObjectNode.attributes.getNamedItem('filename');
-      if filenameAttr <> nil then
-        document.Filename := filenameAttr.text;
-      var strBase64BinaryData : string := binaryObjectNode.text;
-      if strBase64BinaryData <> '' then
+      var content : string := TZUGFeRDXmlUtils.NodeAsString(nodes[i], '.');
+      if content.Trim = '' then
+        continue;
+      var contentParts : TArray<string> := content.Split(['#'], TStringSplitOptions.ExcludeEmpty);
+      var subjectCodeAsString : string := '';
+      if (Length(contentParts) > 1) and (Length(contentParts[0]) = 3) then
       begin
-        document.AttachmentBinaryObject := TMemoryStream.Create;
-        var strBase64BinaryDataBytes : TBytes := TNetEncoding.Base64.DecodeStringToBytes(strBase64BinaryData);
-        document.AttachmentBinaryObject.Write(strBase64BinaryDataBytes, Length(strBase64BinaryDataBytes));
+        subjectCodeAsString := contentParts[0];
+        content := contentParts[1];
+      end;
+      var subjectCode : ZUGFeRDNullable<TZUGFeRDSubjectCodes> :=
+        TEnumExtensions<TZUGFeRDSubjectCodes>.StringToNullableEnum(subjectCodeAsString);
+      Result.AddNote(content, subjectCode);
+    end;
+
+    Result.ReferenceOrderNo := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cbc:BuyerReference');
+
+    // Seller (BG-4)
+    Result.Seller := _nodeAsParty(doc.documentElement, '//cac:AccountingSupplierParty/cac:Party');
+
+    if doc.selectSingleNode('//cac:AccountingSupplierParty/cac:Party/cbc:EndpointID') <> nil then
+    begin
+      var id : string := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:AccountingSupplierParty/cac:Party/cbc:EndpointID');
+      var schemeID : string := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:AccountingSupplierParty/cac:Party/cbc:EndpointID/@schemeID');
+      var eas : ZUGFeRDNullable<TZUGFeRDElectronicAddressSchemeIdentifiers> :=
+        TEnumExtensions<TZUGFeRDElectronicAddressSchemeIdentifiers>.StringToNullableEnum(schemeID);
+      if eas.HasValue then
+        Result.SetSellerElectronicAddress(id, eas);
+    end;
+
+    // Seller Tax Registrations
+    nodes := doc.selectNodes('//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme');
+    for i := 0 to nodes.length - 1 do
+    begin
+      var id : string := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/cbc:CompanyID');
+      var taxSchemeID : string := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/cac:TaxScheme/cbc:ID');
+      // Map UBL tax scheme: VAT -> VA, TAX -> FC
+      var schemeID : TZUGFeRDTaxRegistrationSchemeID;
+      if SameText(taxSchemeID, 'VAT') then
+        schemeID := TZUGFeRDTaxRegistrationSchemeID.VA
+      else
+        schemeID := TZUGFeRDTaxRegistrationSchemeID.FC;
+      Result.AddSellerTaxRegistration(id, schemeID);
+    end;
+
+    // Seller Contact
+    if doc.selectSingleNode('//cac:AccountingSupplierParty/cac:Party/cac:Contact') <> nil then
+    begin
+      Result.SellerContact := TZUGFeRDContact.Create;
+      Result.SellerContact.Name := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:AccountingSupplierParty/cac:Party/cac:Contact/cbc:Name');
+      Result.SellerContact.OrgUnit := '';
+      Result.SellerContact.PhoneNo := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:AccountingSupplierParty/cac:Party/cac:Contact/cbc:Telephone');
+      Result.SellerContact.FaxNo := '';
+      Result.SellerContact.EmailAddress := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:AccountingSupplierParty/cac:Party/cac:Contact/cbc:ElectronicMail');
+    end;
+
+    // Buyer (BG-7)
+    Result.Buyer := _nodeAsParty(doc.documentElement, '//cac:AccountingCustomerParty/cac:Party');
+
+    if doc.selectSingleNode('//cac:AccountingCustomerParty/cac:Party/cbc:EndpointID') <> nil then
+    begin
+      var id : string := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:AccountingCustomerParty/cac:Party/cbc:EndpointID');
+      var schemeID : string := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:AccountingCustomerParty/cac:Party/cbc:EndpointID/@schemeID');
+      var eas : ZUGFeRDNullable<TZUGFeRDElectronicAddressSchemeIdentifiers> :=
+        TEnumExtensions<TZUGFeRDElectronicAddressSchemeIdentifiers>.StringToNullableEnum(schemeID);
+      if eas.HasValue then
+        Result.SetBuyerElectronicAddress(id, eas);
+    end;
+
+    // Buyer Tax Registrations
+    nodes := doc.selectNodes('//cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme');
+    for i := 0 to nodes.length - 1 do
+    begin
+      var id : string := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/cbc:CompanyID');
+      var taxSchemeID : string := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/cac:TaxScheme/cbc:ID');
+      var schemeID : TZUGFeRDTaxRegistrationSchemeID;
+      if SameText(taxSchemeID, 'VAT') then
+        schemeID := TZUGFeRDTaxRegistrationSchemeID.VA
+      else
+        schemeID := TZUGFeRDTaxRegistrationSchemeID.FC;
+      Result.AddBuyerTaxRegistration(id, schemeID);
+    end;
+
+    // Buyer Contact
+    if doc.selectSingleNode('//cac:AccountingCustomerParty/cac:Party/cac:Contact') <> nil then
+    begin
+      Result.BuyerContact := TZUGFeRDContact.Create;
+      Result.BuyerContact.Name := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:AccountingCustomerParty/cac:Party/cac:Contact/cbc:Name');
+      Result.BuyerContact.OrgUnit := '';
+      Result.BuyerContact.PhoneNo := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:AccountingCustomerParty/cac:Party/cac:Contact/cbc:Telephone');
+      Result.BuyerContact.FaxNo := '';
+      Result.BuyerContact.EmailAddress := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:AccountingCustomerParty/cac:Party/cac:Contact/cbc:ElectronicMail');
+    end;
+
+    // Tax Representative (BG-11) - Note: in UBL TaxRepresentativeParty contains party info directly
+    Result.SellerTaxRepresentative := _nodeAsParty(doc.documentElement, '//cac:TaxRepresentativeParty');
+
+    // Delivery (BG-13)
+    var deliveryNode : IXMLDOMNode := doc.selectSingleNode('//cac:Delivery');
+    if deliveryNode <> nil then
+    begin
+      var deliveryLocationNode : IXMLDOMNode := deliveryNode.selectSingleNode('.//cac:DeliveryLocation');
+      if deliveryLocationNode <> nil then
+      begin
+        Result.ShipTo := _nodeAsAddressParty(deliveryLocationNode, 'cac:Address');
+        if Result.ShipTo = nil then
+          Result.ShipTo := TZUGFeRDParty.Create;
+        // Party construction already owns both identifiers; populate rather than replace them.
+        Result.ShipTo.ID.SchemeID := TEnumExtensions<TZUGFeRDGlobalIDSchemeIdentifiers>.StringToNullableEnum(
+          TZUGFeRDXmlUtils.NodeAsString(deliveryLocationNode, './/cbc:ID/@schemeID'));
+        Result.ShipTo.ID.ID := TZUGFeRDXmlUtils.NodeAsString(deliveryLocationNode, './/cbc:ID');
+        Result.ShipTo.Name := TZUGFeRDXmlUtils.NodeAsString(deliveryNode, './/cac:DeliveryParty/cac:PartyName/cbc:Name');
+      end;
+      Result.ActualDeliveryDate := TZUGFeRDXmlUtils.NodeAsDateTime(doc.documentElement, '//cac:Delivery/cbc:ActualDeliveryDate');
+    end;
+
+    // Payee (BG-10)
+    Result.Payee := _nodeAsParty(doc.documentElement, '//cac:PayeeParty');
+
+    // Payment Reference
+    Result.PaymentReference := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:PaymentMeans/cbc:PaymentID');
+
+    // Currency (BT-5)
+    Result.Currency := TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToEnum(
+      TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cbc:DocumentCurrencyCode'));
+
+    // Tax Currency (BT-6)
+    var optionalTaxCurrency : ZUGFeRDNullable<TZUGFeRDCurrencyCodes> :=
+      TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToNullableEnum(
+        TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cbc:TaxCurrencyCode'));
+    if optionalTaxCurrency.HasValue then
+      Result.TaxCurrency := optionalTaxCurrency;
+
+    // PaymentMeans (BG-16)
+    Result.PaymentMeans := TZUGFeRDPaymentMeans.Create;
+    Result.PaymentMeans.TypeCode := TEnumExtensions<TZUGFeRDPaymentMeansTypeCodes>.StringToNullableEnum(
+      TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:PaymentMeans/cbc:PaymentMeansCode'));
+    Result.PaymentMeans.Information := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:PaymentMeans/cbc:PaymentMeansCode/@name');
+    Result.PaymentMeans.SEPACreditorIdentifier := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement,
+      '//cac:AccountingSupplierParty/cac:Party/cac:PartyIdentification/cbc:ID[@schemeID=''SEPA'']');
+    Result.PaymentMeans.SEPAMandateReference := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement,
+      '//cac:PaymentMeans/cac:PaymentMandate/cbc:ID');
+
+    var financialCardId : string := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement,
+      '//cac:PaymentMeans/cac:CardAccount/cbc:PrimaryAccountNumberID');
+    var financialCardCardholderName : string := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement,
+      '//cac:PaymentMeans/cac:CardAccount/cbc:HolderName');
+
+    if (financialCardId <> '') or (financialCardCardholderName <> '') then
+    begin
+      Result.PaymentMeans.FinancialCard := TZUGFeRDFinancialCard.Create;
+      Result.PaymentMeans.FinancialCard.Id := financialCardId;
+      Result.PaymentMeans.FinancialCard.CardholderName := financialCardCardholderName;
+    end;
+
+    // Billing Period
+    Result.BillingPeriodStart := TZUGFeRDXmlUtils.NodeAsDateTime(doc.documentElement, '/*[1]/cac:InvoicePeriod/cbc:StartDate');
+    Result.BillingPeriodEnd := TZUGFeRDXmlUtils.NodeAsDateTime(doc.documentElement, '/*[1]/cac:InvoicePeriod/cbc:EndDate');
+
+    // Creditor Bank Accounts (BG-17)
+    nodes := doc.selectNodes('//cac:PaymentMeans/cac:PayeeFinancialAccount');
+    for i := 0 to nodes.length - 1 do
+    begin
+      var bankAccount : TZUGFeRDBankAccount := _nodeAsBankAccount(nodes[i], '.');
+      if bankAccount <> nil then
+      begin
+        try
+          Result.CreditorBankAccounts.Add(bankAccount);
+        except
+          bankAccount.Free;
+          raise;
+        end;
       end;
     end;
 
-    Result.AdditionalReferencedDocuments.Add(document);
-  end;
-
-  // Project Reference (BT-11)
-  Result.SpecifiedProcuringProject := TZUGFeRDSpecifiedProcuringProject.Create;
-  Result.SpecifiedProcuringProject.ID := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:ProjectReference/cbc:ID');
-  Result.SpecifiedProcuringProject.Name := '';
-
-  // Trade Line Items
-  nodes := doc.selectNodes(tradeLineItemSelector);
-  for i := 0 to nodes.length - 1 do
-  begin
-    var item : TZUGFeRDTradeLineItem := _parseTradeLineItem(nodes[i], isInvoice);
-    if item <> nil then
+    // Debitor Bank Accounts (BG-19)
+    nodes := doc.selectNodes('//cac:PaymentMeans/cac:PaymentMandate/cac:PayerFinancialAccount');
+    for i := 0 to nodes.length - 1 do
     begin
-      Result.TradeLineItems.Add(item);
-      _addSubLineItems(nodes[i], item.AssociatedDocument.LineID, isInvoice, Result.TradeLineItems);
+      var bankAccount : TZUGFeRDBankAccount := _nodeAsBankAccount(nodes[i], '.');
+      if bankAccount <> nil then
+      begin
+        try
+          Result.DebitorBankAccounts.Add(bankAccount);
+        except
+          bankAccount.Free;
+          raise;
+        end;
+      end;
     end;
+
+    // Taxes (BG-23)
+    nodes := doc.selectNodes('/*/cac:TaxTotal/cac:TaxSubtotal');
+    for i := 0 to nodes.length - 1 do
+    begin
+      var taxableAmount : Currency := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], 'cbc:TaxableAmount', 0);
+      var percent : Currency := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], 'cac:TaxCategory/cbc:Percent', 0);
+      var taxAmount : Currency := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], 'cbc:TaxAmount', 0);
+      var taxType : TZUGFeRDTaxTypes := TEnumExtensions<TZUGFeRDTaxTypes>.StringToEnum(
+        TZUGFeRDXmlUtils.NodeAsString(nodes[i], 'cac:TaxCategory/cac:TaxScheme/cbc:ID'));
+      var categoryCode : TZUGFeRDTaxCategoryCodes := TEnumExtensions<TZUGFeRDTaxCategoryCodes>.StringToEnum(
+        TZUGFeRDXmlUtils.NodeAsString(nodes[i], 'cac:TaxCategory/cbc:ID'));
+      var exemptionReasonCode : ZUGFeRDNullable<TZUGFeRDTaxExemptionReasonCodes> :=
+        TEnumExtensions<TZUGFeRDTaxExemptionReasonCodes>.StringToNullableEnum(
+          TZUGFeRDXmlUtils.NodeAsString(nodes[i], 'cac:TaxCategory/cbc:TaxExemptionReasonCode'));
+      var exemptionReason : string := TZUGFeRDXmlUtils.NodeAsString(nodes[i], 'cac:TaxCategory/cbc:TaxExemptionReason');
+
+      Result.AddApplicableTradeTax(taxAmount, taxableAmount, percent, taxType, categoryCode,
+        nil, exemptionReasonCode, exemptionReason);
+    end;
+
+    // Document-level AllowanceCharges (BG-20, BG-21)
+    // Use baseNode with direct child selector to avoid getting line-level ones
+    nodes := baseNode.selectNodes('cac:AllowanceCharge');
+    for i := 0 to nodes.length - 1 do
+    begin
+      var chargePercentage : ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/cbc:MultiplierFactorNumeric');
+      var basisAmount : ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/cbc:BaseAmount');
+      var actualAmount : ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/cbc:Amount', 0);
+      var reason : string := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/cbc:AllowanceChargeReason');
+      var taxTypeCode : ZUGFeRDNullable<TZUGFeRDTaxTypes> := TEnumExtensions<TZUGFeRDTaxTypes>.StringToNullableEnum(
+        TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/cac:TaxCategory/cac:TaxScheme/cbc:ID'));
+      var taxCategoryCode : ZUGFeRDNullable<TZUGFeRDTaxCategoryCodes> := TEnumExtensions<TZUGFeRDTaxCategoryCodes>.StringToNullableEnum(
+        TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/cac:TaxCategory/cbc:ID'));
+      var taxPercent : ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/cac:TaxCategory/cbc:Percent', 0);
+
+      if TZUGFeRDXmlUtils.NodeAsBool(nodes[i], './/cbc:ChargeIndicator') then // charge
+      begin
+        var chargeReasonCode : ZUGFeRDNullable<TZUGFeRDChargeReasonCodes> := TEnumExtensions<TZUGFeRDChargeReasonCodes>.StringToNullableEnum(
+          TZUGFeRDXmlUtils.NodeAsString(nodes[i], './cbc:AllowanceChargeReasonCode'));
+        Result.AddTradeCharge(basisAmount, Result.Currency, actualAmount, chargePercentage, reason, taxTypeCode, taxCategoryCode, taxPercent, chargeReasonCode);
+      end
+      else // allowance
+      begin
+        var allowanceReasonCode : ZUGFeRDNullable<TZUGFeRDAllowanceReasonCodes> := TEnumExtensions<TZUGFeRDAllowanceReasonCodes>.StringToNullableEnum(
+          TZUGFeRDXmlUtils.NodeAsString(nodes[i], './cbc:AllowanceChargeReasonCode'));
+        Result.AddTradeAllowance(basisAmount, Result.Currency, actualAmount, chargePercentage, reason, taxTypeCode, taxCategoryCode, taxPercent, allowanceReasonCode);
+      end;
+    end;
+
+    // Invoice Referenced Documents (BG-3)
+    nodes := doc.documentElement.selectNodes('//cac:BillingReference/cac:InvoiceDocumentReference');
+    for i := 0 to nodes.length - 1 do
+    begin
+      Result.AddInvoiceReferencedDocument(
+        TZUGFeRDXmlUtils.NodeAsString(nodes[i], './cbc:ID'),
+        TZUGFeRDXmlUtils.NodeAsDateTime(nodes[i], './cbc:IssueDate'));
+      break; // only one occurrence allowed in UBL
+    end;
+
+    // Despatch Document Reference (BT-16)
+    node := baseNode.selectSingleNode('cac:DespatchDocumentReference/cbc:ID');
+    if node <> nil then
+      Result.SetDespatchAdviceReferencedDocument(node.text);
+
+    // Receiving Advice Reference (BT-15)
+    node := baseNode.selectSingleNode('cac:ReceiptDocumentReference/cbc:ID');
+    if node <> nil then
+      Result.SetReceivingAdviceReferencedDocument(node.text);
+
+    // Payment Terms
+    Result.AddTradePaymentTerms(
+      TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:PaymentTerms/cbc:Note'),
+      TZUGFeRDXmlUtils.NodeAsDateTime(doc.documentElement, '//cbc:DueDate'));
+
+    // Monetary Totals
+    Result.LineTotalAmount := TZUGFeRDXmlUtils.NodeAsDecimal(doc.documentElement, '//cac:LegalMonetaryTotal/cbc:LineExtensionAmount');
+    Result.ChargeTotalAmount := TZUGFeRDXmlUtils.NodeAsDecimal(doc.documentElement, '//cac:LegalMonetaryTotal/cbc:ChargeTotalAmount');
+    Result.AllowanceTotalAmount := TZUGFeRDXmlUtils.NodeAsDecimal(doc.documentElement, '//cac:LegalMonetaryTotal/cbc:AllowanceTotalAmount');
+    Result.TaxBasisAmount := TZUGFeRDXmlUtils.NodeAsDecimal(doc.documentElement, '//cac:LegalMonetaryTotal/cbc:TaxExclusiveAmount');
+    Result.TaxTotalAmount := TZUGFeRDXmlUtils.NodeAsDecimal(doc.documentElement,
+      Format('/*/cac:TaxTotal/cbc:TaxAmount[@currencyID=''%s'']',
+        [TEnumExtensions<TZUGFeRDCurrencyCodes>.EnumToString(Result.Currency)]));
+    if not Result.TaxTotalAmount.HasValue then
+    begin
+      // PEPPOL-EN16931-R053 identifies BT-110 as the single TaxTotal group with a
+      // VAT breakdown. Requiring exactly one group avoids confusing reordered BT-111.
+      nodes := doc.documentElement.selectNodes('/*/cac:TaxTotal[cac:TaxSubtotal]/cbc:TaxAmount');
+      if nodes.length = 1 then
+        Result.TaxTotalAmount := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[0], '.');
+    end;
+    if Result.TaxCurrency.HasValue and (Result.TaxCurrency.Value <> Result.Currency) then
+      Result.TaxTotalAmountInAccountingCurrency := TZUGFeRDXmlUtils.NodeAsDecimal(doc.documentElement,
+        Format('/*/cac:TaxTotal/cbc:TaxAmount[@currencyID=''%s'']',
+          [TEnumExtensions<TZUGFeRDCurrencyCodes>.EnumToString(Result.TaxCurrency.Value)]));
+    Result.GrandTotalAmount := TZUGFeRDXmlUtils.NodeAsDecimal(doc.documentElement, '//cac:LegalMonetaryTotal/cbc:TaxInclusiveAmount');
+    Result.RoundingAmount := TZUGFeRDXmlUtils.NodeAsDecimal(doc.documentElement, '//cac:LegalMonetaryTotal/cbc:PayableRoundingAmount');
+    Result.TotalPrepaidAmount := TZUGFeRDXmlUtils.NodeAsDecimal(doc.documentElement, '//cac:LegalMonetaryTotal/cbc:PrepaidAmount');
+    Result.DuePayableAmount := TZUGFeRDXmlUtils.NodeAsDecimal(doc.documentElement, '//cac:LegalMonetaryTotal/cbc:PayableAmount');
+
+    // Accounting Cost
+    nodes := doc.selectNodes('//cbc:AccountingCost');
+    for i := 0 to nodes.length - 1 do
+    begin
+      var content : string := TZUGFeRDXmlUtils.NodeAsString(nodes[i], '.');
+      if content.Trim <> '' then
+        Result.AddReceivableSpecifiedTradeAccountingAccount(content);
+    end;
+
+    // Order Reference (BT-13)
+    Result.OrderNo := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:OrderReference/cbc:ID');
+
+    // Seller Order Referenced Document (BT-14)
+    if doc.selectSingleNode('//cac:OrderReference/cbc:SalesOrderID') <> nil then
+    begin
+      Result.SellerOrderReferencedDocument := TZUGFeRDSellerOrderReferencedDocument.Create;
+      Result.SellerOrderReferencedDocument.ID := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:OrderReference/cbc:SalesOrderID');
+    end;
+
+    // Contract Referenced Document (BT-12)
+    if doc.selectSingleNode('//cac:ContractDocumentReference/cbc:ID') <> nil then
+    begin
+      Result.ContractReferencedDocument := TZUGFeRDContractReferencedDocument.Create;
+      Result.ContractReferencedDocument.ID := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:ContractDocumentReference/cbc:ID');
+    end;
+
+    // Additional Document References (BG-24)
+    nodes := doc.selectNodes('//cac:AdditionalDocumentReference');
+    for i := 0 to nodes.length - 1 do
+    begin
+      var document : TZUGFeRDAdditionalReferencedDocument := TZUGFeRDAdditionalReferencedDocument.Create(false);
+      try
+        document.ID := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/cbc:ID');
+        document.ReferenceTypeCode := TEnumExtensions<TZUGFeRDReferenceTypeCodes>.StringToNullableEnum(
+          TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/cbc:ID/@schemeID'));
+        document.TypeCode := TEnumExtensions<TZUGFeRDAdditionalReferencedDocumentTypeCode>.StringToEnum(
+          TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/cbc:DocumentTypeCode'));
+        document.Name := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/cbc:DocumentDescription');
+
+        var binaryObjectNode : IXMLDOMNode := nodes[i].selectSingleNode('.//cac:Attachment/cbc:EmbeddedDocumentBinaryObject');
+        if binaryObjectNode <> nil then
+        begin
+          var filenameAttr : IXMLDOMNode := binaryObjectNode.attributes.getNamedItem('filename');
+          if filenameAttr <> nil then
+            document.Filename := filenameAttr.text;
+          var strBase64BinaryData : string := binaryObjectNode.text;
+          if strBase64BinaryData <> '' then
+          begin
+            document.AttachmentBinaryObject := TMemoryStream.Create;
+            var strBase64BinaryDataBytes : TBytes := TNetEncoding.Base64.DecodeStringToBytes(strBase64BinaryData);
+            document.AttachmentBinaryObject.Write(strBase64BinaryDataBytes, Length(strBase64BinaryDataBytes));
+          end;
+        end;
+
+        Result.AdditionalReferencedDocuments.Add(document);
+      except
+        document.Free;
+        raise;
+      end;
+    end;
+
+    // Project Reference (BT-11)
+    Result.SpecifiedProcuringProject := TZUGFeRDSpecifiedProcuringProject.Create;
+    Result.SpecifiedProcuringProject.ID := TZUGFeRDXmlUtils.NodeAsString(doc.documentElement, '//cac:ProjectReference/cbc:ID');
+    Result.SpecifiedProcuringProject.Name := '';
+
+    // Trade Line Items
+    nodes := doc.selectNodes(tradeLineItemSelector);
+    for i := 0 to nodes.length - 1 do
+    begin
+      var item : TZUGFeRDTradeLineItem := _parseTradeLineItem(nodes[i], isInvoice);
+      if item <> nil then
+      begin
+        try
+          Result.TradeLineItems.Add(item);
+        except
+          item.Free;
+          raise;
+        end;
+        _addSubLineItems(nodes[i], item.AssociatedDocument.LineID, isInvoice, Result.TradeLineItems);
+      end;
+    end;
+  except
+    Result.Free;
+    raise;
   end;
 end;
 
+/// <summary>Retains local ownership until a nonduplicate subline has been added to the invoice.</summary>
 procedure TZUGFeRDInvoiceDescriptor22UBLReader._addSubLineItems(
   parentNode: IXMLDOMNode; const parentLineId: string; isInvoice: Boolean;
   tradeLineItems: TObjectList<TZUGFeRDTradeLineItem>);
@@ -632,19 +662,24 @@ begin
     subItem := _parseTradeLineItem(subNodes[j], isInvoice, parentLineId);
     if subItem <> nil then
     begin
-      isDuplicate := False;
-      for k := 0 to tradeLineItems.Count - 1 do
-        if tradeLineItems[k].AssociatedDocument.LineID = subItem.AssociatedDocument.LineID then
-        begin
-          isDuplicate := True;
-          subItem.Free;
-          Break;
-        end;
-      if not isDuplicate then
-      begin
-        tradeLineItems.Add(subItem);
-        _addSubLineItems(subNodes[j], subItem.AssociatedDocument.LineID, isInvoice, tradeLineItems);
+      try
+        isDuplicate := False;
+        for k := 0 to tradeLineItems.Count - 1 do
+          if tradeLineItems[k].AssociatedDocument.LineID = subItem.AssociatedDocument.LineID then
+          begin
+            isDuplicate := True;
+            Break;
+          end;
+        if not isDuplicate then
+          tradeLineItems.Add(subItem);
+      except
+        subItem.Free;
+        raise;
       end;
+      if isDuplicate then
+        subItem.Free
+      else
+        _addSubLineItems(subNodes[j], subItem.AssociatedDocument.LineID, isInvoice, tradeLineItems);
     end;
   end;
 end;
@@ -667,10 +702,13 @@ begin
     TZUGFeRDXmlUtils.NodeAsString(baseNode, 'cac:PartyName/cbc:Name'));
 end;
 
+/// <summary>Transfers the parsed result to the caller only after successful loading.</summary>
 function TZUGFeRDInvoiceDescriptor22UBLReader._nodeAsParty(basenode: IXmlDomNode;
   const xpath: string) : TZUGFeRDParty;
 var
   node : IXmlDomNode;
+  schemeID: ZUGFeRDNullable<TZUGFeRDGlobalIDSchemeIdentifiers>;
+  identification: TZUGFeRDGlobalID;
 begin
   Result := nil;
   if baseNode = nil then
@@ -682,31 +720,31 @@ begin
   Result := _nodeAsAddressParty(node, 'cac:PostalAddress');
   if Result = nil then
     Result := TZUGFeRDParty.Create;
+  try
 
-  // Party Identification - route GLN to GlobalID, others to ID
-  var id : TZUGFeRDGlobalID := TZUGFeRDGlobalID.CreateWithParams(
-    TEnumExtensions<TZUGFeRDGlobalIDSchemeIdentifiers>.StringToNullableEnum(
-      TZUGFeRDXmlUtils.NodeAsString(node, 'cac:PartyIdentification/cbc:ID/@schemeID')),
-    TZUGFeRDXmlUtils.NodeAsString(node, 'cac:PartyIdentification/cbc:ID'));
+    // Party Identification - route GLN to GlobalID, others to ID
+    schemeID := TEnumExtensions<TZUGFeRDGlobalIDSchemeIdentifiers>.StringToNullableEnum(
+      TZUGFeRDXmlUtils.NodeAsString(node, 'cac:PartyIdentification/cbc:ID/@schemeID'));
+    // Both objects belong to the new party already; replacing either one would leak it.
+    if schemeID.HasValue and (schemeID.Value = TZUGFeRDGlobalIDSchemeIdentifiers.GLN) then
+      identification := Result.GlobalID
+    else
+      identification := Result.ID;
+    identification.SchemeID := schemeID;
+    identification.ID := TZUGFeRDXmlUtils.NodeAsString(node, 'cac:PartyIdentification/cbc:ID');
 
-  if id.SchemeID.HasValue and (id.SchemeID.Value = TZUGFeRDGlobalIDSchemeIdentifiers.GLN) then
-  begin
-    Result.ID := TZUGFeRDGlobalID.Create;
-    Result.GlobalID := id;
-  end
-  else
-  begin
-    Result.ID := id;
-    Result.GlobalID := TZUGFeRDGlobalID.Create;
+    Result.Name := TZUGFeRDXmlUtils.NodeAsString(node, 'cac:PartyLegalEntity/cbc:RegistrationName');
+    Result.SpecifiedLegalOrganization := _nodeAsLegalOrganization(node, 'cac:PartyLegalEntity');
+
+    if Result.Description.Trim = '' then
+      Result.Description := TZUGFeRDXmlUtils.NodeAsString(node, 'cac:PartyLegalEntity/cbc:CompanyLegalForm');
+  except
+    Result.Free;
+    raise;
   end;
-
-  Result.Name := TZUGFeRDXmlUtils.NodeAsString(node, 'cac:PartyLegalEntity/cbc:RegistrationName');
-  Result.SpecifiedLegalOrganization := _nodeAsLegalOrganization(node, 'cac:PartyLegalEntity');
-
-  if Result.Description.Trim = '' then
-    Result.Description := TZUGFeRDXmlUtils.NodeAsString(node, 'cac:PartyLegalEntity/cbc:CompanyLegalForm');
 end;
 
+/// <summary>Transfers the parsed result to the caller only after successful loading.</summary>
 function TZUGFeRDInvoiceDescriptor22UBLReader._nodeAsAddressParty(basenode: IXmlDomNode;
   const xpath: string) : TZUGFeRDParty;
 var
@@ -720,16 +758,22 @@ begin
     exit;
 
   Result := TZUGFeRDParty.Create;
-  Result.Street := TZUGFeRDXmlUtils.NodeAsString(node, 'cbc:StreetName');
-  Result.Street2 := TZUGFeRDXmlUtils.NodeAsString(node, 'cbc:AdditionalStreetName');
-  Result.AddressLine3 := TZUGFeRDXmlUtils.NodeAsString(node, 'cac:AddressLine/cbc:Line');
-  Result.City := TZUGFeRDXmlUtils.NodeAsString(node, 'cbc:CityName');
-  Result.Postcode := TZUGFeRDXmlUtils.NodeAsString(node, 'cbc:PostalZone');
-  Result.CountrySubdivisionName := TZUGFeRDXmlUtils.NodeAsString(node, 'cbc:CountrySubentity');
-  Result.Country := TEnumExtensions<TZUGFeRDCountryCodes>.StringToNullableEnum(
-    TZUGFeRDXmlUtils.NodeAsString(node, 'cac:Country/cbc:IdentificationCode'));
+  try
+    Result.Street := TZUGFeRDXmlUtils.NodeAsString(node, 'cbc:StreetName');
+    Result.Street2 := TZUGFeRDXmlUtils.NodeAsString(node, 'cbc:AdditionalStreetName');
+    Result.AddressLine3 := TZUGFeRDXmlUtils.NodeAsString(node, 'cac:AddressLine/cbc:Line');
+    Result.City := TZUGFeRDXmlUtils.NodeAsString(node, 'cbc:CityName');
+    Result.Postcode := TZUGFeRDXmlUtils.NodeAsString(node, 'cbc:PostalZone');
+    Result.CountrySubdivisionName := TZUGFeRDXmlUtils.NodeAsString(node, 'cbc:CountrySubentity');
+    Result.Country := TEnumExtensions<TZUGFeRDCountryCodes>.StringToNullableEnum(
+      TZUGFeRDXmlUtils.NodeAsString(node, 'cac:Country/cbc:IdentificationCode'));
+  except
+    Result.Free;
+    raise;
+  end;
 end;
 
+/// <summary>Transfers the parsed result to the caller only after successful loading.</summary>
 function TZUGFeRDInvoiceDescriptor22UBLReader._nodeAsBankAccount(basenode: IXmlDomNode;
   const xpath: string) : TZUGFeRDBankAccount;
 var
@@ -743,13 +787,19 @@ begin
     exit;
 
   Result := TZUGFeRDBankAccount.Create;
-  Result.Name := TZUGFeRDXmlUtils.NodeAsString(node, 'cbc:Name');
-  Result.IBAN := TZUGFeRDXmlUtils.NodeAsString(node, 'cbc:ID');
-  Result.BIC := TZUGFeRDXmlUtils.NodeAsString(node, 'cac:FinancialInstitutionBranch/cbc:ID');
-  Result.BankName := TZUGFeRDXmlUtils.NodeAsString(node, 'cac:FinancialInstitutionBranch/cbc:Name');
-  Result.ID := '';
+  try
+    Result.Name := TZUGFeRDXmlUtils.NodeAsString(node, 'cbc:Name');
+    Result.IBAN := TZUGFeRDXmlUtils.NodeAsString(node, 'cbc:ID');
+    Result.BIC := TZUGFeRDXmlUtils.NodeAsString(node, 'cac:FinancialInstitutionBranch/cbc:ID');
+    Result.BankName := TZUGFeRDXmlUtils.NodeAsString(node, 'cac:FinancialInstitutionBranch/cbc:Name');
+    Result.ID := '';
+  except
+    Result.Free;
+    raise;
+  end;
 end;
 
+/// <summary>Transfers the parsed result to the caller only after successful loading.</summary>
 function TZUGFeRDInvoiceDescriptor22UBLReader._parseTradeLineItem(
   tradeLineItem: IXmlDomNode; isInvoice: Boolean; const parentLineId: string = ''): TZUGFeRDTradeLineItem;
 var
@@ -779,172 +829,195 @@ begin
   end;
 
   Result := TZUGFeRDTradeLineItem.Create(lineId);
+  try
 
-  Result.GlobalID.SchemeID := TEnumExtensions<TZUGFeRDGlobalIDSchemeIdentifiers>.StringToNullableEnum(
-    TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './cac:Item/cac:StandardItemIdentification/cbc:ID/@schemeID'));
-  Result.GlobalID.ID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './cac:Item/cac:StandardItemIdentification/cbc:ID');
-  Result.SellerAssignedID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './cac:Item/cac:SellersItemIdentification/cbc:ID');
-  Result.BuyerAssignedID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './cac:Item/cac:BuyersItemIdentification/cbc:ID');
-  Result.Name := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './cac:Item/cbc:Name');
-  Result.Description := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/cac:Item/cbc:Description');
-  Result.NetQuantity := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/cac:Price/cbc:BaseQuantity');
-  if billedQuantity.HasValue then
-    Result.BilledQuantity := billedQuantity.Value
-  else
-    Result.BilledQuantity := 0;
-  Result.LineTotalAmount := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/cbc:LineExtensionAmount', 0);
-  Result.TaxCategoryCode := TEnumExtensions<TZUGFeRDTaxCategoryCodes>.StringToNullableEnum(
-    TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/cac:Item/cac:ClassifiedTaxCategory/cbc:ID'));
-  Result.TaxType := TEnumExtensions<TZUGFeRDTaxTypes>.StringToNullableEnum(
-    TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/cac:Item/cac:ClassifiedTaxCategory/cac:TaxScheme/cbc:ID'));
-  Result.TaxPercent := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/cac:Item/cac:ClassifiedTaxCategory/cbc:Percent', 0);
-  Result.NetUnitPrice := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/cac:Price/cbc:PriceAmount', 0); // BT-146
+    Result.GlobalID.SchemeID := TEnumExtensions<TZUGFeRDGlobalIDSchemeIdentifiers>.StringToNullableEnum(
+      TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './cac:Item/cac:StandardItemIdentification/cbc:ID/@schemeID'));
+    Result.GlobalID.ID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './cac:Item/cac:StandardItemIdentification/cbc:ID');
+    Result.SellerAssignedID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './cac:Item/cac:SellersItemIdentification/cbc:ID');
+    Result.BuyerAssignedID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './cac:Item/cac:BuyersItemIdentification/cbc:ID');
+    Result.Name := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './cac:Item/cbc:Name');
+    Result.Description := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/cac:Item/cbc:Description');
+    Result.NetQuantity := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/cac:Price/cbc:BaseQuantity');
+    if billedQuantity.HasValue then
+      Result.BilledQuantity := billedQuantity.Value
+    else
+      Result.BilledQuantity := 0;
+    Result.LineTotalAmount := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/cbc:LineExtensionAmount', 0);
+    Result.TaxCategoryCode := TEnumExtensions<TZUGFeRDTaxCategoryCodes>.StringToNullableEnum(
+      TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/cac:Item/cac:ClassifiedTaxCategory/cbc:ID'));
+    Result.TaxType := TEnumExtensions<TZUGFeRDTaxTypes>.StringToNullableEnum(
+      TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/cac:Item/cac:ClassifiedTaxCategory/cac:TaxScheme/cbc:ID'));
+    Result.TaxPercent := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/cac:Item/cac:ClassifiedTaxCategory/cbc:Percent', 0);
+    Result.NetUnitPrice := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/cac:Price/cbc:PriceAmount', 0); // BT-146
 
-  // BT-147/BT-148: Der Preisnachlass haengt in UBL unter cac:Price und ist etwas anderes
-  // als die Zu- und Abschlaege der Position selbst (BG-27/BG-28) weiter unten.
-  var priceAllowanceChargeNode : IXMLDOMNode := tradeLineItem.selectSingleNode('./cac:Price/cac:AllowanceCharge');
-  var priceBasisAmount : ZUGFeRDNullable<Currency> := nil;
-  if priceAllowanceChargeNode <> nil then
-    priceBasisAmount := TZUGFeRDXmlUtils.NodeAsDecimal(priceAllowanceChargeNode, './cbc:BaseAmount'); // BT-148
+    // BT-147/BT-148: Der Preisnachlass haengt in UBL unter cac:Price und ist etwas anderes
+    // als die Zu- und Abschlaege der Position selbst (BG-27/BG-28) weiter unten.
+    var priceAllowanceChargeNode : IXMLDOMNode := tradeLineItem.selectSingleNode('./cac:Price/cac:AllowanceCharge');
+    var priceBasisAmount : ZUGFeRDNullable<Currency> := nil;
+    if priceAllowanceChargeNode <> nil then
+      priceBasisAmount := TZUGFeRDXmlUtils.NodeAsDecimal(priceAllowanceChargeNode, './cbc:BaseAmount'); // BT-148
 
-  if priceBasisAmount.HasValue then
-    Result.GrossUnitPrice := priceBasisAmount
-  else if priceAllowanceChargeNode <> nil then
-    // BT-148 ist optional; der Bruttopreis ist dann der Nettopreis zuzueglich des Nachlasses (BT-147)
-    Result.GrossUnitPrice := Result.NetUnitPrice.GetValueOrDefault +
-      TZUGFeRDXmlUtils.NodeAsDecimal(priceAllowanceChargeNode, './cbc:Amount', 0).GetValueOrDefault;
-  Result.UnitCode := unitCode;
-  Result.BillingPeriodStart := TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/cac:InvoicePeriod/cbc:StartDate');
-  Result.BillingPeriodEnd := TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/cac:InvoicePeriod/cbc:EndDate');
+    if priceBasisAmount.HasValue then
+      Result.GrossUnitPrice := priceBasisAmount
+    else if priceAllowanceChargeNode <> nil then
+      // BT-148 ist optional; der Bruttopreis ist dann der Nettopreis zuzueglich des Nachlasses (BT-147)
+      Result.GrossUnitPrice := Result.NetUnitPrice.GetValueOrDefault +
+        TZUGFeRDXmlUtils.NodeAsDecimal(priceAllowanceChargeNode, './cbc:Amount', 0).GetValueOrDefault;
+    Result.UnitCode := unitCode;
+    Result.BillingPeriodStart := TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/cac:InvoicePeriod/cbc:StartDate');
+    Result.BillingPeriodEnd := TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/cac:InvoicePeriod/cbc:EndDate');
 
-  if parentLineId <> '' then
-    Result.SetParentLineId(parentLineId);
+    if parentLineId <> '' then
+      Result.SetParentLineId(parentLineId);
 
-  // Commodity Classifications
-  nodes := tradeLineItem.selectNodes('.//cac:Item/cac:CommodityClassification/cbc:ItemClassificationCode');
-  if nodes <> nil then
-    for i := 0 to nodes.length - 1 do
-    begin
-      var listID : TZUGFeRDDesignatedProductClassificationClassCodes :=
-        TEnumExtensions<TZUGFeRDDesignatedProductClassificationClassCodes>.StringToEnum(
-          TZUGFeRDXmlUtils.NodeAsString(nodes[i], './@listID'));
-      var listVersionID : string := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './@listVersionID');
-      Result.AddDesignatedProductClassification(listID, listVersionID, nodes[i].text, '');
-    end;
-
-  // Product Characteristics (BG-32)
-  nodes := tradeLineItem.selectNodes('.//cac:Item/cac:AdditionalItemProperty');
-  if nodes <> nil then
-    for i := 0 to nodes.length - 1 do
-    begin
-      var apcItem : TZUGFeRDApplicableProductCharacteristic := TZUGFeRDApplicableProductCharacteristic.Create;
-      apcItem.Description := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/cbc:Name');
-      apcItem.Value := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/cbc:Value');
-      Result.ApplicableProductCharacteristics.Add(apcItem);
-    end;
-
-  // Buyer Order Referenced Document
-  if tradeLineItem.selectSingleNode('cac:OrderLineReference') <> nil then
-  begin
-    Result.BuyerOrderReferencedDocument := TZUGFeRDBuyerOrderReferencedDocument.Create;
-    Result.BuyerOrderReferencedDocument.ID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/cac:OrderLineReference/cbc:LineID');
-    Result.BuyerOrderReferencedDocument.LineID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/cac:OrderLineReference/cbc:LineID');
-  end;
-
-  // Additional Referenced Documents
-  nodes := tradeLineItem.selectNodes('.//cac:DocumentReference');
-  if nodes <> nil then
-    for i := 0 to nodes.length - 1 do
-    begin
-      var document : TZUGFeRDAdditionalReferencedDocument := TZUGFeRDAdditionalReferencedDocument.Create(false);
-      document.ID := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/cbc:ID');
-      document.ReferenceTypeCode := TEnumExtensions<TZUGFeRDReferenceTypeCodes>.StringToNullableEnum(
-        TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/cbc:ID/@schemeID'));
-      document.TypeCode := TEnumExtensions<TZUGFeRDAdditionalReferencedDocumentTypeCode>.StringToEnum(
-        TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/cbc:DocumentTypeCode'));
-      document.Name := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/cbc:DocumentDescription');
-
-      var binaryObjectNode : IXMLDOMNode := nodes[i].selectSingleNode('.//cac:Attachment/cbc:EmbeddedDocumentBinaryObject');
-      if binaryObjectNode <> nil then
+    // Commodity Classifications
+    nodes := tradeLineItem.selectNodes('.//cac:Item/cac:CommodityClassification/cbc:ItemClassificationCode');
+    if nodes <> nil then
+      for i := 0 to nodes.length - 1 do
       begin
-        var filenameAttr : IXMLDOMNode := binaryObjectNode.attributes.getNamedItem('filename');
-        if filenameAttr <> nil then
-          document.Filename := filenameAttr.text;
-        var strBase64BinaryData : string := binaryObjectNode.text;
-        if strBase64BinaryData <> '' then
-        begin
-          document.AttachmentBinaryObject := TMemoryStream.Create;
-          var strBase64BinaryDataBytes : TBytes := TNetEncoding.Base64.DecodeStringToBytes(strBase64BinaryData);
-          document.AttachmentBinaryObject.Write(strBase64BinaryDataBytes, Length(strBase64BinaryDataBytes));
+        var listID : TZUGFeRDDesignatedProductClassificationClassCodes :=
+          TEnumExtensions<TZUGFeRDDesignatedProductClassificationClassCodes>.StringToEnum(
+            TZUGFeRDXmlUtils.NodeAsString(nodes[i], './@listID'));
+        var listVersionID : string := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './@listVersionID');
+        Result.AddDesignatedProductClassification(listID, listVersionID, nodes[i].text, '');
+      end;
+
+    // Product Characteristics (BG-32)
+    nodes := tradeLineItem.selectNodes('.//cac:Item/cac:AdditionalItemProperty');
+    if nodes <> nil then
+      for i := 0 to nodes.length - 1 do
+      begin
+        var apcItem : TZUGFeRDApplicableProductCharacteristic := TZUGFeRDApplicableProductCharacteristic.Create;
+        try
+          apcItem.Description := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/cbc:Name');
+          apcItem.Value := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/cbc:Value');
+          Result.ApplicableProductCharacteristics.Add(apcItem);
+        except
+          apcItem.Free;
+          raise;
         end;
       end;
 
-      Result.AdditionalReferencedDocuments.Add(document);
-    end;
-
-  // Notes
-  nodes := tradeLineItem.selectNodes('.//cbc:Note');
-  if nodes <> nil then
-    for i := 0 to nodes.length - 1 do
-      Result.AssociatedDocument.Notes.Add(TZUGFeRDNote.Create(nodes[i].text));
-
-  // BG-27/BG-28: Zu- und Abschlaege der Position selbst. Nur direkte Kindknoten, denn der
-  // Preisnachlass unter cac:Price (BT-147/BT-148) ist ein anderes Konzept und wird darunter
-  // getrennt eingelesen.
-  nodes := tradeLineItem.selectNodes('./cac:AllowanceCharge');
-  if nodes <> nil then
-    for i := 0 to nodes.length - 1 do
+    // Buyer Order Referenced Document
+    if tradeLineItem.selectSingleNode('cac:OrderLineReference') <> nil then
     begin
-      var chargeIndicator : Boolean := TZUGFeRDXmlUtils.NodeAsBool(nodes[i], './cbc:ChargeIndicator');
-      var basisAmount : ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './cbc:BaseAmount'); // BT-137/BT-142
-      var basisAmountCurrency : string := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './cbc:BaseAmount/@currencyID');
-      var actualAmount : Currency := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './cbc:Amount', 0); // BT-136/BT-141
-      var reason : string := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './cbc:AllowanceChargeReason');
-      var reasonCode : string := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './cbc:AllowanceChargeReasonCode');
-      var chargePercentage : ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './cbc:MultiplierFactorNumeric'); // BT-138/BT-143
-
-      if chargeIndicator then // charge
-        Result.AddSpecifiedTradeCharge(
-          TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToEnum(basisAmountCurrency),
-          basisAmount, actualAmount, chargePercentage, reason,
-          TEnumExtensions<TZUGFeRDChargeReasonCodes>.StringToNullableEnum(reasonCode))
-      else // allowance
-        Result.AddSpecifiedTradeAllowance(
-          TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToEnum(basisAmountCurrency),
-          basisAmount, actualAmount, chargePercentage, reason,
-          TEnumExtensions<TZUGFeRDAllowanceReasonCodes>.StringToNullableEnum(reasonCode));
+      Result.BuyerOrderReferencedDocument := TZUGFeRDBuyerOrderReferencedDocument.Create;
+      Result.BuyerOrderReferencedDocument.ID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/cac:OrderLineReference/cbc:LineID');
+      Result.BuyerOrderReferencedDocument.LineID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/cac:OrderLineReference/cbc:LineID');
     end;
 
-  // BT-147/BT-148: Nachlass auf den Einzelpreis. UBL laesst davon einen je Position zu.
-  if priceAllowanceChargeNode <> nil then
-  begin
-    var priceChargeIndicator : Boolean := TZUGFeRDXmlUtils.NodeAsBool(priceAllowanceChargeNode, './cbc:ChargeIndicator');
-    var priceActualAmount : Currency := TZUGFeRDXmlUtils.NodeAsDecimal(priceAllowanceChargeNode, './cbc:Amount', 0); // BT-147
-    var priceCurrency : string := TZUGFeRDXmlUtils.NodeAsString(priceAllowanceChargeNode, './cbc:Amount/@currencyID');
-    var priceReason : string := TZUGFeRDXmlUtils.NodeAsString(priceAllowanceChargeNode, './cbc:AllowanceChargeReason');
-    var priceReasonCode : string := TZUGFeRDXmlUtils.NodeAsString(priceAllowanceChargeNode, './cbc:AllowanceChargeReasonCode');
+    // Additional Referenced Documents
+    nodes := tradeLineItem.selectNodes('.//cac:DocumentReference');
+    if nodes <> nil then
+      for i := 0 to nodes.length - 1 do
+      begin
+        var document : TZUGFeRDAdditionalReferencedDocument := TZUGFeRDAdditionalReferencedDocument.Create(false);
+        try
+          document.ID := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/cbc:ID');
+          document.ReferenceTypeCode := TEnumExtensions<TZUGFeRDReferenceTypeCodes>.StringToNullableEnum(
+            TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/cbc:ID/@schemeID'));
+          document.TypeCode := TEnumExtensions<TZUGFeRDAdditionalReferencedDocumentTypeCode>.StringToEnum(
+            TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/cbc:DocumentTypeCode'));
+          document.Name := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/cbc:DocumentDescription');
 
-    if priceChargeIndicator then // charge
-      Result.AddTradeCharge(
-        TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToEnum(priceCurrency),
-        priceBasisAmount, priceActualAmount, priceReason,
-        TEnumExtensions<TZUGFeRDChargeReasonCodes>.StringToNullableEnum(priceReasonCode))
-    else // allowance
-      Result.AddTradeAllowance(
-        TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToEnum(priceCurrency),
-        priceBasisAmount, priceActualAmount, priceReason,
-        TEnumExtensions<TZUGFeRDAllowanceReasonCodes>.StringToNullableEnum(priceReasonCode));
-  end;
+          var binaryObjectNode : IXMLDOMNode := nodes[i].selectSingleNode('.//cac:Attachment/cbc:EmbeddedDocumentBinaryObject');
+          if binaryObjectNode <> nil then
+          begin
+            var filenameAttr : IXMLDOMNode := binaryObjectNode.attributes.getNamedItem('filename');
+            if filenameAttr <> nil then
+              document.Filename := filenameAttr.text;
+            var strBase64BinaryData : string := binaryObjectNode.text;
+            if strBase64BinaryData <> '' then
+            begin
+              document.AttachmentBinaryObject := TMemoryStream.Create;
+              var strBase64BinaryDataBytes : TBytes := TNetEncoding.Base64.DecodeStringToBytes(strBase64BinaryData);
+              document.AttachmentBinaryObject.Write(strBase64BinaryDataBytes, Length(strBase64BinaryDataBytes));
+            end;
+          end;
 
-  // UnitCode fallback
-  if not Result.UnitCode.HasValue then
-  begin
-    if isInvoice then
-      Result.UnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToNullableEnum(
-        TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/cbc:InvoicedQuantity/@unitCode'))
-    else
-      Result.UnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToNullableEnum(
-        TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/cbc:CreditedQuantity/@unitCode'));
+          Result.AdditionalReferencedDocuments.Add(document);
+        except
+          document.Free;
+          raise;
+        end;
+      end;
+
+    // Notes
+    nodes := tradeLineItem.selectNodes('.//cbc:Note');
+    if nodes <> nil then
+      for i := 0 to nodes.length - 1 do
+      begin
+        var parsedItem := TZUGFeRDNote.Create(nodes[i].text);
+        try
+          Result.AssociatedDocument.Notes.Add(parsedItem);
+        except
+          parsedItem.Free;
+          raise;
+        end;
+      end;
+
+    // BG-27/BG-28: Zu- und Abschlaege der Position selbst. Nur direkte Kindknoten, denn der
+    // Preisnachlass unter cac:Price (BT-147/BT-148) ist ein anderes Konzept und wird darunter
+    // getrennt eingelesen.
+    nodes := tradeLineItem.selectNodes('./cac:AllowanceCharge');
+    if nodes <> nil then
+      for i := 0 to nodes.length - 1 do
+      begin
+        var chargeIndicator : Boolean := TZUGFeRDXmlUtils.NodeAsBool(nodes[i], './cbc:ChargeIndicator');
+        var basisAmount : ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './cbc:BaseAmount'); // BT-137/BT-142
+        var basisAmountCurrency : string := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './cbc:BaseAmount/@currencyID');
+        var actualAmount : Currency := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './cbc:Amount', 0); // BT-136/BT-141
+        var reason : string := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './cbc:AllowanceChargeReason');
+        var reasonCode : string := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './cbc:AllowanceChargeReasonCode');
+        var chargePercentage : ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './cbc:MultiplierFactorNumeric'); // BT-138/BT-143
+
+        if chargeIndicator then // charge
+          Result.AddSpecifiedTradeCharge(
+            TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToEnum(basisAmountCurrency),
+            basisAmount, actualAmount, chargePercentage, reason,
+            TEnumExtensions<TZUGFeRDChargeReasonCodes>.StringToNullableEnum(reasonCode))
+        else // allowance
+          Result.AddSpecifiedTradeAllowance(
+            TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToEnum(basisAmountCurrency),
+            basisAmount, actualAmount, chargePercentage, reason,
+            TEnumExtensions<TZUGFeRDAllowanceReasonCodes>.StringToNullableEnum(reasonCode));
+      end;
+
+    // BT-147/BT-148: Nachlass auf den Einzelpreis. UBL laesst davon einen je Position zu.
+    if priceAllowanceChargeNode <> nil then
+    begin
+      var priceChargeIndicator : Boolean := TZUGFeRDXmlUtils.NodeAsBool(priceAllowanceChargeNode, './cbc:ChargeIndicator');
+      var priceActualAmount : Currency := TZUGFeRDXmlUtils.NodeAsDecimal(priceAllowanceChargeNode, './cbc:Amount', 0); // BT-147
+      var priceCurrency : string := TZUGFeRDXmlUtils.NodeAsString(priceAllowanceChargeNode, './cbc:Amount/@currencyID');
+      var priceReason : string := TZUGFeRDXmlUtils.NodeAsString(priceAllowanceChargeNode, './cbc:AllowanceChargeReason');
+      var priceReasonCode : string := TZUGFeRDXmlUtils.NodeAsString(priceAllowanceChargeNode, './cbc:AllowanceChargeReasonCode');
+
+      if priceChargeIndicator then // charge
+        Result.AddTradeCharge(
+          TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToEnum(priceCurrency),
+          priceBasisAmount, priceActualAmount, priceReason,
+          TEnumExtensions<TZUGFeRDChargeReasonCodes>.StringToNullableEnum(priceReasonCode))
+      else // allowance
+        Result.AddTradeAllowance(
+          TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToEnum(priceCurrency),
+          priceBasisAmount, priceActualAmount, priceReason,
+          TEnumExtensions<TZUGFeRDAllowanceReasonCodes>.StringToNullableEnum(priceReasonCode));
+    end;
+
+    // UnitCode fallback
+    if not Result.UnitCode.HasValue then
+    begin
+      if isInvoice then
+        Result.UnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToNullableEnum(
+          TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/cbc:InvoicedQuantity/@unitCode'))
+      else
+        Result.UnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToNullableEnum(
+          TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/cbc:CreditedQuantity/@unitCode'));
+    end;
+  except
+    Result.Free;
+    raise;
   end;
 end;
 

--- a/intf.ZUGFeRDInvoiceDescriptor23CIIReader.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor23CIIReader.pas
@@ -745,124 +745,197 @@ begin
 
   Result := TZUGFeRDTradeLineItem.Create(lineId);
   try
-  Result.GlobalID.SchemeID := TEnumExtensions<TZUGFeRDGlobalIDSchemeIdentifiers>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:GlobalID/@schemeID'));
-  Result.GlobalID.ID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:GlobalID');
-  Result.SellerAssignedID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:SellerAssignedID');
-  Result.BuyerAssignedID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:BuyerAssignedID');
-  Result.IndustryAssignedID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:IndustryAssignedID');
-  Result.ModelID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:ModelID');
-  Result.Name := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:Name');
-  Result.Description := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:Description');
-  Result.BatchID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:BatchID');
-  Result.BrandName := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:BrandName');
-  Result.ModelName := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:ModelName');
-  Result.BilledQuantity := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:BilledQuantity', 0);
-  Result.ShipTo := _nodeAsParty(tradeLineItem, './/ram:SpecifiedLineTradeDelivery/ram:ShipToTradeParty');
-  Result.ShipToContact := _nodeAsContact(tradeLineItem, './/ram:SpecifiedLineTradeDelivery/ram:ShipToTradeParty/ram:DefinedTradeContact');
-  Result.UltimateShipTo := _nodeAsParty(tradeLineItem, './/ram:SpecifiedLineTradeDelivery/ram:UltimateShipToTradeParty');
-  Result.UltimateShipToContact := _nodeAsContact(tradeLineItem, './/ram:SpecifiedLineTradeDelivery/ram:UltimateShipToTradeParty/ram:DefinedTradeContact');
-  Result.ChargeFreeQuantity := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:ChargeFreeQuantity');
-  Result.PackageQuantity := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:PackageQuantity');
-  Result.LineTotalAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:LineTotalAmount');
-  Result.TaxCategoryCode := TEnumExtensions<TZUGFeRDTaxCategoryCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:ApplicableTradeTax/ram:CategoryCode'));
-  Result.TaxType := TEnumExtensions<TZUGFeRDTaxTypes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:ApplicableTradeTax/ram:TypeCode'));
-  Result.TaxPercent := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:ApplicableTradeTax/ram:RateApplicablePercent', 0);
-  Result.TaxExemptionReasonCode := TEnumExtensions<TZUGFeRDTaxExemptionReasonCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:ApplicableTradeTax/ram:ExemptionReasonCode'));
-  Result.TaxExemptionReason := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:ApplicableTradeTax/ram:ExemptionReason');
-  Result.NetUnitPrice:= TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:NetPriceProductTradePrice/ram:ChargeAmount');
-  Result.NetQuantity := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:NetPriceProductTradePrice/ram:BasisQuantity');
-  Result.NetUnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:NetPriceProductTradePrice/ram:BasisQuantity/@unitCode'));
-  Result.GrossUnitPrice:= TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:GrossPriceProductTradePrice/ram:ChargeAmount');
-  Result.GrossQuantity := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:GrossPriceProductTradePrice/ram:BasisQuantity');
-  Result.UnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:BilledQuantity/@unitCode'));
-  Result.ChargeFreeUnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:ChargeFreeQuantity/@unitCode'));
-  Result.PackageUnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:PackageQuantity/@unitCode'));
-  Result.GrossUnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:GrossPriceProductTradePrice/ram:BasisQuantity/@unitCode'));
-  Result.BillingPeriodStart := TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:BillingSpecifiedPeriod/ram:StartDateTime/udt:DateTimeString');
-  Result.BillingPeriodEnd := TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:BillingSpecifiedPeriod/ram:EndDateTime/udt:DateTimeString');
+    Result.GlobalID.SchemeID := TEnumExtensions<TZUGFeRDGlobalIDSchemeIdentifiers>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:GlobalID/@schemeID'));
+    Result.GlobalID.ID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:GlobalID');
+    Result.SellerAssignedID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:SellerAssignedID');
+    Result.BuyerAssignedID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:BuyerAssignedID');
+    Result.IndustryAssignedID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:IndustryAssignedID');
+    Result.ModelID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:ModelID');
+    Result.Name := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:Name');
+    Result.Description := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:Description');
+    Result.BatchID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:BatchID');
+    Result.BrandName := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:BrandName');
+    Result.ModelName := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedTradeProduct/ram:ModelName');
+    Result.BilledQuantity := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:BilledQuantity', 0);
+    Result.ShipTo := _nodeAsParty(tradeLineItem, './/ram:SpecifiedLineTradeDelivery/ram:ShipToTradeParty');
+    Result.ShipToContact := _nodeAsContact(tradeLineItem, './/ram:SpecifiedLineTradeDelivery/ram:ShipToTradeParty/ram:DefinedTradeContact');
+    Result.UltimateShipTo := _nodeAsParty(tradeLineItem, './/ram:SpecifiedLineTradeDelivery/ram:UltimateShipToTradeParty');
+    Result.UltimateShipToContact := _nodeAsContact(tradeLineItem, './/ram:SpecifiedLineTradeDelivery/ram:UltimateShipToTradeParty/ram:DefinedTradeContact');
+    Result.ChargeFreeQuantity := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:ChargeFreeQuantity');
+    Result.PackageQuantity := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:PackageQuantity');
+    Result.LineTotalAmount:= TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:LineTotalAmount');
+    Result.TaxCategoryCode := TEnumExtensions<TZUGFeRDTaxCategoryCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:ApplicableTradeTax/ram:CategoryCode'));
+    Result.TaxType := TEnumExtensions<TZUGFeRDTaxTypes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:ApplicableTradeTax/ram:TypeCode'));
+    Result.TaxPercent := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:ApplicableTradeTax/ram:RateApplicablePercent', 0);
+    Result.TaxExemptionReasonCode := TEnumExtensions<TZUGFeRDTaxExemptionReasonCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:ApplicableTradeTax/ram:ExemptionReasonCode'));
+    Result.TaxExemptionReason := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:ApplicableTradeTax/ram:ExemptionReason');
+    Result.NetUnitPrice:= TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:NetPriceProductTradePrice/ram:ChargeAmount');
+    Result.NetQuantity := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:NetPriceProductTradePrice/ram:BasisQuantity');
+    Result.NetUnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:NetPriceProductTradePrice/ram:BasisQuantity/@unitCode'));
+    Result.GrossUnitPrice:= TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:GrossPriceProductTradePrice/ram:ChargeAmount');
+    Result.GrossQuantity := TZUGFeRDXmlUtils.NodeAsDecimal(tradeLineItem, './/ram:GrossPriceProductTradePrice/ram:BasisQuantity');
+    Result.UnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:BilledQuantity/@unitCode'));
+    Result.ChargeFreeUnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:ChargeFreeQuantity/@unitCode'));
+    Result.PackageUnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:PackageQuantity/@unitCode'));
+    Result.GrossUnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:GrossPriceProductTradePrice/ram:BasisQuantity/@unitCode'));
+    Result.BillingPeriodStart := TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:BillingSpecifiedPeriod/ram:StartDateTime/udt:DateTimeString');
+    Result.BillingPeriodEnd := TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:BillingSpecifiedPeriod/ram:EndDateTime/udt:DateTimeString');
 
-  if parentLineId<>'' then
-    Result.SetParentLineId(parentLineId);
+    if parentLineId<>'' then
+      Result.SetParentLineId(parentLineId);
 
-  // Beide Felder werden unabhaengig voneinander uebernommen: die offiziellen
-  // ZUGFeRD-Beispiele nutzen LineStatusReasonCode (BT-X-9) auch ohne
-  // LineStatusCode (BT-X-8), z.B. in den Abschlagsrechnungen mit SubInvoiceLine.
-  if lineStatusCode.HasValue then
-    Result.AssociatedDocument.LineStatusCode := lineStatusCode;
-  if lineStatusReasonCode.HasValue then
-    Result.AssociatedDocument.LineStatusReasonCode := lineStatusReasonCode;
+    // Beide Felder werden unabhaengig voneinander uebernommen: die offiziellen
+    // ZUGFeRD-Beispiele nutzen LineStatusReasonCode (BT-X-9) auch ohne
+    // LineStatusCode (BT-X-8), z.B. in den Abschlagsrechnungen mit SubInvoiceLine.
+    if lineStatusCode.HasValue then
+      Result.AssociatedDocument.LineStatusCode := lineStatusCode;
+    if lineStatusReasonCode.HasValue then
+      Result.AssociatedDocument.LineStatusReasonCode := lineStatusReasonCode;
 
-  nodes := tradeLineItem.SelectNodes('.//ram:SpecifiedTradeProduct/ram:ApplicableProductCharacteristic');
-  for i := 0 to nodes.length-1 do
-  begin
-    var apcItem : TZUGFeRDApplicableProductCharacteristic := TZUGFeRDApplicableProductCharacteristic.Create;
-    try
-      apcItem.Description := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Description');
-      apcItem.Value := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Value');
-      Result.ApplicableProductCharacteristics.Add(apcItem);
-    except
-      // Until Add succeeds, the partially parsed line item does not own this child.
-      apcItem.Free;
-      raise;
-    end;
-  end;
-
-  nodes := tradeLineItem.SelectNodes('.//ram:SpecifiedTradeProduct/ram:IncludedReferencedProduct');
-  for i := 0 to nodes.length-1 do
-  begin
-    var irpItem: TZUGFeRDIncludedReferencedProduct := TZUGFeRDIncludedReferencedProduct.Create;
-    try
-      irpItem.GlobalID.SchemeID := TEnumExtensions<TZUGFeRDGlobalIDSchemeIdentifiers>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:GlobalID/@schemeID'));
-      irpItem.GlobalID.ID := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:GlobalID');
-      irpItem.SellerAssignedID := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:SellerAssignedID');
-      irpItem.BuyerAssignedID := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:BuyerAssignedID');
-      irpItem.IndustryAssignedID := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:IndustryAssignedID');
-      irpItem.Name := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Name');
-      irpItem.Description := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Description');
-      irpItem.UnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:UnitQuantity/@unitCode'));
-      irpItem.UnitQuantity:= TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:UnitQuantity');
-      Result.IncludedReferencedProducts.Add(irpItem);
-    except
-      irpItem.Free;
-      raise;
-    end;
-  end;
-
-  if (tradeLineItem.SelectSingleNode('.//ram:SpecifiedLineTradeAgreement/ram:BuyerOrderReferencedDocument') <> nil) then
-  begin
-    Result.BuyerOrderReferencedDocument:= TZUGFeRDBuyerOrderReferencedDocument.Create;
-    Result.BuyerOrderReferencedDocument.ID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedLineTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssuerAssignedID');
-    Result.BuyerOrderReferencedDocument.IssueDateTime := TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:SpecifiedLineTradeAgreement/ram:BuyerOrderReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString');
-    Result.BuyerOrderReferencedDocument.LineID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedLineTradeAgreement/ram:BuyerOrderReferencedDocument/ram:LineID');
-  end;
-
-  if (tradeLineItem.SelectSingleNode('.//ram:SpecifiedLineTradeAgreement/ram:SellerOrderReferencedDocument') <> nil) then
-  begin
-    Result.SellerOrderReferencedDocument:= TZUGFeRDSellerOrderReferencedDocument.Create;
-    Result.SellerOrderReferencedDocument.ID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedLineTradeAgreement/ram:SellerOrderReferencedDocument/ram:IssuerAssignedID');
-    Result.SellerOrderReferencedDocument.IssueDateTime := TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:SpecifiedLineTradeAgreement/ram:SellerOrderReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString');
-  end;
-
-  if (tradeLineItem.SelectSingleNode('.//ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument') <> nil) then
-  begin
-    Result.ContractReferencedDocument := TZUGFeRDContractReferencedDocument.Create;
-    Result.ContractReferencedDocument.ID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument/ram:IssuerAssignedID');
-    Result.ContractReferencedDocument.IssueDateTime:= TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString');
-    Result.ContractReferencedDocument.LineID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument/ram:LineID');
-  end;
-
-  // read SpecifiedLineTradeSettlement
-  if (tradeLineItem.SelectSingleNode('.//ram:SpecifiedLineTradeSettlement') <> nil) then
-  begin
-    var applicableTradeTaxNode: IXMLDOMNode:= tradeLineItem.SelectSingleNode('.//ram:SpecifiedLineTradeSettlement/ram:ApplicableTradeTax');
-    // TODO: process
-
-    var billingSpecifiedPeriodNode: IXMLDOMNode := tradeLineItem.SelectSingleNode('.//ram:SpecifiedLineTradeSettlement/ram:BillingSpecifiedPeriod');
-    // TODO: process
-
-    nodes := tradeLineItem.SelectNodes('.//ram:SpecifiedLineTradeSettlement/ram:SpecifiedTradeAllowanceCharge');
+    nodes := tradeLineItem.SelectNodes('.//ram:SpecifiedTradeProduct/ram:ApplicableProductCharacteristic');
     for i := 0 to nodes.length-1 do
     begin
+      var apcItem : TZUGFeRDApplicableProductCharacteristic := TZUGFeRDApplicableProductCharacteristic.Create;
+      try
+        apcItem.Description := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Description');
+        apcItem.Value := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Value');
+        Result.ApplicableProductCharacteristics.Add(apcItem);
+      except
+        // Until Add succeeds, the partially parsed line item does not own this child.
+        apcItem.Free;
+        raise;
+      end;
+    end;
+
+    nodes := tradeLineItem.SelectNodes('.//ram:SpecifiedTradeProduct/ram:IncludedReferencedProduct');
+    for i := 0 to nodes.length-1 do
+    begin
+      var irpItem: TZUGFeRDIncludedReferencedProduct := TZUGFeRDIncludedReferencedProduct.Create;
+      try
+        irpItem.GlobalID.SchemeID := TEnumExtensions<TZUGFeRDGlobalIDSchemeIdentifiers>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:GlobalID/@schemeID'));
+        irpItem.GlobalID.ID := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:GlobalID');
+        irpItem.SellerAssignedID := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:SellerAssignedID');
+        irpItem.BuyerAssignedID := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:BuyerAssignedID');
+        irpItem.IndustryAssignedID := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:IndustryAssignedID');
+        irpItem.Name := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Name');
+        irpItem.Description := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Description');
+        irpItem.UnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:UnitQuantity/@unitCode'));
+        irpItem.UnitQuantity:= TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:UnitQuantity');
+        Result.IncludedReferencedProducts.Add(irpItem);
+      except
+        irpItem.Free;
+        raise;
+      end;
+    end;
+
+    if (tradeLineItem.SelectSingleNode('.//ram:SpecifiedLineTradeAgreement/ram:BuyerOrderReferencedDocument') <> nil) then
+    begin
+      Result.BuyerOrderReferencedDocument:= TZUGFeRDBuyerOrderReferencedDocument.Create;
+      Result.BuyerOrderReferencedDocument.ID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedLineTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssuerAssignedID');
+      Result.BuyerOrderReferencedDocument.IssueDateTime := TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:SpecifiedLineTradeAgreement/ram:BuyerOrderReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString');
+      Result.BuyerOrderReferencedDocument.LineID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedLineTradeAgreement/ram:BuyerOrderReferencedDocument/ram:LineID');
+    end;
+
+    if (tradeLineItem.SelectSingleNode('.//ram:SpecifiedLineTradeAgreement/ram:SellerOrderReferencedDocument') <> nil) then
+    begin
+      Result.SellerOrderReferencedDocument:= TZUGFeRDSellerOrderReferencedDocument.Create;
+      Result.SellerOrderReferencedDocument.ID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedLineTradeAgreement/ram:SellerOrderReferencedDocument/ram:IssuerAssignedID');
+      Result.SellerOrderReferencedDocument.IssueDateTime := TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:SpecifiedLineTradeAgreement/ram:SellerOrderReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString');
+    end;
+
+    if (tradeLineItem.SelectSingleNode('.//ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument') <> nil) then
+    begin
+      Result.ContractReferencedDocument := TZUGFeRDContractReferencedDocument.Create;
+      Result.ContractReferencedDocument.ID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument/ram:IssuerAssignedID');
+      Result.ContractReferencedDocument.IssueDateTime:= TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString');
+      Result.ContractReferencedDocument.LineID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument/ram:LineID');
+    end;
+
+    // read SpecifiedLineTradeSettlement
+    if (tradeLineItem.SelectSingleNode('.//ram:SpecifiedLineTradeSettlement') <> nil) then
+    begin
+      var applicableTradeTaxNode: IXMLDOMNode:= tradeLineItem.SelectSingleNode('.//ram:SpecifiedLineTradeSettlement/ram:ApplicableTradeTax');
+      // TODO: process
+
+      var billingSpecifiedPeriodNode: IXMLDOMNode := tradeLineItem.SelectSingleNode('.//ram:SpecifiedLineTradeSettlement/ram:BillingSpecifiedPeriod');
+      // TODO: process
+
+      nodes := tradeLineItem.SelectNodes('.//ram:SpecifiedLineTradeSettlement/ram:SpecifiedTradeAllowanceCharge');
+      for i := 0 to nodes.length-1 do
+      begin
+        var chargeIndicator : Boolean := TZUGFeRDXmlUtils.NodeAsBool(nodes[i], './ram:ChargeIndicator/udt:Indicator');
+        var basisAmount : ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './ram:BasisAmount');
+        var basisAmountCurrency : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:BasisAmount/@currencyID');
+        var actualAmount : Currency := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './ram:ActualAmount',0);
+        var actualAmountCurrency : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:ActualAmount/@currencyID');
+        var reason : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:Reason');
+        var chargePercentage: ZUGFeRDNullable<Currency> :=TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './ram:CalculationPercent');
+        var reasonCode: String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:ReasonCode');
+
+          if chargeIndicator then
+            Result.AddSpecifiedTradeCharge(TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToEnum(basisAmountCurrency),
+                                                               basisAmount,
+                                                               actualAmount,
+                                                               chargePercentage,
+                                                               reason,
+                                                               TEnumExtensions<TZUGFeRDChargeReasonCodes>.StringToNullableEnum(reasonCode))
+          else // allowance
+            Result.AddSpecifiedTradeAllowance(TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToEnum(basisAmountCurrency),
+                                                                  basisAmount,
+                                                                  actualAmount,
+                                                                  chargePercentage,
+                                                                  reason,
+                                                                  TEnumExtensions<TZUGFeRDAllowanceReasonCodes>.StringToNullableEnum(reasonCode));
+      end;
+
+      var specifiedTradeSettlementLineMonetarySummationNode: IXMLDOMNode:= tradeLineItem.SelectSingleNode('.//ram:SpecifiedLineTradeSettlement/ram:SpecifiedTradeSettlementLineMonetarySummation');
+      if specifiedTradeSettlementLineMonetarySummationNode <> nil then
+        // Gesamtbetrag der Positionszu- und -abschlaege, nur EXTENDED
+        Result.TotalAllowanceChargeAmount := TZUGFeRDXmlUtils.NodeAsDecimal(
+          specifiedTradeSettlementLineMonetarySummationNode, './ram:TotalAllowanceChargeAmount');
+
+      nodes := tradeLineItem.SelectNodes('.//ram:SpecifiedLineTradeSettlement/ram:InvoiceReferencedDocument');
+      for i := 0 to nodes.length-1 do
+      begin
+        // TODO: process
+      end;
+    end;
+
+    nodes := tradeLineItem.SelectNodes('.//ram:SpecifiedLineTradeSettlement/ram:AdditionalReferencedDocument');
+    for i := 0 to nodes.length-1 do
+      Result.AdditionalReferencedDocuments.Add(_getAdditionalReferencedDocument(nodes[i]));
+
+    nodes := tradeLineItem.SelectNodes('.//ram:SpecifiedLineTradeSettlement/ram:ReceivableSpecifiedTradeAccountingAccount');
+    for i := 0 to nodes.length-1 do
+    begin
+      var rstaaItem : TZUGFeRDReceivableSpecifiedTradeAccountingAccount := TZUGFeRDReceivableSpecifiedTradeAccountingAccount.Create;
+      try
+        rstaaItem.TradeAccountID := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ID');
+        rstaaItem.TradeAccountTypeCode := TEnumExtensions<TZUGFeRDAccountingAccountTypeCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:TypeCode'));
+        Result.ReceivableSpecifiedTradeAccountingAccounts.Add(rstaaItem);
+      except
+        rstaaItem.Free;
+        raise;
+      end;
+      break; // an if above would have done it also <g>
+    end;
+
+    if (tradeLineItem.SelectSingleNode('.//ram:AssociatedDocumentLineDocument') <> nil) then
+    begin
+      nodes := tradeLineItem.SelectNodes('.//ram:AssociatedDocumentLineDocument/ram:IncludedNote');
+      for i := 0 to nodes.length-1 do
+        Result.AssociatedDocument.Notes.Add(
+          TZUGFeRDNote.Create(
+              TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Content'),
+              TEnumExtensions<TZUGFeRDSubjectCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:SubjectCode')),
+              TEnumExtensions<TZUGFeRDContentCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ContentCode'))
+        ));
+    end;
+
+    nodes := tradeLineItem.SelectNodes('.//ram:SpecifiedLineTradeAgreement/ram:GrossPriceProductTradePrice/ram:AppliedTradeAllowanceCharge');
+    for i := 0 to nodes.length-1 do
+    begin
+
       var chargeIndicator : Boolean := TZUGFeRDXmlUtils.NodeAsBool(nodes[i], './ram:ChargeIndicator/udt:Indicator');
       var basisAmount : ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './ram:BasisAmount');
       var basisAmountCurrency : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:BasisAmount/@currencyID');
@@ -870,121 +943,48 @@ begin
       var actualAmountCurrency : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:ActualAmount/@currencyID');
       var reason : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:Reason');
       var chargePercentage: ZUGFeRDNullable<Currency> :=TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './ram:CalculationPercent');
-      var reasonCode: String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:ReasonCode');
 
-        if chargeIndicator then
-          Result.AddSpecifiedTradeCharge(TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToEnum(basisAmountCurrency),
-                                                             basisAmount,
-                                                             actualAmount,
-                                                             chargePercentage,
-                                                             reason,
-                                                             TEnumExtensions<TZUGFeRDChargeReasonCodes>.StringToNullableEnum(reasonCode))
-        else // allowance
-          Result.AddSpecifiedTradeAllowance(TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToEnum(basisAmountCurrency),
-                                                                basisAmount,
-                                                                actualAmount,
-                                                                chargePercentage,
-                                                                reason,
-                                                                TEnumExtensions<TZUGFeRDAllowanceReasonCodes>.StringToNullableEnum(reasonCode));
+      if chargeIndicator then // charge
+        Result.AddTradeCharge(TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToEnum(basisAmountCurrency),
+                                      basisAmount,
+                                      actualAmount,
+                                      chargePercentage,
+                                      reason)
+      else // allowance
+        Result.AddTradeAllowance(TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToEnum(basisAmountCurrency),
+                                      basisAmount,
+                                      actualAmount,
+                                      chargePercentage,
+                                      reason);
     end;
 
-    var specifiedTradeSettlementLineMonetarySummationNode: IXMLDOMNode:= tradeLineItem.SelectSingleNode('.//ram:SpecifiedLineTradeSettlement/ram:SpecifiedTradeSettlementLineMonetarySummation');
-    if specifiedTradeSettlementLineMonetarySummationNode <> nil then
-      // Gesamtbetrag der Positionszu- und -abschlaege, nur EXTENDED
-      Result.TotalAllowanceChargeAmount := TZUGFeRDXmlUtils.NodeAsDecimal(
-        specifiedTradeSettlementLineMonetarySummationNode, './ram:TotalAllowanceChargeAmount');
+    if not Result.UnitCode.HasValue then
+      // UnitCode alternativ aus BilledQuantity extrahieren
+      Result.UnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:BilledQuantity/@unitCode'));
 
-    nodes := tradeLineItem.SelectNodes('.//ram:SpecifiedLineTradeSettlement/ram:InvoiceReferencedDocument');
+    if (tradeLineItem.SelectSingleNode('.//ram:SpecifiedLineTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssuerAssignedID') <> nil) then
+    begin
+      Result.DeliveryNoteReferencedDocument := TZUGFeRDDeliveryNoteReferencedDocument.Create;
+      Result.DeliveryNoteReferencedDocument.ID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedLineTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssuerAssignedID');
+      Result.DeliveryNoteReferencedDocument.IssueDateTime:= TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:SpecifiedLineTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString');
+      Result.DeliveryNoteReferencedDocument.LineID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedLineTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:LineID');
+    end;
+
+    if tradeLineItem.SelectSingleNode('.//ram:SpecifiedLineTradeDelivery/ram:ActualDeliverySupplyChainEvent/ram:OccurrenceDateTime') <> nil then
+      Result.ActualDeliveryDate:= TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:SpecifiedLineTradeDelivery/ram:ActualDeliverySupplyChainEvent/ram:OccurrenceDateTime/udt:DateTimeString');
+
+    nodes := tradeLineItem.SelectNodes('.//ram:DesignatedProductClassification');
     for i := 0 to nodes.length-1 do
     begin
-      // TODO: process
+      var className : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ClassName');
+      var classCode : string := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ClassCode');
+      var listID : TZUGFeRDDesignatedProductClassificationClassCodes := TEnumExtensions<TZUGFeRDDesignatedProductClassificationClassCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ClassCode/@listID'));
+      var listVersionID : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ClassCode/@listVersionID');
+      Result.AddDesignatedProductClassification(listID, listVersionID, classCode, className);
     end;
-  end;
 
-  nodes := tradeLineItem.SelectNodes('.//ram:SpecifiedLineTradeSettlement/ram:AdditionalReferencedDocument');
-  for i := 0 to nodes.length-1 do
-    Result.AdditionalReferencedDocuments.Add(_getAdditionalReferencedDocument(nodes[i]));
-
-  nodes := tradeLineItem.SelectNodes('.//ram:SpecifiedLineTradeSettlement/ram:ReceivableSpecifiedTradeAccountingAccount');
-  for i := 0 to nodes.length-1 do
-  begin
-    var rstaaItem : TZUGFeRDReceivableSpecifiedTradeAccountingAccount := TZUGFeRDReceivableSpecifiedTradeAccountingAccount.Create;
-    try
-      rstaaItem.TradeAccountID := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ID');
-      rstaaItem.TradeAccountTypeCode := TEnumExtensions<TZUGFeRDAccountingAccountTypeCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:TypeCode'));
-      Result.ReceivableSpecifiedTradeAccountingAccounts.Add(rstaaItem);
-    except
-      rstaaItem.Free;
-      raise;
-    end;
-    break; // an if above would have done it also <g>
-  end;
-
-  if (tradeLineItem.SelectSingleNode('.//ram:AssociatedDocumentLineDocument') <> nil) then
-  begin
-    nodes := tradeLineItem.SelectNodes('.//ram:AssociatedDocumentLineDocument/ram:IncludedNote');
-    for i := 0 to nodes.length-1 do
-      Result.AssociatedDocument.Notes.Add(
-        TZUGFeRDNote.Create(
-            TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:Content'),
-            TEnumExtensions<TZUGFeRDSubjectCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:SubjectCode')),
-            TEnumExtensions<TZUGFeRDContentCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ContentCode'))
-      ));
-  end;
-
-  nodes := tradeLineItem.SelectNodes('.//ram:SpecifiedLineTradeAgreement/ram:GrossPriceProductTradePrice/ram:AppliedTradeAllowanceCharge');
-  for i := 0 to nodes.length-1 do
-  begin
-
-    var chargeIndicator : Boolean := TZUGFeRDXmlUtils.NodeAsBool(nodes[i], './ram:ChargeIndicator/udt:Indicator');
-    var basisAmount : ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './ram:BasisAmount');
-    var basisAmountCurrency : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:BasisAmount/@currencyID');
-    var actualAmount : Currency := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './ram:ActualAmount',0);
-    var actualAmountCurrency : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:ActualAmount/@currencyID');
-    var reason : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:Reason');
-    var chargePercentage: ZUGFeRDNullable<Currency> :=TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './ram:CalculationPercent');
-
-    if chargeIndicator then // charge
-      Result.AddTradeCharge(TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToEnum(basisAmountCurrency),
-                                    basisAmount,
-                                    actualAmount,
-                                    chargePercentage,
-                                    reason)
-    else // allowance
-      Result.AddTradeAllowance(TEnumExtensions<TZUGFeRDCurrencyCodes>.StringToEnum(basisAmountCurrency),
-                                    basisAmount,
-                                    actualAmount,
-                                    chargePercentage,
-                                    reason);
-  end;
-
-  if not Result.UnitCode.HasValue then
-    // UnitCode alternativ aus BilledQuantity extrahieren
-    Result.UnitCode := TEnumExtensions<TZUGFeRDQuantityCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:BilledQuantity/@unitCode'));
-
-  if (tradeLineItem.SelectSingleNode('.//ram:SpecifiedLineTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssuerAssignedID') <> nil) then
-  begin
-    Result.DeliveryNoteReferencedDocument := TZUGFeRDDeliveryNoteReferencedDocument.Create;
-    Result.DeliveryNoteReferencedDocument.ID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedLineTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssuerAssignedID');
-    Result.DeliveryNoteReferencedDocument.IssueDateTime:= TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:SpecifiedLineTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString');
-    Result.DeliveryNoteReferencedDocument.LineID := TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:SpecifiedLineTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:LineID');
-  end;
-
-  if tradeLineItem.SelectSingleNode('.//ram:SpecifiedLineTradeDelivery/ram:ActualDeliverySupplyChainEvent/ram:OccurrenceDateTime') <> nil then
-    Result.ActualDeliveryDate:= TZUGFeRDXmlUtils.NodeAsDateTime(tradeLineItem, './/ram:SpecifiedLineTradeDelivery/ram:ActualDeliverySupplyChainEvent/ram:OccurrenceDateTime/udt:DateTimeString');
-
-  nodes := tradeLineItem.SelectNodes('.//ram:DesignatedProductClassification');
-  for i := 0 to nodes.length-1 do
-  begin
-    var className : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ClassName');
-    var classCode : string := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ClassCode');
-    var listID : TZUGFeRDDesignatedProductClassificationClassCodes := TEnumExtensions<TZUGFeRDDesignatedProductClassificationClassCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ClassCode/@listID'));
-    var listVersionID : String := TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:ClassCode/@listVersionID');
-    Result.AddDesignatedProductClassification(listID, listVersionID, classCode, className);
-  end;
-
-  if tradeLineItem.SelectSingleNode('.//ram:OriginTradeCountry//ram:ID') <> nil then
-    Result.OriginTradeCountry := TEnumExtensions<TZUGFeRDCountryCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:OriginTradeCountry//ram:ID'));
+    if tradeLineItem.SelectSingleNode('.//ram:OriginTradeCountry//ram:ID') <> nil then
+      Result.OriginTradeCountry := TEnumExtensions<TZUGFeRDCountryCodes>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(tradeLineItem, './/ram:OriginTradeCountry//ram:ID'));
   except
     // Load cannot release this line until it has been returned and added to TradeLineItems.
     Result.Free;
@@ -992,6 +992,7 @@ begin
   end;
 end;
 
+/// <summary>Evaluates XML fields before construction; constructor failure releases its own instance.</summary>
 function TZUGFeRDInvoiceDescriptor23CIIReader._nodeAsLegalOrganization(
   basenode: IXmlDomNode; const xpath: string) : TZUGFeRDLegalOrganization;
 var
@@ -1009,6 +1010,7 @@ begin
                TZUGFeRDXmlUtils.NodeAsString(node, 'ram:TradingBusinessName'));
 end;
 
+/// <summary>Transfers the parsed result to the caller only after successful loading.</summary>
 function TZUGFeRDInvoiceDescriptor23CIIReader._nodeAsContact(basenode: IXmlDomNode;  const xpath: string) : TZUGFeRDContact;
 var
   node : IXmlDomNode;
@@ -1020,13 +1022,19 @@ begin
   if (node = nil) then
     exit;
   Result := TZUGFeRDContact.Create;
-  Result.Name := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PersonName');
-  Result.OrgUnit := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:DepartmentName');
-  Result.PhoneNo := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:TelephoneUniversalCommunication/ram:CompleteNumber');
-  Result.FaxNo := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:FaxUniversalCommunication/ram:CompleteNumber');
-  Result.EmailAddress := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:EmailURIUniversalCommunication/ram:URIID');
+  try
+    Result.Name := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PersonName');
+    Result.OrgUnit := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:DepartmentName');
+    Result.PhoneNo := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:TelephoneUniversalCommunication/ram:CompleteNumber');
+    Result.FaxNo := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:FaxUniversalCommunication/ram:CompleteNumber');
+    Result.EmailAddress := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:EmailURIUniversalCommunication/ram:URIID');
+  except
+    Result.Free;
+    raise;
+  end;
 end;
 
+/// <summary>Transfers the parsed result to the caller only after successful loading.</summary>
 function TZUGFeRDInvoiceDescriptor23CIIReader._nodeAsParty(basenode: IXmlDomNode;  const xpath: string) : TZUGFeRDParty;
 var
   node : IXmlDomNode;
@@ -1039,33 +1047,38 @@ begin
   if (node = nil) then
     exit;
   Result := TZUGFeRDParty.Create;
-  Result.ID.SchemeID := TEnumExtensions<TZUGFeRDGlobalIDSchemeIdentifiers>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(node, 'ram:ID/@schemeID'));
-  Result.ID.ID := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:ID');
-  Result.GlobalID.SchemeID := TEnumExtensions<TZUGFeRDGlobalIDSchemeIdentifiers>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(node, 'ram:GlobalID/@schemeID'));
-  Result.GlobalID.ID := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:GlobalID');
-  Result.Name := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:Name');
-  Result.Description := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:Description'); // Seller only BT-33
-  Result.Postcode := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:PostcodeCode');
-  Result.City := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:CityName');
-  Result.Country := TEnumExtensions<TZUGFeRDCountryCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:CountryID'));
-  Result.SpecifiedLegalOrganization := _nodeAsLegalOrganization(node, 'ram:SpecifiedLegalOrganization');
+  try
+    Result.ID.SchemeID := TEnumExtensions<TZUGFeRDGlobalIDSchemeIdentifiers>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(node, 'ram:ID/@schemeID'));
+    Result.ID.ID := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:ID');
+    Result.GlobalID.SchemeID := TEnumExtensions<TZUGFeRDGlobalIDSchemeIdentifiers>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(node, 'ram:GlobalID/@schemeID'));
+    Result.GlobalID.ID := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:GlobalID');
+    Result.Name := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:Name');
+    Result.Description := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:Description'); // Seller only BT-33
+    Result.Postcode := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:PostcodeCode');
+    Result.City := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:CityName');
+    Result.Country := TEnumExtensions<TZUGFeRDCountryCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:CountryID'));
+    Result.SpecifiedLegalOrganization := _nodeAsLegalOrganization(node, 'ram:SpecifiedLegalOrganization');
 
-  lineOne := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:LineOne');
-  lineTwo := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:LineTwo');
+    lineOne := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:LineOne');
+    lineTwo := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:LineTwo');
 
-  if (not lineTwo.IsEmpty) then
-  begin
-    Result.Street2 := lineOne;
-    Result.ContactName := lineOne; // backward compatibility
-    Result.Street := lineTwo;
-  end else
-  begin
-    Result.Street := lineOne;
-    Result.Street2 := '';
-    Result.ContactName := '';
+    if (not lineTwo.IsEmpty) then
+    begin
+      Result.Street2 := lineOne;
+      Result.ContactName := lineOne; // backward compatibility
+      Result.Street := lineTwo;
+    end else
+    begin
+      Result.Street := lineOne;
+      Result.Street2 := '';
+      Result.ContactName := '';
+    end;
+    Result.AddressLine3 := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:LineThree');
+    Result.CountrySubdivisionName := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:CountrySubDivisionName');
+  except
+    Result.Free;
+    raise;
   end;
-  Result.AddressLine3 := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:LineThree');
-  Result.CountrySubdivisionName := TZUGFeRDXmlUtils.NodeAsString(node, 'ram:PostalTradeAddress/ram:CountrySubDivisionName');
 end;
 
 function TZUGFeRDInvoiceDescriptor23CIIReader._getAdditionalReferencedDocument(a_oXmlNode: IXmlDomNode): TZUGFeRDAdditionalReferencedDocument;
@@ -1073,20 +1086,20 @@ begin
   var strBase64BinaryData : String := TZUGFeRDXmlUtils.NodeAsString(a_oXmlNode, 'ram:AttachmentBinaryObject');
   Result := TZUGFeRDAdditionalReferencedDocument.Create(false);
   try
-  Result.ID := TZUGFeRDXmlUtils.NodeAsString(a_oXmlNode, 'ram:IssuerAssignedID');
-  Result.TypeCode := TEnumExtensions<TZUGFeRDAdditionalReferencedDocumentTypeCode>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(a_oXmlNode, 'ram:TypeCode'));
-  Result.Name := TZUGFeRDXmlUtils.NodeAsString(a_oXmlNode, 'ram:Name');
-  Result.IssueDateTime:= TZUGFeRDXmlUtils.NodeAsDateTime(a_oXmlNode, 'ram:FormattedIssueDateTime/qdt:DateTimeString');
-  if strBase64BinaryData <> '' then
-  begin
-    Result.AttachmentBinaryObject := TMemoryStream.Create;
-    var strBase64BinaryDataBytes : TBytes := TNetEncoding.Base64.DecodeStringToBytes(strBase64BinaryData);
-    Result.AttachmentBinaryObject.Write(strBase64BinaryDataBytes,Length(strBase64BinaryDataBytes));
-  end;
-  Result.Filename := TZUGFeRDXmlUtils.NodeAsString(a_oXmlNode, 'ram:AttachmentBinaryObject/@filename');
-  Result.ReferenceTypeCode := TEnumExtensions<TZUGFeRDReferenceTypeCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(a_oXmlNode, 'ram:ReferenceTypeCode'));
-  Result.URIID := TZUGFeRDXmlUtils.NodeAsString(a_oXmlNode, 'ram:URIID');
-  Result.LineID := TZUGFeRDXmlUtils.NodeAsString(a_oXmlNode, 'ram:LineID');
+    Result.ID := TZUGFeRDXmlUtils.NodeAsString(a_oXmlNode, 'ram:IssuerAssignedID');
+    Result.TypeCode := TEnumExtensions<TZUGFeRDAdditionalReferencedDocumentTypeCode>.StringToEnum(TZUGFeRDXmlUtils.NodeAsString(a_oXmlNode, 'ram:TypeCode'));
+    Result.Name := TZUGFeRDXmlUtils.NodeAsString(a_oXmlNode, 'ram:Name');
+    Result.IssueDateTime:= TZUGFeRDXmlUtils.NodeAsDateTime(a_oXmlNode, 'ram:FormattedIssueDateTime/qdt:DateTimeString');
+    if strBase64BinaryData <> '' then
+    begin
+      Result.AttachmentBinaryObject := TMemoryStream.Create;
+      var strBase64BinaryDataBytes : TBytes := TNetEncoding.Base64.DecodeStringToBytes(strBase64BinaryData);
+      Result.AttachmentBinaryObject.Write(strBase64BinaryDataBytes,Length(strBase64BinaryDataBytes));
+    end;
+    Result.Filename := TZUGFeRDXmlUtils.NodeAsString(a_oXmlNode, 'ram:AttachmentBinaryObject/@filename');
+    Result.ReferenceTypeCode := TEnumExtensions<TZUGFeRDReferenceTypeCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(a_oXmlNode, 'ram:ReferenceTypeCode'));
+    Result.URIID := TZUGFeRDXmlUtils.NodeAsString(a_oXmlNode, 'ram:URIID');
+    Result.LineID := TZUGFeRDXmlUtils.NodeAsString(a_oXmlNode, 'ram:LineID');
   except
     // The reference owns the stream even if decoding or later field parsing fails.
     Result.Free;

--- a/intf.ZUGFeRDProfileAwareXmlTextWriter.pas
+++ b/intf.ZUGFeRDProfileAwareXmlTextWriter.pas
@@ -1,4 +1,4 @@
-{* Licensed to the Apache Software Foundation (ASF) under one
+﻿{* Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file


### PR DESCRIPTION
## Summary

Follow-up to #116, based directly on the merged `main` branch.

- Release partially parsed descriptors, lines and untransferred child objects in the ZUGFeRD 1.0, CII 2.0 and UBL readers. Protect the CII 2.3 party/contact helpers as well. Preserve the original exceptions and caller-owned input streams.
- Populate the UBL party identifiers already allocated by the constructor instead of replacing and leaking them. This also fixes heap growth on successful Invoice/CreditNote loads without changing identifier routing or the public properties.
- Replace seven identical positive CII 2.3 ownership cases with one common valid document, retaining all seven distinct date-error cases. Check warmup results and clarify attachment-cleanup coverage. The added outer guards account for much of the reader indentation diff.
- Add UTF-8 BOMs to the eight reviewed non-ASCII units, verify a compiled assertion diagnostic against its Unicode code point, and add a scoped encoding check with counterexamples.
- Document and test exact parameterized-case selection, zero-test method selection and stale reports after early option errors. Keep `Free` and the existing public interfaces.

## Verification

- Delphi 11, Win64 Debug: console and GUI builds succeed without errors, warnings or hints.
- Console suite: **418 tests passed**. Runner/encoding verification: **29 process checks passed**, plus three targeted rounding/documentation-fixture checks.
- Four document variants cover direct readers and automatic dispatch: CII 1.0, CII 2.0 EXTENDED, UBL Invoice and UBL CreditNote. Four successful cases, eight early/late date-error cases and two payment-term error cases use warmed allocated-heap comparisons. The original readers fail the relevant heap counterexamples; the corrected readers pass.
- Isolated removal of descriptor, line and payment-term cleanup produces the expected 10, 4 and 2 failing reader cases. Removing CII 2.3 line/reference cleanup is detected by 5 and 4 cases respectively.
- Six isolated fault-injection pairs exercise product characteristics, included products, accounting accounts, an allocated reference stream, a party with a nested legal organization, and a contact. Each injected error passes with cleanup retained and produces heap growth when that specific cleanup is removed. No injection hooks are added to production code.
- The Unicode diagnostic test fails without the source BOM and passes with it. Encoding probes reject missing BOMs, malformed UTF-8 and missing files; valid UTF-8/BOM and ASCII files pass.

These are scoped ownership and regression checks, not a claim of general leak freedom or exhaustive COM/allocation/I/O failure coverage. Line-total validation/recalculation and the general owning-setter work package are not changed by this PR.
