### PR TITLE
Preserve nullable tax amounts and tolerate incomplete advance payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,24 @@ amount of zero are not the same thing.
 BIS document reads back as `Unknown` rather than `XRechnung`, and cannot be written out again
 unchanged. The raw identifier is always kept in `GuideLine`.
 
+### Steuerbeträge und fehlende Anzahlungsdaten
+
+`TZUGFeRDTax.TaxAmount` und der Parameter `calculatedAmount` von `AddApplicableTradeTax`
+haben den Typ `ZUGFeRDNullable<Currency>`. Ein neues Steuerobjekt hat keinen Betrag;
+die Zuweisung `TaxAmount := 0` setzt dagegen einen vorhandenen Nullbetrag. Numerische
+Zuweisungen bleiben möglich. Bei Berechnungen und Vergleichen zuerst `HasValue` prüfen
+und anschließend `Value` verwenden. Der Betrag wird nicht automatisch aus Basis und
+Steuersatz berechnet. Abhängige Anwendungen müssen neu kompiliert werden.
+
+Der CII-Reader erhält fehlende Pflichtangaben in `SpecifiedAdvancePayment` (BG-X-45),
+statt deshalb den übrigen Beleg abzulehnen. Fehlende Beträge und Steuercodes bleiben
+ohne Wert, eine fehlende Steuerliste bleibt leer; eine vorhandene Rechnungsreferenz
+bleibt auch ohne ID erhalten. Nichtleere, unlesbare Pflichtbeträge und Steuercodes
+bleiben Lesefehler. Das tolerante Lesen bestätigt keine Standardkonformität:
+Der EXTENDED-Writer lehnt unvollständige Anzahlungen weiterhin ab, insbesondere einen
+fehlenden Steuerbetrag BT-X-293 nach `FX-SCH-A-000952`. Auch die Kopfsteuer-Writer
+verlangen vorhandene Beträge; der Summenvalidator meldet fehlendes BT-117.
+
 ## Validating totals
 
 `TZUGFeRDInvoiceValidator` recalculates the monetary summation of a loaded or newly built invoice and

--- a/README.md
+++ b/README.md
@@ -182,11 +182,14 @@ Zuweisungen bleiben möglich. Bei Berechnungen und Vergleichen zuerst `HasValue`
 und anschließend `Value` verwenden. Der Betrag wird nicht automatisch aus Basis und
 Steuersatz berechnet. Abhängige Anwendungen müssen neu kompiliert werden.
 
-Der CII-Reader erhält fehlende Pflichtangaben in `SpecifiedAdvancePayment` (BG-X-45),
-statt deshalb den übrigen Beleg abzulehnen. Fehlende Beträge und Steuercodes bleiben
+Der CII-Reader erhält Anzahlungen in `SpecifiedAdvancePayment` (BG-X-45) auch bei
+fehlenden oder unlesbaren Pflichtangaben, statt deshalb den übrigen Beleg abzulehnen.
+Fehlende oder unlesbare Pflichtbeträge und unbekannte Steuercodes bleiben
 ohne Wert, eine fehlende Steuerliste bleibt leer; eine vorhandene Rechnungsreferenz
-bleibt auch ohne ID erhalten. Nichtleere, unlesbare Pflichtbeträge und Steuercodes
-bleiben Lesefehler. Das tolerante Lesen bestätigt keine Standardkonformität:
+bleibt auch ohne ID erhalten. Ein leerer Nullable unterscheidet fehlende und
+unlesbare Werte nicht; der ursprüngliche ungültige Text wird nicht gespeichert.
+XML-, Datei-, Stream- und Datumsfehler werden nicht zusätzlich abgefangen.
+Das tolerante Lesen bestätigt keine Standardkonformität:
 Der EXTENDED-Writer lehnt unvollständige Anzahlungen weiterhin ab, insbesondere einen
 fehlenden Steuerbetrag BT-X-293 nach `FX-SCH-A-000952`. Auch die Kopfsteuer-Writer
 verlangen vorhandene Beträge; der Summenvalidator meldet fehlendes BT-117.

--- a/Unittest/intf.ZUGFeRD22Tests.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRD22Tests.UnitTests.pas
@@ -42,7 +42,19 @@ type
     [Test]
     procedure TestNilAdvancePaymentValidation;
     [Test]
-    procedure TestAdvancePaymentReaderRejectsMissingMandatoryData;
+    [TestCase('ValidAmount', 'None')]
+    [TestCase('ExplicitZero', 'Zero')]
+    [TestCase('MissingPaidAmount', 'PaidAmount')]
+    [TestCase('MissingIncludedTradeTax', 'IncludedTradeTax')]
+    [TestCase('MissingCalculatedAmount', 'CalculatedAmount')]
+    [TestCase('MissingTypeCode', 'TypeCode')]
+    [TestCase('MissingCategoryCode', 'CategoryCode')]
+    [TestCase('MissingReferenceID', 'IssuerAssignedID')]
+    [TestCase('InvalidPaidAmount', 'InvalidPaidAmount')]
+    [TestCase('InvalidCalculatedAmount', 'InvalidCalculatedAmount')]
+    [TestCase('InvalidTypeCode', 'InvalidTypeCode')]
+    [TestCase('InvalidCategoryCode', 'InvalidCategoryCode')]
+    procedure TestAdvancePaymentReaderPreservesMissingMandatoryData(const missingField: string);
     [Test]
     procedure TestCIIReaderReleasesDescriptorAfterParsingError;
     /// <summary>Checks one valid document and seven distinct date failures before and after ownership transfer.</summary>
@@ -745,8 +757,12 @@ begin
     AssertSaveRaisesMissingData;
 
     includedTax := TZUGFeRDTax.Create;
-    includedTax.TypeCode := nil;
     advancePayment.IncludedTradeTaxes.Add(includedTax);
+    Assert.IsFalse(includedTax.TaxAmount.HasValue);
+    AssertSaveRaisesMissingData;
+
+    includedTax.TaxAmount := 0;
+    includedTax.TypeCode := nil;
     AssertSaveRaisesMissingData;
 
     includedTax.TypeCode := TZUGFeRDTaxTypes.VAT;
@@ -799,57 +815,146 @@ begin
 end;
 
 /// <summary>
-/// Prüft, dass fehlende XML-Pflichtwerte nicht als Nullwerte übernommen werden.
+/// Bewahrt fehlende BG-X-45-Pflichtwerte ohne erfundene Nullwerte oder Verlust des
+/// übrigen Belegs. Nur die gültigen Kontrollen dürfen wieder geschrieben werden.
+/// Nichtleere, ungültige Beträge/Codes bleiben dagegen Lesefehler.
+/// Aufgewärmte Lade-/Schreibzyklen prüfen zugleich die geänderten Besitzpfade.
 /// </summary>
-procedure TZUGFeRD22Tests.TestAdvancePaymentReaderRejectsMissingMandatoryData;
+procedure TZUGFeRD22Tests.TestAdvancePaymentReaderPreservesMissingMandatoryData(const missingField: string);
 var
   desc: TZUGFeRDInvoiceDescriptor;
   advancePayment: TZUGFeRDAdvancePayment;
   includedTax: TZUGFeRDTax;
   stream: TMemoryStream;
   bytes: TBytes;
-  xmlContent: string;
+  xmlContent, advanceXml, fieldName, removedFieldXml, changedAdvanceXml: string;
+  firstBatchMemory, secondBatchMemory: NativeUInt;
+  invalidValue: Boolean;
 
-  procedure AssertRemovalRaisesMissingData(const pattern: string);
+  // Prüft den geladenen Inhalt vor dem erneuten Schreiben, nicht nur Ausnahmefreiheit.
+  procedure LoadAndCheck;
   var
-    invalidXml: string;
-    invalidStream: TStringStream;
+    inputStream: TStringStream;
+    outputStream: TMemoryStream;
     loadedInvoice: TZUGFeRDInvoiceDescriptor;
+    loadedPayment: TZUGFeRDAdvancePayment;
+    loadedTax: TZUGFeRDTax;
+    expectedAmount: Currency;
   begin
-    invalidXml := TRegEx.Replace(xmlContent, pattern, '', [roSingleLine]);
-    Assert.IsTrue(invalidXml <> xmlContent, 'Das zu entfernende XML-Pflichtfeld wurde nicht gefunden.');
-
-    invalidStream := TStringStream.Create(invalidXml, TEncoding.UTF8);
-    loadedInvoice := nil;
+    inputStream := TStringStream.Create(xmlContent, TEncoding.UTF8);
     try
-      Assert.WillRaise(
-        procedure
+      if invalidValue then
+      begin
+        Assert.WillRaise(
+          procedure
+          var
+            unexpectedInvoice: TZUGFeRDInvoiceDescriptor;
+          begin
+            unexpectedInvoice := TZUGFeRDInvoiceDescriptor.Load(inputStream);
+            unexpectedInvoice.Free;
+          end,
+          TZUGFeRDMissingDataException);
+        Exit;
+      end;
+      loadedInvoice := TZUGFeRDInvoiceDescriptor.Load(inputStream);
+      try
+        Assert.AreEqual(desc.InvoiceNo, loadedInvoice.InvoiceNo);
+        Assert.AreEqual(Integer(desc.TradeLineItems.Count), Integer(loadedInvoice.TradeLineItems.Count));
+        Assert.AreEqual(desc.TradeLineItems[0].Name, loadedInvoice.TradeLineItems[0].Name);
+        Assert.AreEqual<Currency>(desc.GrandTotalAmount.Value, loadedInvoice.GrandTotalAmount.Value);
+        Assert.AreEqual<Currency>(desc.TotalPrepaidAmount.Value, loadedInvoice.TotalPrepaidAmount.Value);
+        Assert.AreEqual<Currency>(desc.Taxes[0].TaxAmount.Value, loadedInvoice.Taxes[0].TaxAmount.Value);
+        Assert.AreEqual(1, Integer(loadedInvoice.AdvancePayments.Count));
+        loadedPayment := loadedInvoice.AdvancePayments[0];
+        Assert.AreEqual(missingField <> 'PaidAmount', loadedPayment.PaidAmount.HasValue);
+        if loadedPayment.PaidAmount.HasValue then
+          Assert.AreEqual<Currency>(2975, loadedPayment.PaidAmount.Value);
+        Assert.AreEqual(EncodeDate(2025, 6, 7), loadedPayment.FormattedReceivedDateTime.Value);
+
+        if missingField = 'IncludedTradeTax' then
+          Assert.AreEqual(0, Integer(loadedPayment.IncludedTradeTaxes.Count))
+        else
         begin
-          invalidStream.Position := 0;
-          loadedInvoice := TZUGFeRDInvoiceDescriptor.Load(invalidStream);
-        end,
-        TZUGFeRDMissingDataException);
+          Assert.AreEqual(1, Integer(loadedPayment.IncludedTradeTaxes.Count));
+          loadedTax := loadedPayment.IncludedTradeTaxes[0];
+          Assert.AreEqual(missingField <> 'CalculatedAmount', loadedTax.TaxAmount.HasValue);
+          if loadedTax.TaxAmount.HasValue then
+          begin
+            expectedAmount := 1900;
+            if missingField = 'Zero' then
+              expectedAmount := 0;
+            Assert.AreEqual<Currency>(expectedAmount, loadedTax.TaxAmount.Value);
+          end;
+          Assert.AreEqual(missingField <> 'TypeCode', loadedTax.TypeCode.HasValue);
+          if loadedTax.TypeCode.HasValue then
+            Assert.AreEqual<TZUGFeRDTaxTypes>(TZUGFeRDTaxTypes.VAT, loadedTax.TypeCode.Value);
+          Assert.AreEqual(missingField <> 'CategoryCode', loadedTax.CategoryCode.HasValue);
+          if loadedTax.CategoryCode.HasValue then
+            Assert.AreEqual<TZUGFeRDTaxCategoryCodes>(TZUGFeRDTaxCategoryCodes.S, loadedTax.CategoryCode.Value);
+        end;
+
+        Assert.IsNotNull(loadedPayment.InvoiceSpecifiedReferencedDocument);
+        if missingField = 'IssuerAssignedID' then
+          Assert.AreEqual('', loadedPayment.InvoiceSpecifiedReferencedDocument.ID)
+        else
+          Assert.AreEqual('R202506-01', loadedPayment.InvoiceSpecifiedReferencedDocument.ID);
+        Assert.AreEqual(EncodeDate(2025, 6, 1), loadedPayment.InvoiceSpecifiedReferencedDocument.IssueDateTime.Value);
+        Assert.AreEqual<TZUGFeRDInvoiceType>(TZUGFeRDInvoiceType.PartialInvoice,
+          loadedPayment.InvoiceSpecifiedReferencedDocument.TypeCode.Value);
+
+        outputStream := TMemoryStream.Create;
+        try
+          if (missingField = 'None') or (missingField = 'Zero') then
+          begin
+            loadedInvoice.Save(outputStream, TZUGFeRDVersion.Version23, TZUGFeRDProfile.Extended);
+            Assert.IsTrue(outputStream.Size > 0);
+          end
+          else
+          begin
+            Assert.WillRaise(
+              procedure
+              begin
+                loadedInvoice.Save(outputStream, TZUGFeRDVersion.Version23, TZUGFeRDProfile.Extended);
+              end,
+              TZUGFeRDMissingDataException);
+            Assert.AreEqual<Int64>(0, outputStream.Size, 'Pflichtdaten vor der Ausgabe ablehnen.');
+          end;
+        finally
+          outputStream.Free;
+        end;
+      finally
+        loadedInvoice.Free;
+      end;
+      Assert.IsTrue(inputStream.Size > 0, 'Der Reader darf den Eingabestream nicht freigeben.');
     finally
-      loadedInvoice.Free;
-      invalidStream.Free;
+      inputStream.Free;
     end;
   end;
 
 begin
+  invalidValue := missingField.StartsWith('Invalid');
+  fieldName := missingField;
+  if invalidValue then
+    fieldName := missingField.Substring(Length('Invalid'));
   desc := TZUGFeRDInvoiceDescriptor.Load(DemodataPath('zugferd21\zugferd_2p1_EXTENDED_Warenrechnung-factur-x.xml'));
   try
     desc.AdvancePayments.Clear;
     advancePayment := TZUGFeRDAdvancePayment.Create;
+    desc.AdvancePayments.Add(advancePayment);
     advancePayment.PaidAmount := 2975.0;
+    advancePayment.FormattedReceivedDateTime := EncodeDate(2025, 6, 7);
 
     includedTax := TZUGFeRDTax.Create;
+    advancePayment.IncludedTradeTaxes.Add(includedTax);
     includedTax.TaxAmount := 1900;
+    if missingField = 'Zero' then
+      includedTax.TaxAmount := 0;
     includedTax.TypeCode := TZUGFeRDTaxTypes.VAT;
     includedTax.CategoryCode := TZUGFeRDTaxCategoryCodes.S;
-    advancePayment.IncludedTradeTaxes.Add(includedTax);
 
-    advancePayment.SetInvoiceReferencedDocument('R202506-01');
-    desc.AdvancePayments.Add(advancePayment);
+    advancePayment.SetInvoiceReferencedDocument('R202506-01',
+      TZUGFeRDNullableParam<TDateTime>.Create(EncodeDate(2025, 6, 1)),
+      TZUGFeRDNullableParam<TZUGFeRDInvoiceType>.Create(TZUGFeRDInvoiceType.PartialInvoice));
 
     stream := TMemoryStream.Create;
     try
@@ -862,12 +967,31 @@ begin
       stream.Free;
     end;
 
-    AssertRemovalRaisesMissingData('<ram:PaidAmount(?:\s[^>]*)?>.*?</ram:PaidAmount>');
-    AssertRemovalRaisesMissingData('<ram:IncludedTradeTax>.*?</ram:IncludedTradeTax>');
-    AssertRemovalRaisesMissingData('<ram:CalculatedAmount(?:\s[^>]*)?>.*?</ram:CalculatedAmount>');
-    AssertRemovalRaisesMissingData('<ram:TypeCode>VAT</ram:TypeCode>');
-    AssertRemovalRaisesMissingData('<ram:CategoryCode>S</ram:CategoryCode>');
-    AssertRemovalRaisesMissingData('<ram:IssuerAssignedID>R202506-01</ram:IssuerAssignedID>');
+    if (missingField <> 'None') and (missingField <> 'Zero') then
+    begin
+      // Ausschließlich BG-X-45 mutieren, niemals gleichnamige Kopf-/Positionsfelder.
+      advanceXml := TRegEx.Match(xmlContent,
+        '<ram:SpecifiedAdvancePayment>.*?</ram:SpecifiedAdvancePayment>', [roSingleLine]).Value;
+      Assert.IsTrue(advanceXml <> '', 'Anzahlungsgruppe fehlt in der positiven Kontrolle.');
+      removedFieldXml := TRegEx.Match(advanceXml,
+        '<ram:' + fieldName + '(?:\s[^>]*)?>.*?</ram:' + fieldName + '>', [roSingleLine]).Value;
+      Assert.IsTrue(removedFieldXml <> '', 'Das zu entfernende XML-Pflichtfeld wurde nicht gefunden.');
+      // Nur den ersten Treffer entfernen: TypeCode kommt auch in der Rechnungsreferenz vor.
+      changedAdvanceXml := StringReplace(advanceXml, removedFieldXml, '', []);
+      if invalidValue then
+        changedAdvanceXml := StringReplace(advanceXml, removedFieldXml,
+          '<ram:' + fieldName + '>INVALID</ram:' + fieldName + '>', []);
+      Assert.IsTrue(changedAdvanceXml <> advanceXml, 'Das zu entfernende XML-Pflichtfeld wurde nicht gefunden.');
+      xmlContent := StringReplace(xmlContent, advanceXml, changedAdvanceXml, []);
+    end;
+
+    for var iteration := 1 to 10 do
+      LoadAndCheck;
+    firstBatchMemory := GetAllocatedMemory;
+    for var iteration := 1 to 10 do
+      LoadAndCheck;
+    secondBatchMemory := GetAllocatedMemory;
+    AssertNoMemoryGrowth(firstBatchMemory, secondBatchMemory);
   finally
     desc.Free;
   end;

--- a/Unittest/intf.ZUGFeRD22Tests.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRD22Tests.UnitTests.pas
@@ -815,9 +815,9 @@ begin
 end;
 
 /// <summary>
-/// Bewahrt fehlende BG-X-45-Pflichtwerte ohne erfundene Nullwerte oder Verlust des
-/// übrigen Belegs. Nur die gültigen Kontrollen dürfen wieder geschrieben werden.
-/// Nichtleere, ungültige Beträge/Codes bleiben dagegen Lesefehler.
+/// Liest fehlende oder unlesbare BG-X-45-Pflichtwerte als leere Nullable, ohne
+/// erfundene Nullwerte oder Verlust des übrigen Belegs. Nur die gültigen Kontrollen
+/// dürfen wieder geschrieben werden; alle unbrauchbaren Pflichtwerte sind abzulehnen.
 /// Aufgewärmte Lade-/Schreibzyklen prüfen zugleich die geänderten Besitzpfade.
 /// </summary>
 procedure TZUGFeRD22Tests.TestAdvancePaymentReaderPreservesMissingMandatoryData(const missingField: string);
@@ -843,19 +843,6 @@ var
   begin
     inputStream := TStringStream.Create(xmlContent, TEncoding.UTF8);
     try
-      if invalidValue then
-      begin
-        Assert.WillRaise(
-          procedure
-          var
-            unexpectedInvoice: TZUGFeRDInvoiceDescriptor;
-          begin
-            unexpectedInvoice := TZUGFeRDInvoiceDescriptor.Load(inputStream);
-            unexpectedInvoice.Free;
-          end,
-          TZUGFeRDMissingDataException);
-        Exit;
-      end;
       loadedInvoice := TZUGFeRDInvoiceDescriptor.Load(inputStream);
       try
         Assert.AreEqual(desc.InvoiceNo, loadedInvoice.InvoiceNo);
@@ -866,7 +853,7 @@ var
         Assert.AreEqual<Currency>(desc.Taxes[0].TaxAmount.Value, loadedInvoice.Taxes[0].TaxAmount.Value);
         Assert.AreEqual(1, Integer(loadedInvoice.AdvancePayments.Count));
         loadedPayment := loadedInvoice.AdvancePayments[0];
-        Assert.AreEqual(missingField <> 'PaidAmount', loadedPayment.PaidAmount.HasValue);
+        Assert.AreEqual(fieldName <> 'PaidAmount', loadedPayment.PaidAmount.HasValue);
         if loadedPayment.PaidAmount.HasValue then
           Assert.AreEqual<Currency>(2975, loadedPayment.PaidAmount.Value);
         Assert.AreEqual(EncodeDate(2025, 6, 7), loadedPayment.FormattedReceivedDateTime.Value);
@@ -877,7 +864,7 @@ var
         begin
           Assert.AreEqual(1, Integer(loadedPayment.IncludedTradeTaxes.Count));
           loadedTax := loadedPayment.IncludedTradeTaxes[0];
-          Assert.AreEqual(missingField <> 'CalculatedAmount', loadedTax.TaxAmount.HasValue);
+          Assert.AreEqual(fieldName <> 'CalculatedAmount', loadedTax.TaxAmount.HasValue);
           if loadedTax.TaxAmount.HasValue then
           begin
             expectedAmount := 1900;
@@ -885,10 +872,10 @@ var
               expectedAmount := 0;
             Assert.AreEqual<Currency>(expectedAmount, loadedTax.TaxAmount.Value);
           end;
-          Assert.AreEqual(missingField <> 'TypeCode', loadedTax.TypeCode.HasValue);
+          Assert.AreEqual(fieldName <> 'TypeCode', loadedTax.TypeCode.HasValue);
           if loadedTax.TypeCode.HasValue then
             Assert.AreEqual<TZUGFeRDTaxTypes>(TZUGFeRDTaxTypes.VAT, loadedTax.TypeCode.Value);
-          Assert.AreEqual(missingField <> 'CategoryCode', loadedTax.CategoryCode.HasValue);
+          Assert.AreEqual(fieldName <> 'CategoryCode', loadedTax.CategoryCode.HasValue);
           if loadedTax.CategoryCode.HasValue then
             Assert.AreEqual<TZUGFeRDTaxCategoryCodes>(TZUGFeRDTaxCategoryCodes.S, loadedTax.CategoryCode.Value);
         end;

--- a/Unittest/intf.ZUGFeRDCrossVersionTests.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRDCrossVersionTests.UnitTests.pas
@@ -34,6 +34,24 @@ type
     procedure AssertUBLTaxTotalFallback(const ReplacementCurrencyCode: string;
       const MakeFallbackAmbiguous: Boolean);
   public
+    /// <summary>Unterscheidet einen fehlenden Steuerbetrag von expliziten Null- und Geldbeträgen.</summary>
+    [Test]
+    procedure TestTaxAmountPresence;
+
+    /// <summary>Prüft die Betragspräsenz über alle Reader sowie direkte und vermittelte Writer-Aufrufe.</summary>
+    [Test]
+    [TestCase('CII1Missing', '100,True')]
+    [TestCase('CII1Zero', '100,False')]
+    [TestCase('CII20Missing', '200,True')]
+    [TestCase('CII20Zero', '200,False')]
+    [TestCase('CII23Missing', '230,True')]
+    [TestCase('CII23Zero', '230,False')]
+    [TestCase('UBLInvoiceMissing', '221,True')]
+    [TestCase('UBLInvoiceZero', '221,False')]
+    [TestCase('UBLCreditNoteMissing', '222,True')]
+    [TestCase('UBLCreditNoteZero', '222,False')]
+    procedure TestHeaderTaxAmountPresence(readerKind: Integer; missingAmount: Boolean);
+
     /// <summary>Checks an actual assertion diagnostic against Unicode code points, not another source literal.</summary>
     [Test]
     procedure TestDiagnosticEncoding;
@@ -386,6 +404,12 @@ uses
   intf.ZUGFeRDInvoiceDescriptor1Reader,
   intf.ZUGFeRDInvoiceDescriptor20Reader,
   intf.ZUGFeRDInvoiceDescriptor22UblReader,
+  intf.ZUGFeRDInvoiceDescriptor23CIIReader,
+  intf.ZUGFeRDIInvoiceDescriptorWriter,
+  intf.ZUGFeRDInvoiceDescriptor1Writer,
+  intf.ZUGFeRDInvoiceDescriptor20Writer,
+  intf.ZUGFeRDInvoiceDescriptor23CIIWriter,
+  intf.ZUGFeRDInvoiceDescriptor22UBLWriter,
   intf.ZUGFeRDInvoiceTypes,
   intf.ZUGFeRDProfile,
   intf.ZUGFeRDVersion,
@@ -419,6 +443,184 @@ uses
   intf.ZUGFeRDAdditionalReferencedDocumentTypeCodes;
 
 { TZUGFeRDCrossVersionTests }
+
+procedure TZUGFeRDCrossVersionTests.TestTaxAmountPresence;
+var
+  descriptor: TZUGFeRDInvoiceDescriptor;
+  tax: TZUGFeRDTax;
+begin
+  tax := TZUGFeRDTax.Create;
+  try
+    Assert.IsFalse(tax.TaxAmount.HasValue, 'Ein neuer Steuerbetrag darf nicht als Null vorbelegt sein.');
+    tax.TaxAmount := 0;
+    Assert.IsTrue(tax.TaxAmount.HasValue);
+    Assert.AreEqual<Currency>(0, tax.TaxAmount.Value);
+    tax.TaxAmount := 19;
+    Assert.AreEqual<Currency>(19, tax.TaxAmount.Value);
+    tax.TaxAmount := nil;
+    Assert.IsFalse(tax.TaxAmount.HasValue);
+  finally
+    tax.Free;
+  end;
+
+  descriptor := TZUGFeRDInvoiceDescriptor.Create;
+  try
+    descriptor.AddApplicableTradeTax(nil, 100, 19, TZUGFeRDTaxTypes.VAT, TZUGFeRDTaxCategoryCodes.S);
+    descriptor.AddApplicableTradeTax(0, 100, 0, TZUGFeRDTaxTypes.VAT, TZUGFeRDTaxCategoryCodes.Z);
+    Assert.IsFalse(descriptor.Taxes[0].TaxAmount.HasValue, 'Die Factory muss fehlende Beträge erhalten.');
+    Assert.IsTrue(descriptor.Taxes[1].TaxAmount.HasValue);
+    Assert.AreEqual<Currency>(0, descriptor.Taxes[1].TaxAmount.Value);
+  finally
+    descriptor.Free;
+  end;
+end;
+
+procedure TZUGFeRDCrossVersionTests.TestHeaderTaxAmountPresence(readerKind: Integer; missingAmount: Boolean);
+var
+  sourceInvoice: TZUGFeRDInvoiceDescriptor;
+  reader: TZUGFeRDIInvoiceDescriptorReader;
+  writer: TZUGFeRDIInvoiceDescriptorWriter;
+  version: TZUGFeRDVersion;
+  profile: TZUGFeRDProfile;
+  format: TZUGFeRDFormats;
+  sourceStream: TStringStream;
+  document: IXMLDOMDocument2;
+  amountNode: IXMLDOMNode;
+  xmlContent: string;
+  useDispatcher: Boolean;
+
+  /// <summary>Erhält die XML-Präsenz und prüft beide Schreibwege vor jeder Ausgabe.</summary>
+  procedure LoadAndCheck;
+  var
+    inputStream: TStringStream;
+    outputStream: TMemoryStream;
+    loadedInvoice: TZUGFeRDInvoiceDescriptor;
+  begin
+    inputStream := TStringStream.Create(xmlContent, TEncoding.UTF8);
+    try
+      if useDispatcher then
+        loadedInvoice := TZUGFeRDInvoiceDescriptor.Load(inputStream)
+      else
+        loadedInvoice := reader.Load(inputStream);
+      try
+        Assert.AreEqual(Integer(sourceInvoice.Taxes.Count), Integer(loadedInvoice.Taxes.Count));
+        Assert.AreEqual(not missingAmount, loadedInvoice.Taxes[0].TaxAmount.HasValue);
+        Assert.AreEqual(sourceInvoice.InvoiceNo, loadedInvoice.InvoiceNo);
+        Assert.AreEqual(Integer(sourceInvoice.TradeLineItems.Count), Integer(loadedInvoice.TradeLineItems.Count));
+        if not missingAmount then
+          Assert.AreEqual<Currency>(0, loadedInvoice.Taxes[0].TaxAmount.Value);
+
+        Assert.AreEqual(not missingAmount, writer.Validate(loadedInvoice, False));
+        outputStream := TMemoryStream.Create;
+        try
+          if missingAmount then
+          begin
+            Assert.WillRaise(
+              procedure
+              begin
+                writer.Validate(loadedInvoice, True);
+              end,
+              TZUGFeRDMissingDataException);
+            Assert.WillRaise(
+              procedure
+              begin
+                writer.Save(loadedInvoice, outputStream, format);
+              end,
+              TZUGFeRDMissingDataException);
+            Assert.WillRaise(
+              procedure
+              begin
+                loadedInvoice.Save(outputStream, version, profile, format);
+              end,
+              TZUGFeRDMissingDataException);
+            Assert.AreEqual<Int64>(0, outputStream.Size);
+          end
+          else
+          begin
+            writer.Save(loadedInvoice, outputStream, format);
+            Assert.IsTrue(outputStream.Size > 0);
+          end;
+        finally
+          outputStream.Free;
+        end;
+      finally
+        loadedInvoice.Free;
+      end;
+    finally
+      inputStream.Free;
+    end;
+  end;
+
+begin
+  profile := TZUGFeRDProfile.Extended;
+  format := TZUGFeRDFormats.CII;
+  case readerKind of
+    100: begin
+      version := TZUGFeRDVersion.Version1;
+      reader := TZUGFeRDInvoiceDescriptor1Reader.Create;
+      writer := TZUGFeRDInvoiceDescriptor1Writer.Create;
+    end;
+    200: begin
+      version := TZUGFeRDVersion.Version20;
+      reader := TZUGFeRDInvoiceDescriptor20Reader.Create;
+      writer := TZUGFeRDInvoiceDescriptor20Writer.Create;
+    end;
+    230: begin
+      version := TZUGFeRDVersion.Version23;
+      reader := TZUGFeRDInvoiceDescriptor23CIIReader.Create;
+      writer := TZUGFeRDInvoiceDescriptor23CIIWriter.Create;
+    end;
+    221, 222: begin
+      version := TZUGFeRDVersion.Version23;
+      profile := TZUGFeRDProfile.XRechnung;
+      format := TZUGFeRDFormats.UBL;
+      reader := TZUGFeRDInvoiceDescriptor22UblReader.Create;
+      writer := TZUGFeRDInvoiceDescriptor22UBLWriter.Create;
+    end;
+  else
+    raise EArgumentException.Create('Unknown reader kind.');
+  end;
+  try
+    sourceInvoice := TZUGFeRDInvoiceProvider.CreateInvoice;
+    try
+      sourceInvoice.Taxes[0].TaxAmount := 0;
+      if format = TZUGFeRDFormats.UBL then
+      begin
+        sourceInvoice.PaymentMeans.SEPAMandateReference := '';
+        sourceInvoice.PaymentMeans.SEPACreditorIdentifier := '';
+      end;
+      if readerKind = 222 then
+        sourceInvoice.Type_ := TZUGFeRDInvoiceType.CreditNote;
+      sourceStream := TStringStream.Create('', TEncoding.UTF8);
+      try
+        sourceInvoice.Save(sourceStream, version, profile, format);
+        document := CoDOMDocument60.Create;
+        document.setProperty('SelectionLanguage', 'XPath');
+        Assert.IsTrue(document.loadXML(sourceStream.DataString));
+        if format = TZUGFeRDFormats.UBL then
+          amountNode := document.selectSingleNode('/*/*[local-name()="TaxTotal"]/*[local-name()="TaxSubtotal"]/*[local-name()="TaxAmount"]')
+        else
+          amountNode := document.selectSingleNode(
+            '//*[local-name()="ApplicableHeaderTradeSettlement" or local-name()="ApplicableSupplyChainTradeSettlement"]' +
+            '/*[local-name()="ApplicableTradeTax"]/*[local-name()="CalculatedAmount"]');
+        Assert.IsNotNull(amountNode, 'Die positive Kontrolle muss den Nullbetrag ausgeben.');
+        Assert.AreEqual('0.00', string(amountNode.text));
+        if missingAmount then
+          amountNode.parentNode.removeChild(amountNode);
+        xmlContent := document.xml;
+      finally
+        sourceStream.Free;
+      end;
+      for useDispatcher := False to True do
+        LoadAndCheck;
+    finally
+      sourceInvoice.Free;
+    end;
+  finally
+    writer.Free;
+    reader.Free;
+  end;
+end;
 
 procedure TZUGFeRDCrossVersionTests.TestReaderResultOwnership(readerKind: Integer; const failurePoint: string);
 const

--- a/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
+++ b/Unittest/intf.ZUGFeRDInvoiceValidatorTests.UnitTests.pas
@@ -110,6 +110,11 @@ type
     procedure TestNonVatTaxDoesNotAffectVatTotals;
     [Test]
     procedure TestMissingTaxTypeIsReported;
+    /// <summary>Ein fehlendes BT-117 ist ungültig, eine explizite Null bleibt prüfbar.</summary>
+    [Test]
+    [TestCase('MissingAmount', 'True')]
+    [TestCase('ExplicitZero', 'False')]
+    procedure TestTaxAmountPresence(missingAmount: Boolean);
     [Test]
     procedure TestMissingTaxBasisAmountIsReported;
     [Test]
@@ -968,6 +973,40 @@ begin
     end;
   finally
     Descriptor.Free;
+  end;
+end;
+
+/// <summary>
+/// Prüft fehlendes BT-117 gegen eine ansonsten ausgeglichene Nullsteuerrechnung.
+/// Die Validierung muss die Präsenz erhalten, statt einen Ersatzbetrag einzusetzen.
+/// </summary>
+procedure TZUGFeRDInvoiceValidatorTests.TestTaxAmountPresence(missingAmount: Boolean);
+var
+  descriptor: TZUGFeRDInvoiceDescriptor;
+  validationResult: TZUGFeRDValidationResult;
+begin
+  descriptor := CreateBalancedInvoice(False);
+  try
+    descriptor.TradeLineItems[0].TaxPercent := 0;
+    descriptor.Taxes[0].Percent := 0;
+    descriptor.Taxes[0].TaxAmount := 0;
+    descriptor.TaxTotalAmount := 0;
+    descriptor.GrandTotalAmount := 200;
+    descriptor.DuePayableAmount := 200;
+    if missingAmount then
+      descriptor.Taxes[0].TaxAmount := nil;
+
+    validationResult := TZUGFeRDInvoiceValidator.Validate(descriptor, TZUGFeRDVersion.Version23);
+    try
+      Assert.AreEqual(not missingAmount, validationResult.IsValid, validationResult.Messages.Text);
+      Assert.AreEqual(missingAmount, validationResult.Messages.Text.Contains('Tax amount is required'));
+      Assert.AreEqual(missingAmount, not descriptor.Taxes[0].TaxAmount.HasValue,
+        'Die Validierung darf fehlende Beträge nicht nachberechnen.');
+    finally
+      validationResult.Free;
+    end;
+  finally
+    descriptor.Free;
   end;
 end;
 

--- a/intf.ZUGFeRDIInvoiceDescriptorWriter.pas
+++ b/intf.ZUGFeRDIInvoiceDescriptorWriter.pas
@@ -31,12 +31,19 @@ uses
   ,intf.ZUGFeRDExceptions
   ,intf.ZUGFeRDInvoiceTypes
   ,intf.ZUGFeRDTaxTypes
+  ,intf.ZUGFeRDTax
   ,intf.ZUGFeRDTradeLineItem
   ;
 
 type
   TZUGFeRDIInvoiceDescriptorWriter = class abstract
   protected
+    /// <summary>
+    /// Verhindert, dass fehlende Kopfsteuerbeträge als Null ausgegeben werden.
+    /// BT-117 verlangt einen Betrag (Factur-X: FX-SCH-A-000176); auch ZUGFeRD 1.0
+    /// fordert CalculatedAmount in der Kopfsteuer, trotz optionalem gemeinsamem XSD-Typ.
+    /// </summary>
+    class function ValidateTaxAmounts(descriptor: TZUGFeRDInvoiceDescriptor; throwExceptions: Boolean): Boolean; static;
     /// <summary>
     /// Gemeinsame Vorprüfung für ZUGFeRD 2.x / Factur-X / XRechnung (Version23).
     /// Liegt hier, damit der Dispatcher (23Writer) und die direkt nutzbaren Writer
@@ -110,6 +117,23 @@ begin
   finally
     ms.Free;
   end;
+end;
+
+class function TZUGFeRDIInvoiceDescriptorWriter.ValidateTaxAmounts(
+  descriptor: TZUGFeRDInvoiceDescriptor; throwExceptions: Boolean): Boolean;
+var
+  tax: TZUGFeRDTax;
+begin
+  for tax in descriptor.Taxes do
+  begin
+    if not tax.TaxAmount.HasValue then
+    begin
+      if throwExceptions then
+        raise TZUGFeRDMissingDataException.Create('Tax amount is required for every header tax breakdown (BT-117).');
+      Exit(False);
+    end;
+  end;
+  Result := True;
 end;
 
 class function TZUGFeRDIInvoiceDescriptorWriter.ValidateVersion23(descriptor: TZUGFeRDInvoiceDescriptor; throwExceptions: Boolean): Boolean;
@@ -192,7 +216,7 @@ begin
       exit;
   end;
 
-  Result := true;
+  Result := ValidateTaxAmounts(descriptor, throwExceptions);
 end;
 
 class function TZUGFeRDIInvoiceDescriptorWriter.CalculateLineTotalAmount(

--- a/intf.ZUGFeRDInvoiceDescriptor.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor.pas
@@ -926,14 +926,14 @@ type
     /// </summary>
     /// <param name="basisAmount">Base amount for tax calculation</param>
     /// <param name="percent">Tax percentage rate</param>
-    /// <param name="taxAmount">Calculated tax amount</param>
+    /// <param name="calculatedAmount">Angegebener Steuerbetrag; ohne Wert für beim Lesen fehlende Beträge.</param>
     /// <param name="typeCode">Type of tax</param>
     /// <param name="categoryCode">Tax category</param>
     /// <param name="allowanceChargeBasisAmount">Base amount for allowances/charges</param>
     /// <param name="exemptionReasonCode">Tax exemption reason code</param>
     /// <param name="exemptionReason">Tax exemption reason text</param>
     /// <param name="lineTotalBasisAmount">Line total base amount for tax calculation</param>
-    function AddApplicableTradeTax(const calculatedAmount, basisAmount: Currency;
+    function AddApplicableTradeTax(calculatedAmount: ZUGFeRDNullable<Currency>; const basisAmount: Currency;
       const percent: Currency; const typeCode: TZUGFeRDTaxTypes;
       const categoryCode: TZUGFeRDTaxCategoryCodes;
       const allowanceChargeBasisAmount: IZUGFeRDNullableParam<Currency> = Nil;
@@ -1937,7 +1937,7 @@ begin
   TaxCurrency:= accountingCurrency;
 end;
 
-function TZUGFeRDInvoiceDescriptor.AddApplicableTradeTax(const calculatedAmount, basisAmount: Currency;
+function TZUGFeRDInvoiceDescriptor.AddApplicableTradeTax(calculatedAmount: ZUGFeRDNullable<Currency>; const basisAmount: Currency;
   const percent: Currency; const typeCode: TZUGFeRDTaxTypes;
   const categoryCode: TZUGFeRDTaxCategoryCodes;
   const allowanceChargeBasisAmount: IZUGFeRDNullableParam<Currency> = Nil;

--- a/intf.ZUGFeRDInvoiceDescriptor1Reader.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor1Reader.pas
@@ -283,7 +283,7 @@ begin
     nodes := doc.SelectNodes('//ram:ApplicableSupplyChainTradeSettlement/ram:ApplicableTradeTax');
     for i := 0 to nodes.length-1 do
     begin
-      Result.AddApplicableTradeTax(TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:CalculatedAmount', 0),
+      Result.AddApplicableTradeTax(TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:CalculatedAmount'),
                                    TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:BasisAmount', 0),
                                    TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:ApplicablePercent', 0),
                                    TEnumExtensions<TZUGFeRDTaxTypes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:TypeCode')),

--- a/intf.ZUGFeRDInvoiceDescriptor1Writer.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor1Writer.pas
@@ -115,6 +115,7 @@ begin
     raise TZUGFeRDUnsupportedException.Create('Invalid profile used for ZUGFeRD 1.x invoice.');
 
   // write data
+  ValidateTaxAmounts(_descriptor, True);
   streamPosition := _stream.Position;
 
   Descriptor := _descriptor;
@@ -846,7 +847,7 @@ begin
 
     _writer.WriteStartElement('ram:CalculatedAmount');
     _writer.WriteAttributeString('currencyID', TEnumExtensions<TZUGFeRDCurrencyCodes>.EnumToString(Descriptor.Currency));
-    _writer.WriteValue(_formatDecimal(tax.TaxAmount));
+    _writer.WriteValue(_formatDecimal(tax.TaxAmount.Value));
     _writer.WriteEndElement(); // !CalculatedAmount
 
     _writer.WriteElementString('ram:TypeCode', TEnumExtensions<TZUGFeRDTaxTypes>.EnumToString(tax.TypeCode));
@@ -1056,7 +1057,7 @@ begin
     end;
   end;
 
-  Result := true;
+  Result := ValidateTaxAmounts(_descriptor, _throwExceptions);
 end;
 
 procedure TZUGFeRDInvoiceDescriptor1Writer._writeOptionalAmount(

--- a/intf.ZUGFeRDInvoiceDescriptor20Reader.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor20Reader.pas
@@ -405,7 +405,7 @@ begin
 
     nodes := doc.SelectNodes('//ram:ApplicableHeaderTradeSettlement/ram:ApplicableTradeTax');
     for i := 0 to nodes.length-1 do
-      Result.AddApplicableTradeTax(TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:CalculatedAmount', 0),
+      Result.AddApplicableTradeTax(TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:CalculatedAmount'),
                                    TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:BasisAmount', 0),
                                    TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:RateApplicablePercent', 0),
                                    TEnumExtensions<TZUGFeRDTaxTypes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:TypeCode')),

--- a/intf.ZUGFeRDInvoiceDescriptor20Writer.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor20Writer.pas
@@ -124,6 +124,7 @@ begin
     raise TZUGFeRDUnsupportedException.Create('UBL format is not supported for ZUGFeRD 2.0');
 
   // write data
+  ValidateTaxAmounts(_descriptor, True);
   streamPosition := _stream.Position;
 
   Descriptor := _descriptor;
@@ -1176,7 +1177,7 @@ begin
     _writer.WriteStartElement('ram:ApplicableTradeTax');
 
     _writer.WriteStartElement('ram:CalculatedAmount');
-    _writer.WriteValue(_formatDecimal(tax.TaxAmount));
+    _writer.WriteValue(_formatDecimal(tax.TaxAmount.Value));
     _writer.WriteEndElement(); // !CalculatedAmount
 
     _writer.WriteElementString('ram:TypeCode', TEnumExtensions<TZUGFeRDTaxTypes>.EnumToString(tax.TypeCode));
@@ -1385,7 +1386,7 @@ begin
     end;
   end;
 
-  Result := true;
+  Result := ValidateTaxAmounts(_descriptor, _throwExceptions);
 end;
 
 end.

--- a/intf.ZUGFeRDInvoiceDescriptor22UBLWriter.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor22UBLWriter.pas
@@ -139,6 +139,7 @@ begin
 
   // Bei direkter Nutzung des Writers gilt dieselbe Profilgrenze wie im Dispatcher
   _validateProfile(_descriptor, True);
+  ValidateTaxAmounts(_descriptor, True);
 
   streamPosition := _stream.Position;
 

--- a/intf.ZUGFeRDInvoiceDescriptor22UblReader.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor22UblReader.pas
@@ -457,7 +457,7 @@ begin
     begin
       var taxableAmount : Currency := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], 'cbc:TaxableAmount', 0);
       var percent : Currency := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], 'cac:TaxCategory/cbc:Percent', 0);
-      var taxAmount : Currency := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], 'cbc:TaxAmount', 0);
+      var taxAmount: ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], 'cbc:TaxAmount');
       var taxType : TZUGFeRDTaxTypes := TEnumExtensions<TZUGFeRDTaxTypes>.StringToEnum(
         TZUGFeRDXmlUtils.NodeAsString(nodes[i], 'cac:TaxCategory/cac:TaxScheme/cbc:ID'));
       var categoryCode : TZUGFeRDTaxCategoryCodes := TEnumExtensions<TZUGFeRDTaxCategoryCodes>.StringToEnum(

--- a/intf.ZUGFeRDInvoiceDescriptor23CIIReader.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor23CIIReader.pas
@@ -96,6 +96,7 @@ type
 
     /// <summary>
     /// Parses the ZUGFeRD invoice from the given stream.
+    /// Fehlende BG-X-45-Pflichtangaben bleiben im Modell erkennbar; ihre Präsenz prüft der Writer.
     ///
     /// Make sure that the stream is open, otherwise an IllegalStreamException exception is thrown.
     /// Important: the stream will not be closed by this function.
@@ -506,7 +507,7 @@ begin
   nodes := doc.SelectNodes('//ram:ApplicableHeaderTradeSettlement/ram:ApplicableTradeTax');
   for i := 0 to nodes.length-1 do
   begin
-    var calculatedAmount: ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:CalculatedAmount', 0);
+    var calculatedAmount: ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:CalculatedAmount');
     var basisAmount: ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:BasisAmount', 0);
     var ratePercent: ZUGFeRDNullable<Currency> := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './/ram:RateApplicablePercent', 0);
     var taxType: ZUGFeRDNullable<TZUGFeRDTaxTypes> := TEnumExtensions<TZUGFeRDTaxTypes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:TypeCode'));
@@ -625,21 +626,23 @@ begin
       TEnumExtensions<TZUGFeRDAccountingAccountTypeCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:TypeCode')));
 
   // Vorauszahlungen / Anzahlungen, BG-X-45 (nur EXTENDED)
+  // Fehlende Pflichtangaben präsenztreu lesen, damit der übrige Beleg lesbar bleibt.
+  // Die Ausgabe bleibt streng: insbesondere BT-X-293 nach FX-SCH-A-000952 ist Pflicht.
+  // Nichtleere, unlesbare Beträge/Codes bleiben Fehler; nur fehlende Werte sind toleriert.
   nodes := doc.SelectNodes('//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedAdvancePayment');
   for i := 0 to nodes.length-1 do
   begin
     var advancePayment: TZUGFeRDAdvancePayment := TZUGFeRDAdvancePayment.Create;
     try
       advancePayment.PaidAmount := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './ram:PaidAmount');
-      if not advancePayment.PaidAmount.HasValue then
-        raise TZUGFeRDMissingDataException.Create('Advance payment paid amount is required (BG-X-45).');
+      if not advancePayment.PaidAmount.HasValue and
+        (Trim(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:PaidAmount')) <> '') then
+        raise TZUGFeRDMissingDataException.Create('Advance payment paid amount is invalid (BG-X-45).');
 
       advancePayment.FormattedReceivedDateTime := TZUGFeRDXmlUtils.NodeAsDateTime(nodes[i],
         './ram:FormattedReceivedDateTime/qdt:DateTimeString');
 
       var taxNodes: IXMLDOMNodeList := nodes[i].selectNodes('./ram:IncludedTradeTax');
-      if taxNodes.length = 0 then
-        raise TZUGFeRDMissingDataException.Create('At least one included trade tax is required for an advance payment (BG-X-45).');
 
       for var taxIndex: Integer := 0 to taxNodes.length-1 do
       begin
@@ -651,12 +654,18 @@ begin
         var taxCategoryCode: ZUGFeRDNullable<TZUGFeRDTaxCategoryCodes> :=
           TEnumExtensions<TZUGFeRDTaxCategoryCodes>.StringToNullableEnum(
             TZUGFeRDXmlUtils.NodeAsString(taxNodes[taxIndex], './ram:CategoryCode'));
-        if not taxAmount.HasValue or not taxTypeCode.HasValue or not taxCategoryCode.HasValue then
-          raise TZUGFeRDMissingDataException.Create('Advance payment tax amount, type and category are required (BG-X-45).');
+        if not taxAmount.HasValue and
+          (Trim(TZUGFeRDXmlUtils.NodeAsString(taxNodes[taxIndex], './ram:CalculatedAmount')) <> '') then
+          raise TZUGFeRDMissingDataException.Create('Advance payment tax amount is invalid (BG-X-45).');
+        if (not taxTypeCode.HasValue and
+          (Trim(TZUGFeRDXmlUtils.NodeAsString(taxNodes[taxIndex], './ram:TypeCode')) <> '')) or
+          (not taxCategoryCode.HasValue and
+          (Trim(TZUGFeRDXmlUtils.NodeAsString(taxNodes[taxIndex], './ram:CategoryCode')) <> '')) then
+          raise TZUGFeRDMissingDataException.Create('Advance payment tax type or category is invalid (BG-X-45).');
 
         var includedTax: TZUGFeRDTax := TZUGFeRDTax.Create;
         try
-          includedTax.TaxAmount := taxAmount.Value;
+          includedTax.TaxAmount := taxAmount;
           includedTax.TypeCode := taxTypeCode;
           includedTax.CategoryCode := taxCategoryCode;
           includedTax.Percent := TZUGFeRDXmlUtils.NodeAsDecimal(
@@ -672,8 +681,6 @@ begin
       begin
         var invoiceReferenceID: string := TZUGFeRDXmlUtils.NodeAsString(nodes[i],
           './ram:InvoiceSpecifiedReferencedDocument/ram:IssuerAssignedID');
-        if Trim(invoiceReferenceID) = '' then
-          raise TZUGFeRDMissingDataException.Create('Advance payment invoice reference ID is required when a reference is specified (BG-X-45).');
 
         advancePayment.SetInvoiceReferencedDocument(
           invoiceReferenceID,

--- a/intf.ZUGFeRDInvoiceDescriptor23CIIReader.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor23CIIReader.pas
@@ -626,19 +626,16 @@ begin
       TEnumExtensions<TZUGFeRDAccountingAccountTypeCodes>.StringToNullableEnum(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './/ram:TypeCode')));
 
   // Vorauszahlungen / Anzahlungen, BG-X-45 (nur EXTENDED)
-  // Fehlende Pflichtangaben präsenztreu lesen, damit der übrige Beleg lesbar bleibt.
+  // Fehlende oder unlesbare Pflichtbeträge und Steuercodes wie die übrigen
+  // Zahlen-/Enum-Helfer als leere Nullable lesen, damit der übrige Beleg lesbar bleibt.
   // Die Ausgabe bleibt streng: insbesondere BT-X-293 nach FX-SCH-A-000952 ist Pflicht.
-  // Nichtleere, unlesbare Beträge/Codes bleiben Fehler; nur fehlende Werte sind toleriert.
+  // Nullable unterscheidet fehlende und unlesbare Werte nicht; Datumsfehler bleiben unverändert.
   nodes := doc.SelectNodes('//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedAdvancePayment');
   for i := 0 to nodes.length-1 do
   begin
     var advancePayment: TZUGFeRDAdvancePayment := TZUGFeRDAdvancePayment.Create;
     try
       advancePayment.PaidAmount := TZUGFeRDXmlUtils.NodeAsDecimal(nodes[i], './ram:PaidAmount');
-      if not advancePayment.PaidAmount.HasValue and
-        (Trim(TZUGFeRDXmlUtils.NodeAsString(nodes[i], './ram:PaidAmount')) <> '') then
-        raise TZUGFeRDMissingDataException.Create('Advance payment paid amount is invalid (BG-X-45).');
-
       advancePayment.FormattedReceivedDateTime := TZUGFeRDXmlUtils.NodeAsDateTime(nodes[i],
         './ram:FormattedReceivedDateTime/qdt:DateTimeString');
 
@@ -654,15 +651,6 @@ begin
         var taxCategoryCode: ZUGFeRDNullable<TZUGFeRDTaxCategoryCodes> :=
           TEnumExtensions<TZUGFeRDTaxCategoryCodes>.StringToNullableEnum(
             TZUGFeRDXmlUtils.NodeAsString(taxNodes[taxIndex], './ram:CategoryCode'));
-        if not taxAmount.HasValue and
-          (Trim(TZUGFeRDXmlUtils.NodeAsString(taxNodes[taxIndex], './ram:CalculatedAmount')) <> '') then
-          raise TZUGFeRDMissingDataException.Create('Advance payment tax amount is invalid (BG-X-45).');
-        if (not taxTypeCode.HasValue and
-          (Trim(TZUGFeRDXmlUtils.NodeAsString(taxNodes[taxIndex], './ram:TypeCode')) <> '')) or
-          (not taxCategoryCode.HasValue and
-          (Trim(TZUGFeRDXmlUtils.NodeAsString(taxNodes[taxIndex], './ram:CategoryCode')) <> '')) then
-          raise TZUGFeRDMissingDataException.Create('Advance payment tax type or category is invalid (BG-X-45).');
-
         var includedTax: TZUGFeRDTax := TZUGFeRDTax.Create;
         try
           includedTax.TaxAmount := taxAmount;

--- a/intf.ZUGFeRDInvoiceDescriptor23CIIWriter.pas
+++ b/intf.ZUGFeRDInvoiceDescriptor23CIIWriter.pas
@@ -135,6 +135,7 @@ end;
 
 /// <summary>
 /// Prüft die Pflichtangaben der nur im EXTENDED-Profil ausgegebenen Vorauszahlungen.
+/// BT-X-293 ist nach FX-SCH-A-000952 Pflicht, auch wenn TradeTaxType im XSD 0..1 erlaubt.
 /// </summary>
 procedure TZUGFeRDInvoiceDescriptor23CIIWriter._validateAdvancePayments;
 begin
@@ -157,6 +158,8 @@ begin
     begin
       if not Assigned(includedTax) then
         raise TZUGFeRDMissingDataException.Create('Advance payment tax type and category are required (BG-X-45).');
+      if not includedTax.TaxAmount.HasValue then
+        raise TZUGFeRDMissingDataException.Create('Advance payment tax amount is required (BT-X-293, BG-X-45).');
       if not includedTax.TypeCode.HasValue or not includedTax.CategoryCode.HasValue then
         raise TZUGFeRDMissingDataException.Create('Advance payment tax type and category are required (BG-X-45).');
     end;
@@ -175,6 +178,7 @@ begin
     raise TZUGFeRDIllegalStreamException.Create('Cannot write to stream');
 
   // write data
+  ValidateTaxAmounts(_descriptor, True);
   streamPosition := _stream.Position;
 
   Descriptor := _descriptor;
@@ -1294,7 +1298,7 @@ begin
     for var includedTax: TZUGFeRDTax in advancePayment.IncludedTradeTaxes do
     begin
       Writer.WriteStartElement('ram:IncludedTradeTax', [TZUGFeRDProfile.Extended]);
-      Writer.WriteOptionalElementString('ram:CalculatedAmount', _formatDecimal(includedTax.TaxAmount));
+      Writer.WriteOptionalElementString('ram:CalculatedAmount', _formatDecimal(includedTax.TaxAmount.Value));
       if includedTax.TypeCode.HasValue then
         Writer.WriteOptionalElementString('ram:TypeCode', TEnumExtensions<TZUGFeRDTaxTypes>.EnumToString(includedTax.TypeCode));
       if includedTax.CategoryCode.HasValue then
@@ -1661,7 +1665,7 @@ begin
     _writer.WriteStartElement('ram:ApplicableTradeTax');
 
     _writer.WriteStartElement('ram:CalculatedAmount');
-    _writer.WriteValue(_formatDecimal(tax.TaxAmount));
+    _writer.WriteValue(_formatDecimal(tax.TaxAmount.Value));
     _writer.WriteEndElement(); // !CalculatedAmount
 
     _writer.WriteElementString('ram:TypeCode', TEnumExtensions<TZUGFeRDTaxTypes>.EnumToString(tax.TypeCode));

--- a/intf.ZUGFeRDInvoiceValidator.pas
+++ b/intf.ZUGFeRDInvoiceValidator.pas
@@ -55,6 +55,7 @@ type
   TZUGFeRDInvoiceValidator = class
   public
     class procedure ValidateAndPrint(descriptor: TZUGFeRDInvoiceDescriptor; version: TZUGFeRDVersion; filename: string = '');
+    /// <summary>Prüft deklarierte Beträge und Summen; fehlendes BT-117 wird gemeldet, nicht als Null summiert.</summary>
     class function Validate(descriptor: TZUGFeRDInvoiceDescriptor; version: TZUGFeRDVersion): TZUGFeRDValidationResult;
   end;
 
@@ -98,7 +99,7 @@ var
     rounding, duePayable, expectedDuePayable, expectedTaxAmount,
     recalculatedLineAmount: Currency;
   declaredAllowanceTotal, declaredChargeTotal, expectedTaxBasis: Currency;
-  taxDeviation: Currency;
+  taxDeviation, declaredTaxAmount: Currency;
   item: TZUGFeRDTradeLineItem;
   tax: TZUGFeRDTax;
 begin
@@ -220,6 +221,15 @@ begin
 
     for tax in descriptor.Taxes do
     begin
+      // Die implizite Nullable-Konvertierung würde einen fehlenden Pflichtbetrag
+      // als null behandeln. BT-117 verlangt Präsenz, auch bei steuerfreien Umsätzen.
+      if not tax.TaxAmount.HasValue then
+      begin
+        Result.Messages.Add('Tax amount is required for every tax breakdown (BT-117)');
+        Result.IsValid := false;
+        Continue;
+      end;
+      declaredTaxAmount := tax.TaxAmount.Value;
       if not tax.TypeCode.HasValue then
       begin
         Result.Messages.Add('Tax type code is required for every tax breakdown');
@@ -234,7 +244,7 @@ begin
       // BR-CO-14 bildet BT-110 aus den angegebenen BT-117, nicht aus den
       // nachgerechneten Sollwerten. Beides fällt nur zusammen, solange BR-CO-17
       // exakt erzwungen wird - die Regel lässt aber eine Abweichung zu.
-      taxTotal := taxTotal + tax.TaxAmount;
+      taxTotal := taxTotal + declaredTaxAmount;
 
       Result.Messages.Add(Format('===> %f x %f%% = %f', [tax.BasisAmount, tax.Percent, expectedTaxAmount]));
 
@@ -244,10 +254,10 @@ begin
       // deshalb für jeden sechsten sauber zweistelligen Betrag einen Verstoß,
       // etwa für 0,07 oder 20,90. Currency rechnet in Hundertsteln exakt, also
       // beantwortet der Nachkommaanteil nach Multiplikation mit 100 die Frage genau.
-      if Frac(tax.TaxAmount * 100) <> 0 then
+      if Frac(declaredTaxAmount * 100) <> 0 then
       begin
         Result.Messages.Add(Format(
-          'BR-DEC-20: Der Steuerbetrag[%.4f] hat mehr als zwei Nachkommastellen', [tax.TaxAmount]));
+          'BR-DEC-20: Der Steuerbetrag[%.4f] hat mehr als zwei Nachkommastellen', [declaredTaxAmount]));
         Result.IsValid := false;
       end;
 
@@ -257,7 +267,7 @@ begin
       // Artefakte eine strikt kleinere Abweichung verlangen. Bis der Validator das
       // konkrete Regelwerk kennt, bleibt die Factur-X-Grenze für alle Profile
       // erhalten. Abweichungen werden protokolliert, damit sie nicht untergehen.
-      taxDeviation := tax.TaxAmount - expectedTaxAmount;
+      taxDeviation := declaredTaxAmount - expectedTaxAmount;
       if Abs(tax.Percent) < 0.5 then
       begin
         // Erster Zweig von FX-SCH-A-000052: rundet der Steuersatz auf null, muss
@@ -266,32 +276,32 @@ begin
         // Steuerbetrag von bis zu einer Einheit unbeanstandet. Die Kategorien mit
         // Nullsatz verlangen über BR-Z-09, BR-E-09, BR-AE-09, BR-G-09 und
         // BR-O-09 ohnehin genau null.
-        if Abs(tax.TaxAmount) >= 0.5 then
+        if Abs(declaredTaxAmount) >= 0.5 then
         begin
           Result.Messages.Add(Format(
             'BR-CO-17: Bei Steuersatz[%4f] muss der Steuerbetrag null sein, angegeben ist[%4f] bei Bemessungsgrundlage[%4f]',
-            [tax.Percent, tax.TaxAmount, tax.BasisAmount]));
+            [tax.Percent, declaredTaxAmount, tax.BasisAmount]));
           Result.IsValid := false;
         end
-        else if tax.TaxAmount <> 0 then
+        else if declaredTaxAmount <> 0 then
         begin
           Result.Messages.Add(Format(
             'Hinweis: Bei Steuersatz[%4f] ist ein Steuerbetrag von[%4f] angegeben, der auf null rundet',
-            [tax.Percent, tax.TaxAmount]));
+            [tax.Percent, declaredTaxAmount]));
         end;
       end
       else if Abs(taxDeviation) > 1 then
       begin
         Result.Messages.Add(Format(
           'BR-CO-17: Berechneter Steuerbetrag ist[%4f] aber vorhandener Steuerbetrag ist[%4f] bei Bemessungsgrundlage[%4f] und Steuersatz[%4f]',
-          [expectedTaxAmount, tax.TaxAmount, tax.BasisAmount, tax.Percent]));
+          [expectedTaxAmount, declaredTaxAmount, tax.BasisAmount, tax.Percent]));
         Result.IsValid := false;
       end
       else if taxDeviation <> 0 then
       begin
         Result.Messages.Add(Format(
           'Hinweis: Der Steuerbetrag[%4f] weicht um [%4f] vom berechneten Wert[%4f] ab, bleibt aber innerhalb der BR-CO-17-Toleranz von einer Währungseinheit',
-          [tax.TaxAmount, taxDeviation, expectedTaxAmount]));
+          [declaredTaxAmount, taxDeviation, expectedTaxAmount]));
       end;
     end;
 

--- a/intf.ZUGFeRDTax.pas
+++ b/intf.ZUGFeRDTax.pas
@@ -41,14 +41,15 @@ type
     FLineTotalBasisAmount: ZUGFeRDNullable<Currency>;
     FExemptionReasonCode: ZUGFeRDNullable<TZUGFeRDTaxExemptionReasonCodes>;
     FExemptionReason: string;
-    FTaxAmount: Currency;
+    FTaxAmount: ZUGFeRDNullable<Currency>;
     FTaxPointDate: ZUGFeRDNullable<TDateTime>;
     FDueDateTypeCode: ZUGFeRDNullable<TZUGFeRDDateTypeCodes>;
   public
     /// <summary>
-    /// Returns the amount of the tax (Percent * BasisAmount)
+    /// Angegebener Steuerbetrag, nicht aus BasisAmount und Percent berechnet.
+    /// Ohne Wert bleibt ein fehlender XML-Betrag von einer expliziten Null unterscheidbar.
     /// </summary>
-    property TaxAmount: Currency read FTaxAmount write FTaxAmount;
+    property TaxAmount: ZUGFeRDNullable<Currency> read FTaxAmount write FTaxAmount;
     /// <summary>
     /// VAT category taxable amount
     /// </summary>
@@ -133,7 +134,7 @@ begin
   FTypeCode := TZUGFeRDTaxTypes.VAT;
   FCategoryCode := TZUGFeRDTaxCategoryCodes.S;
   FExemptionReason := '';
-  FTaxAmount := 0;
+  FTaxAmount := nil;
 end;
 
 procedure TZUGFeRDTax.SetTaxPointDate(taxPointDate: IZUGFeRDNullableParam<TDateTime>; dueDateTypeCode: IZUGFeRDNullableParam<TZUGFeRDDateTypeCodes>);


### PR DESCRIPTION
## Purpose

Incomplete or invalid advance-payment amounts and tax codes should not prevent reading the remaining invoice data. At the same time, a missing tax amount must not silently become an explicitly stated zero, and incomplete data must still be rejected when writing.

## Changes

- Make `TZUGFeRDTax.TaxAmount` and the `calculatedAmount` parameter of `AddApplicableTradeTax` nullable. New tax objects start without an amount; an explicit `0` remains a present value.
- Preserve header tax amount presence in the CII 1.0, 2.0, 2.3 and UBL readers. Require header tax amounts before writer output and report missing BT-117 in the totals validator.
- Use the existing numeric and enum conversion helpers for BG-X-45. Missing or unreadable mandatory amounts and unknown tax types/categories become empty nullable values instead of aborting the reader. Retain the available advance-payment and reference data, including a reference without an ID.
- Keep EXTENDED writer validation strict, including BT-X-293 (`FX-SCH-A-000952`). Reject incomplete advance payments before producing XML. Explicit zero amounts remain supported.
- Do not add catch-all exception handling: XML, file, stream and date error handling is unchanged. An empty nullable does not distinguish absent input from an unreadable value; the original invalid text is not retained.

## API compatibility

Dependent applications need recompilation. Numeric assignments remain supported, but consumers should check `HasValue` before using `Value` in calculations or comparisons. `BasisAmount` and `Percent` remain non-nullable. No tax amount is calculated automatically from the basis and rate.

## Verification

- Delphi 11, Win64 Debug: console and GUI projects build with no errors, warnings or hints. GUI verification is build-only.
- 446 tests and 36 process checks pass under both Windows PowerShell 5.1 and PowerShell 7.
- Twelve BG-X-45 cases verify preserved invoice data, nullable presence, explicit zero and warmed heap checks. All ten invalid/incomplete cases load but are rejected by the writer with an empty output stream.
- Counterchecks detect all four previous reader exceptions. In an isolated source copy with BG-X-45 writer validation disabled, all ten mandatory-data cases detect the missing rejection, while both valid controls pass.
